### PR TITLE
Feature/refactor logger

### DIFF
--- a/src/web/logger/format.js
+++ b/src/web/logger/format.js
@@ -1,5 +1,5 @@
 const { format } = require('winston')
-const { pathOr, partial } = require('ramda')
+const { pathOr } = require('ramda')
 const { printf } = format
 
 const SESSION_ID_PATH = ['sessionID']
@@ -9,10 +9,10 @@ const pathOrEmpty = pathOr('')
 const sessionIDPath = pathOrEmpty(SESSION_ID_PATH)
 const requestIdPath = pathOrEmpty(REQUEST_ID_PATH)
 
-const logFormatter = (req, { level, message, timestamp }) =>
+const logFormatter = ({ level, message, timestamp, req }) =>
   `${timestamp} ${level.toUpperCase()} [${sessionIDPath(req)}][${requestIdPath(req)}] ${message}`
 
-const formatLog = (req) => printf(partial(logFormatter, [req]))
+const formatLog = printf(logFormatter)
 
 module.exports = {
   logFormatter,

--- a/src/web/logger/format.test.js
+++ b/src/web/logger/format.test.js
@@ -7,7 +7,7 @@ test('logFormatter() formats log correctly if IDs are not available', (t) => {
   const message = 'log message'
   const timestamp = '2019-02-14'
 
-  const result = logFormatter(req, { level, message, timestamp })
+  const result = logFormatter({ level, message, timestamp, req })
   const expected = '2019-02-14 INFO [][] log message'
 
   t.equal(result, expected, 'formats log correctly if IDs are not available')
@@ -25,7 +25,7 @@ test('logFormatter() formats log correctly if IDs are available', (t) => {
   const message = 'log message'
   const timestamp = '2019-02-14'
 
-  const result = logFormatter(req, { level, message, timestamp })
+  const result = logFormatter({ level, message, timestamp, req })
   const expected = '2019-02-14 INFO [5678][1234] log message'
 
   t.equal(result, expected, 'formats log correctly if IDs are available')

--- a/src/web/logger/logger.js
+++ b/src/web/logger/logger.js
@@ -6,13 +6,13 @@ const { combine, timestamp } = format
 
 const TIMESTAMP_FORMAT = 'HH:mm:ss.SSS'
 
-const logger = (req) => createLogger({
+const logger = createLogger({
   level: config.environment.LOG_LEVEL,
   format: combine(
     timestamp({
       format: TIMESTAMP_FORMAT
     }),
-    formatLog(req)
+    formatLog
   ),
   transports: [
     new transports.Console()

--- a/src/web/routes/application/common/state-machine/state-machine.js
+++ b/src/web/routes/application/common/state-machine/state-machine.js
@@ -23,10 +23,7 @@ const stateMachine = {
   },
 
   setState: (state, req) => {
-    logger(req).log({
-      level: 'info',
-      message: `State set to ${state}`
-    })
+    logger(req).info(`State set to ${state}`)
     req.session.state = state
   },
 

--- a/src/web/routes/application/common/state-machine/state-machine.js
+++ b/src/web/routes/application/common/state-machine/state-machine.js
@@ -23,7 +23,7 @@ const stateMachine = {
   },
 
   setState: (state, req) => {
-    logger(req).info(`State set to ${state}`)
+    logger.info(`State set to ${state}`, { req })
     req.session.state = state
   },
 

--- a/src/web/server/error-handlers.js
+++ b/src/web/server/error-handlers.js
@@ -2,10 +2,7 @@ const httpStatus = require('http-status-codes')
 const { logger } = require('../logger')
 
 const logErrors = (err, req, res, next) => {
-  logger(req).log({
-    level: 'error',
-    message: err.stack
-  })
+  logger(req).error(err.stack)
   next(err)
 }
 

--- a/src/web/server/error-handlers.js
+++ b/src/web/server/error-handlers.js
@@ -2,7 +2,7 @@ const httpStatus = require('http-status-codes')
 const { logger } = require('../logger')
 
 const logErrors = (err, req, res, next) => {
-  logger(req).error(err.stack)
+  logger.error(err.stack, { req })
   next(err)
 }
 

--- a/src/web/server/server.js
+++ b/src/web/server/server.js
@@ -25,7 +25,7 @@ const configureStaticPaths = (app) => {
 
 const listen = (config, app) =>
   app.listen(config.server.PORT, () => {
-    logger().info(`App listening on port ${config.server.PORT}`)
+    logger.info(`App listening on port ${config.server.PORT}`)
   })
 
 const start = (config, app) => () => {

--- a/src/web/server/server.js
+++ b/src/web/server/server.js
@@ -24,12 +24,9 @@ const configureStaticPaths = (app) => {
 }
 
 const listen = (config, app) =>
-  app.listen(config.server.PORT, () =>
-    logger().log({
-      level: 'info',
-      message: `App listening on port ${config.server.PORT}`
-    })
-  )
+  app.listen(config.server.PORT, () => {
+    logger().info(`App listening on port ${config.server.PORT}`)
+  })
 
 const start = (config, app) => () => {
   /**

--- a/src/web/server/session/session.js
+++ b/src/web/server/session/session.js
@@ -6,17 +6,11 @@ const { path } = require('ramda')
 const { logger } = require('../../logger')
 
 const onClientError = (error) => {
-  logger().log({
-    level: 'error',
-    message: `Error with redis session: ${error}`
-  })
+  logger().error(`Error with redis session: ${error}`)
 }
 
 const onClientConnection = (callback) => () => {
-  logger().log({
-    level: 'info',
-    message: 'Redis client connected'
-  })
+  logger().info('Redis client connected')
   callback()
 }
 
@@ -49,10 +43,7 @@ const getSessionConfig = (store, config) => {
     sessionConfig.cookie.secure = false
   }
 
-  logger().log({
-    level: 'info',
-    message: `Using secure cookie: ${sessionConfig.cookie.secure}`
-  })
+  logger().info(`Using secure cookie: ${sessionConfig.cookie.secure}`)
 
   return sessionConfig
 }

--- a/src/web/server/session/session.js
+++ b/src/web/server/session/session.js
@@ -6,11 +6,11 @@ const { path } = require('ramda')
 const { logger } = require('../../logger')
 
 const onClientError = (error) => {
-  logger().error(`Error with redis session: ${error}`)
+  logger.error(`Error with redis session: ${error}`)
 }
 
 const onClientConnection = (callback) => () => {
-  logger().info('Redis client connected')
+  logger.info('Redis client connected')
   callback()
 }
 
@@ -43,7 +43,7 @@ const getSessionConfig = (store, config) => {
     sessionConfig.cookie.secure = false
   }
 
-  logger().info(`Using secure cookie: ${sessionConfig.cookie.secure}`)
+  logger.info(`Using secure cookie: ${sessionConfig.cookie.secure}`)
 
   return sessionConfig
 }


### PR DESCRIPTION
- Log messages using logger methods aliased by level e.g. `logger.error( ... )`
- Stop creating unnecessary logger instances by passing `req` to Winston logger as a property on the meta argument (see https://github.com/winstonjs/winston#streams-objectmode-and-info-objects)