### PR TITLE
NO-JIRA Changing node version on travis to 10.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '10.10'
+- '10.15'
 
 cache: npm
 


### PR DESCRIPTION
Travis no longer supports version 10.10 of node so we're updating the version to use to 10.15.0