### PR TITLE
HTBHF-418 Added expected delivery date to the check details page

### DIFF
--- a/src/web/views/check.njk
+++ b/src/web/views/check.njk
@@ -50,6 +50,22 @@
         ],
         [
           {
+            text: "Are you pregnant?"
+          },
+          {
+            text: claim.areYouPregnant
+          }
+        ],
+        [
+          {
+            text: "When is your baby due to be born"
+          },
+          {
+            text: [claim['expectedDeliveryDate-day'], claim['expectedDeliveryDate-month'], claim['expectedDeliveryDate-year']] | join(' ')
+          }
+        ],
+        [
+          {
             text: "Card delivery address"
           },
           {


### PR DESCRIPTION
I've added both are you pregnant and expected delivery date - which will always appear. I expect HTBHF-18 (check your answers) to fix the display of the due date.