### PR TITLE
HTBHF-534 Fix from BrowserStack for compatibility test failures, in F…

### DIFF
--- a/src/test/compatibility/driver/browserstack-driver.js
+++ b/src/test/compatibility/driver/browserstack-driver.js
@@ -28,7 +28,8 @@ class BrowserstackDriver extends DriverManager {
         'realMobile': 'true',
         'device': process.env.BROWSER_STACK_DEVICE,
         'browserstack.user': BROWSER_STACK_USER,
-        'browserstack.key': BROWSER_STACK_KEY
+        'browserstack.key': BROWSER_STACK_KEY,
+        'browserstack.use_w3c': 'true'
       })
       .usingServer(BROWSER_STACK_URL)
       .build()


### PR DESCRIPTION
…irefox  we'd see the error "Could not convert 'text' to string" and in Edge we'd see: "JSON format error: parameters object must contain pair with name "keysToSend"".