### PR TITLE
Feature/nunjucks configuration

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -6,3 +6,5 @@ CLAIMANT_SERVICE_URL=http://localhost:8090
 # This is used if you want to test the smoke tests by pointing them to localhost.
 APP_HOST=http://localhost:8080
 NODE_ENV=development
+# Set caching for Nunjucks templates
+CACHE_VIEW_TEMPLATES=false

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -1,5 +1,8 @@
+const { toBoolean } = require('./to-boolean')
+
 module.exports = {
   PORT: process.env.PORT,
   SESSION_SECRET: process.env.SESSION_SECRET,
-  SESSION_ID_NAME: 'htbhf.sid'
+  SESSION_ID_NAME: 'htbhf.sid',
+  CACHE_VIEW_TEMPLATES: toBoolean(process.env.CACHE_VIEW_TEMPLATES)
 }

--- a/src/config/to-boolean.js
+++ b/src/config/to-boolean.js
@@ -1,0 +1,8 @@
+const { isNil } = require('ramda')
+
+const toBoolean = (value) =>
+  isNil(value) ? false : value.toString().toLowerCase() === 'true'
+
+module.exports = {
+  toBoolean
+}

--- a/src/config/to-boolean.test.js
+++ b/src/config/to-boolean.test.js
@@ -1,0 +1,16 @@
+const test = require('tape')
+const { toBoolean } = require('./to-boolean')
+
+test('toBoolean()', (t) => {
+  t.equal(toBoolean(), false, 'an undefined value should return false')
+  t.equal(toBoolean(null), false, 'a null value should return false')
+  t.equal(toBoolean(33), false, 'an integer value should return false')
+  t.equal(toBoolean('random string'), false, 'a random string should return false')
+  t.equal(toBoolean('false'), false, 'the string "false" should return false')
+  t.equal(toBoolean('FALSE'), false, 'the string "FALSE" should return false')
+  t.equal(toBoolean('true'), true, 'the string "true" should return true')
+  t.equal(toBoolean('TRUE'), true, 'the string "TRUE" should return true')
+  t.equal(toBoolean(false), false, 'the boolean "false" should return false')
+  t.equal(toBoolean(true), true, 'the boolean "true" should return true')
+  t.end()
+})

--- a/src/web/server/server.js
+++ b/src/web/server/server.js
@@ -28,7 +28,7 @@ const start = (config, app) => () => {
   app.use(compression())
   app.use(bodyParser.urlencoded({ extended: false }))
 
-  setViewEngine(app)
+  setViewEngine(config, app)
   registerRoutes(config, app)
   registerErrorHandlers(app)
   listen(config, app)

--- a/src/web/server/view-engine/view-engine.js
+++ b/src/web/server/view-engine/view-engine.js
@@ -1,7 +1,7 @@
 const nunjucks = require('nunjucks')
 const { toErrorList, getErrorForField } = require('./filters')
 
-const setViewEngine = (app) => {
+const setViewEngine = (config, app) => {
   const env = nunjucks.configure([
     'src/web/views',
     'node_modules/govuk-frontend/',
@@ -9,7 +9,7 @@ const setViewEngine = (app) => {
   ], {
     autoescape: true,
     express: app,
-    noCache: true
+    noCache: config.server.CACHE_VIEW_TEMPLATES
   })
 
   env.addFilter('toErrorList', toErrorList)


### PR DESCRIPTION
Set configuration for Nunjucks template caching as an environment variable.

Taken the decision to create a simple string -> boolean coercing function as it seemed better than importing a library (which could introduce vulnerabilities). The use case is fairly specific; coercing environment variables (which are always strings) to boolean values.