### PR TITLE
HTBHF-291 Fix acceptance test async errors

### DIFF
--- a/src/test/common/page/enter-nino.js
+++ b/src/test/common/page/enter-nino.js
@@ -23,7 +23,7 @@ class EnterNino extends Page {
 
   async enterNino (nino) {
     const ninoField = await this.getNinoField()
-    ninoField.sendKeys(nino)
+    await ninoField.sendKeys(nino)
   }
 
   async getNinoField () {


### PR DESCRIPTION
Not waiting for inputted keys to complete was resulting in periodic stale web element errors. `await` forces this async task to complete before continuing with the test.