### PR TITLE
Feature/custom error summary title

### DIFF
--- a/src/test/common/steps/are-you-pregnant.js
+++ b/src/test/common/steps/are-you-pregnant.js
@@ -89,13 +89,13 @@ Then(/^I am informed that I need to enter an expected delivery date$/, async fun
 })
 
 Then(/^I am informed that the date is too far in the past$/, async function () {
-  await assertErrorHeaderTextPresent(pages.areYouPregnant)
-  await assertExpectedDeliveryDateErrorPresent('The due date you entered is more than 1 month ago. Please call our helpline on 0345 607 6823 to talk about your application.')
+  await assertErrorHeaderTextPresent(pages.areYouPregnant, 'The due date you entered is more than 1 month ago')
+  await assertExpectedDeliveryDateErrorPresent('Please call our helpline on 0345 607 6823 to talk about your application')
 })
 
 Then(/^I am informed that the date is too far in the future$/, async function () {
-  await assertErrorHeaderTextPresent(pages.areYouPregnant)
-  await assertExpectedDeliveryDateErrorPresent('The date you have entered is more than 8 months in the future. You must be at least 10 weeks pregnant to apply for yourself. If you have children under the age of 4, answer ‘no’ to this question to continue with this application on their behalf.')
+  await assertErrorHeaderTextPresent(pages.areYouPregnant, 'You must be at least 10 weeks pregnant to apply for yourself')
+  await assertExpectedDeliveryDateErrorPresent('If you have children under the age of 4, answer ‘no’ to this question to continue with this application on their behalf')
 })
 
 async function assertAreYouPregnantErrorPresent () {

--- a/src/test/common/steps/common-steps.js
+++ b/src/test/common/steps/common-steps.js
@@ -55,11 +55,11 @@ async function enterCardAddress (addressLine1, addressLine2, townOrCity, postcod
   }
 }
 
-async function assertErrorHeaderTextPresent (page) {
+async function assertErrorHeaderTextPresent (page, message = 'There is a problem') {
   try {
     await page.waitForPageLoad()
     const errorHeader = await page.getPageErrorHeaderText()
-    expect(errorHeader).to.equal('There is a problem')
+    expect(errorHeader).to.equal(message)
   } catch (error) {
     assert.fail(`Unexpected error caught trying to assert error header text is present - ${error}`)
   }

--- a/src/web/routes/application/are-you-pregnant/test/validate.test.js
+++ b/src/web/routes/application/are-you-pregnant/test/validate.test.js
@@ -10,6 +10,7 @@ const createDateWithMonthAdjustment = (monthAdjustment) => {
 
 test('validateExpectedDeliveryDate() eight months in the future', (t) => {
   const eightMonthsInFuture = createDateWithMonthAdjustment(8)
+  const res = {}
   const req = {
     t: (string) => string,
     body: {
@@ -20,12 +21,15 @@ test('validateExpectedDeliveryDate() eight months in the future', (t) => {
     }
   }
 
-  t.equal(validateExpectedDeliveryDate({}, { req }), true, 'should return true for exactly eight months in future')
+  const result = validateExpectedDeliveryDate(res)({}, { req })
+
+  t.equal(result, true, 'should return true for exactly eight months in future')
   t.end()
 })
 
 test('validateExpectedDeliveryDate() one month in the past', (t) => {
   const oneMonthInPast = createDateWithMonthAdjustment(-1)
+  const res = {}
   const req = {
     t: (string) => string,
     body: {
@@ -36,11 +40,14 @@ test('validateExpectedDeliveryDate() one month in the past', (t) => {
     }
   }
 
-  t.equal(validateExpectedDeliveryDate({}, { req }), true, 'should return true for exactly one month in past')
+  const result = validateExpectedDeliveryDate(res)({}, { req })
+
+  t.equal(result, true, 'should return true for exactly one month in past')
   t.end()
 })
 
 test('validateExpectedDeliveryDate() date too far in the past', (t) => {
+  const res = {}
   const req = {
     t: (string) => string,
     body: {
@@ -51,11 +58,14 @@ test('validateExpectedDeliveryDate() date too far in the past', (t) => {
     }
   }
 
-  t.throws(validateExpectedDeliveryDate.bind(null, {}, { req }), /validation:expectedDeliveryDateInvalidTooFarInPast/, 'not in valid date range')
+  const result = validateExpectedDeliveryDate(res).bind(null, {}, { req })
+
+  t.throws(result, /validation:expectedDeliveryDateTooFarInPast/, 'not in valid date range')
   t.end()
 })
 
 test('validateExpectedDeliveryDate() too far in the future', (t) => {
+  const res = {}
   const req = {
     t: (string) => string,
     body: {
@@ -66,11 +76,14 @@ test('validateExpectedDeliveryDate() too far in the future', (t) => {
     }
   }
 
-  t.throws(validateExpectedDeliveryDate.bind(null, {}, { req }), /validation:expectedDeliveryDateInvalidTooFarInFuture/, 'not in valid date range')
+  const result = validateExpectedDeliveryDate(res).bind(null, {}, { req })
+
+  t.throws(result, /validation:expectedDeliveryDateTooFarInFuture/, 'not in valid date range')
   t.end()
 })
 
 test('validateExpectedDeliveryDate() null date', (t) => {
+  const res = {}
   const req = {
     t: (string) => string,
     body: {
@@ -81,11 +94,14 @@ test('validateExpectedDeliveryDate() null date', (t) => {
     }
   }
 
-  t.throws(validateExpectedDeliveryDate.bind(null, {}, { req }), /validation:expectedDeliveryDateInvalid/, 'not in valid date range')
+  const result = validateExpectedDeliveryDate(res).bind(null, {}, { req })
+
+  t.throws(result, /validation:expectedDeliveryDateInvalid/, 'not in valid date range')
   t.end()
 })
 
 test('validateExpectedDeliveryDate() invalid date', (t) => {
+  const res = {}
   const req = {
     t: (string) => string,
     body: {
@@ -96,11 +112,14 @@ test('validateExpectedDeliveryDate() invalid date', (t) => {
     }
   }
 
-  t.throws(validateExpectedDeliveryDate.bind(null, {}, { req }), /validation:expectedDeliveryDateInvalid/, 'not in valid date range')
+  const result = validateExpectedDeliveryDate(res).bind(null, {}, { req })
+
+  t.throws(result, /validation:expectedDeliveryDateInvalid/, 'not in valid date range')
   t.end()
 })
 
 test('validateExpectedDeliveryDateNotPregnant()', (t) => {
+  const res = {}
   const req = {
     t: (string) => string,
     body: {
@@ -108,6 +127,8 @@ test('validateExpectedDeliveryDateNotPregnant()', (t) => {
     }
   }
 
-  t.equal(validateExpectedDeliveryDate({}, { req }), true, 'should not validate the date if not pregnant')
+  const result = validateExpectedDeliveryDate(res)({}, { req })
+
+  t.equal(result, true, 'should not validate the date if not pregnant')
   t.end()
 })

--- a/src/web/routes/application/are-you-pregnant/test/validate.test.js
+++ b/src/web/routes/application/are-you-pregnant/test/validate.test.js
@@ -2,6 +2,10 @@ const test = require('tape')
 const { validateExpectedDeliveryDate } = require('../validate')
 const { YES, NO } = require('../constants')
 
+const res = {
+  locals: {}
+}
+
 const createDateWithMonthAdjustment = (monthAdjustment) => {
   const date = new Date()
   date.setMonth(date.getMonth() + monthAdjustment)
@@ -10,7 +14,6 @@ const createDateWithMonthAdjustment = (monthAdjustment) => {
 
 test('validateExpectedDeliveryDate() eight months in the future', (t) => {
   const eightMonthsInFuture = createDateWithMonthAdjustment(8)
-  const res = {}
   const req = {
     t: (string) => string,
     body: {
@@ -29,7 +32,6 @@ test('validateExpectedDeliveryDate() eight months in the future', (t) => {
 
 test('validateExpectedDeliveryDate() one month in the past', (t) => {
   const oneMonthInPast = createDateWithMonthAdjustment(-1)
-  const res = {}
   const req = {
     t: (string) => string,
     body: {
@@ -47,7 +49,6 @@ test('validateExpectedDeliveryDate() one month in the past', (t) => {
 })
 
 test('validateExpectedDeliveryDate() date too far in the past', (t) => {
-  const res = {}
   const req = {
     t: (string) => string,
     body: {
@@ -65,7 +66,6 @@ test('validateExpectedDeliveryDate() date too far in the past', (t) => {
 })
 
 test('validateExpectedDeliveryDate() too far in the future', (t) => {
-  const res = {}
   const req = {
     t: (string) => string,
     body: {
@@ -83,7 +83,6 @@ test('validateExpectedDeliveryDate() too far in the future', (t) => {
 })
 
 test('validateExpectedDeliveryDate() null date', (t) => {
-  const res = {}
   const req = {
     t: (string) => string,
     body: {
@@ -101,7 +100,6 @@ test('validateExpectedDeliveryDate() null date', (t) => {
 })
 
 test('validateExpectedDeliveryDate() invalid date', (t) => {
-  const res = {}
   const req = {
     t: (string) => string,
     body: {
@@ -119,7 +117,6 @@ test('validateExpectedDeliveryDate() invalid date', (t) => {
 })
 
 test('validateExpectedDeliveryDateNotPregnant()', (t) => {
-  const res = {}
   const req = {
     t: (string) => string,
     body: {

--- a/src/web/routes/application/are-you-pregnant/test/validation-composition.test.js
+++ b/src/web/routes/application/are-you-pregnant/test/validation-composition.test.js
@@ -36,7 +36,7 @@ test('validation middleware errors for are you pregnant field', async (t) => {
   t.end()
 })
 
-test('validation middleware errors for are you pregnant field', async (t) => {
+test('validation middleware errors for expected delivery date field', async (t) => {
   const twelveMonthsInFuture = dateAsString({ monthAdjustment: 12 }).split('-')
 
   const testReq = {
@@ -53,6 +53,6 @@ test('validation middleware errors for are you pregnant field', async (t) => {
   const error = result.array()[0]
   t.equal(result.array().length, 1, 'should have exactly one error')
   t.equal(error.param, 'expectedDeliveryDate', 'error should be associated with correct field')
-  t.equal(error.msg, 'validation:expectedDeliveryDateInvalidTooFarInFuture', 'error should have correct message')
+  t.equal(error.msg, 'validation:expectedDeliveryDateTooFarInFuture', 'error should have correct message')
   t.end()
 })

--- a/src/web/routes/application/are-you-pregnant/validate.js
+++ b/src/web/routes/application/are-you-pregnant/validate.js
@@ -23,10 +23,12 @@ const validateExpectedDeliveryDate = (res) => (_, { req }) => {
   }
 
   if (isDateMoreThanOneMonthAgo(expectedDeliveryDate)) {
+    res.locals.errorTitleText = req.t('validation:expectedDeliveryDateTooFarInPastTitle')
     throw new Error(req.t('validation:expectedDeliveryDateTooFarInPast'))
   }
 
   if (isDateMoreThanEightMonthsInTheFuture(expectedDeliveryDate)) {
+    res.locals.errorTitleText = req.t('validation:expectedDeliveryDateTooFarInFutureTitle')
     throw new Error(req.t('validation:expectedDeliveryDateTooFarInFuture'))
   }
 

--- a/src/web/routes/application/common/configure-post.js
+++ b/src/web/routes/application/common/configure-post.js
@@ -1,0 +1,8 @@
+const configurePost = (req, res, next) => {
+  res.locals.errorTitleText = req.t('validation:errorTitleText')
+  next()
+}
+
+module.exports = {
+  configurePost
+}

--- a/src/web/routes/application/common/render-view.js
+++ b/src/web/routes/application/common/render-view.js
@@ -6,8 +6,7 @@ const renderView = (template, getPageContent, redirect) => (req, res) => {
   res.render(template, {
     ...getPageContent({ translate: req.t }),
     csrfToken: req.csrfToken(),
-    htmlLang: req.language,
-    errorTitleText: req.t('validation:errorTitleText')
+    htmlLang: req.language
   })
 }
 

--- a/src/web/routes/application/common/test/apply-express-validation.js
+++ b/src/web/routes/application/common/test/apply-express-validation.js
@@ -22,8 +22,12 @@ const callMiddlewareQueue = async (req, res, middlewares) => {
 }
 
 const applyExpressValidation = async (req, middleware) => {
+  const res = {
+    locals: {}
+  }
+
   try {
-    await callMiddlewareQueue(req, {}, middleware)
+    await callMiddlewareQueue(req, res, middleware)
     return validationResult(req)
   } catch (error) {
     console.log('Error applying express validation:', error)

--- a/src/web/routes/application/register-form-routes.js
+++ b/src/web/routes/application/register-form-routes.js
@@ -4,6 +4,7 @@ const { sanitize } = require('./common/sanitize')
 const { renderView } = require('./common/render-view')
 const { handlePost } = require('./common/handle-post')
 const { getSessionDetails } = require('./common/session-details')
+const { configurePost } = require('./common/configure-post')
 
 const middlewareNoop = (req, res, next) => next()
 
@@ -25,6 +26,7 @@ const createRoute = (csrfProtection, steps, router) => (step) =>
     )
     .post(
       csrfProtection,
+      configurePost,
       sanitize,
       handleOptionalMiddleware(step.sanitize),
       handleOptionalMiddleware(step.validate),

--- a/src/web/server/locales/cy/validation.json
+++ b/src/web/server/locales/cy/validation.json
@@ -11,6 +11,8 @@
   "informationTooLong": "Interdum velit laoreet id donec ultrices tincidunt",
   "missingAddressField": "Dui id ornare arcu odio",
   "expectedDeliveryDateInvalid": "Placerat orci nulla pellentesqu",
-  "expectedDeliveryDateInvalidTooFarInPast": "Dictum fusce ut placerat orci nulla pellentesqu",
-  "expectedDeliveryDateInvalidTooFarInFuture": "Interdum velit laoreet id donec ultrices tincidunt"
+  "expectedDeliveryDateTooFarInPastTitle": "Nisi lacus sed viverra tellus in",
+  "expectedDeliveryDateTooFarInPast": "Dictum fusce ut placerat orci nulla pellentesqu",
+  "expectedDeliveryDateTooFarInFutureTitle": "Viverra tellus i ultrices",
+  "expectedDeliveryDateTooFarInFuture": "Interdum velit laoreet id donec ultrices tincidunt"
 }

--- a/src/web/server/locales/en/validation.json
+++ b/src/web/server/locales/en/validation.json
@@ -11,7 +11,9 @@
   "informationTooLong": "The information you entered is too long",
   "missingAddressField": "Tell us your address",
   "expectedDeliveryDateInvalid": "Enter your baby's due date",
-  "expectedDeliveryDateInvalidTooFarInPast": "The due date you entered is more than 1 month ago. Please call our helpline on 0345 607 6823 to talk about your application.",
-  "expectedDeliveryDateInvalidTooFarInFuture": "The date you have entered is more than 8 months in the future. You must be at least 10 weeks pregnant to apply for yourself. If you have children under the age of 4, answer ‘no’ to this question to continue with this application on their behalf."
+  "expectedDeliveryDateTooFarInPastTitle": "The due date you entered is more than 1 month ago",
+  "expectedDeliveryDateTooFarInPast": "Please call our helpline on 0345 607 6823 to talk about your application",
+  "expectedDeliveryDateTooFarInFutureTitle": "You must be at least 10 weeks pregnant to apply for yourself",
+  "expectedDeliveryDateTooFarInFuture": "If you have children under the age of 4, answer ‘no’ to this question to continue with this application on their behalf"
 
 }


### PR DESCRIPTION
- Create configure middleware step to allow general configuration of apply journey POST requests
- Set custom error summary title for expected delivery date validations
- Minor refactor of translation key names
- Set a default value for acceptance tests `assertErrorHeaderTextPresent()` function to allow for different error summary titles