### PR TITLE
HTBHF-8 Fix check details error if no claim present on session

### DIFF
--- a/src/web/routes/application/check/get.js
+++ b/src/web/routes/application/check/get.js
@@ -1,5 +1,3 @@
-const { pick } = require('ramda')
-
 const pageContent = {
   title: 'Check',
   heading: 'Check'
@@ -8,7 +6,7 @@ const pageContent = {
 const getCheck = (req, res) => {
   res.render('check', {
     ...pageContent,
-    claim: pick(['firstName', 'lastName', 'nino'], req.session.claim),
+    claim: req.session.claim,
     csrfToken: req.csrfToken()
   })
 }


### PR DESCRIPTION
Using ramda pick requires a null check on `req.session.claim`. As this data is not sent to the client it seems better to pass the whole `claim` object to the view. No null check is required for this as session will always be defined.