### PR TITLE
Feature/add cookie translation

### DIFF
--- a/src/web/routes/application/check/get.js
+++ b/src/web/routes/application/check/get.js
@@ -35,7 +35,7 @@ const getCheck = (req, res) => {
     ...pageContent({ translate: req.t }),
     csrfToken: req.csrfToken(),
     checkRowData,
-    cookieLinkName: req.t('cookieLinkName')
+    cookieLinkName: req.t('cookies.linkName')
   })
 }
 

--- a/src/web/routes/application/check/get.js
+++ b/src/web/routes/application/check/get.js
@@ -34,7 +34,8 @@ const getCheck = (req, res) => {
     claim: req.session.claim,
     ...pageContent({ translate: req.t }),
     csrfToken: req.csrfToken(),
-    checkRowData
+    checkRowData,
+    cookieLinkName: req.t('cookieLinkName')
   })
 }
 

--- a/src/web/routes/application/confirm.js
+++ b/src/web/routes/application/confirm.js
@@ -9,7 +9,10 @@ const pageContent = ({ language, translate }) => ({
 const getConfirmPage = (req, res) => {
   req.session.destroy()
   res.clearCookie('lang')
-  res.render('confirm', pageContent({ language: getLanguageBase(req.language), translate: req.t }))
+  res.render('confirm', {
+    ...pageContent({ language: getLanguageBase(req.language), translate: req.t }),
+    cookieLinkName: req.t('cookieLinkName')
+  })
 }
 
 const registerConfirmRoute = (app) => {

--- a/src/web/routes/application/confirm.js
+++ b/src/web/routes/application/confirm.js
@@ -11,7 +11,7 @@ const getConfirmPage = (req, res) => {
   res.clearCookie('lang')
   res.render('confirm', {
     ...pageContent({ language: getLanguageBase(req.language), translate: req.t }),
-    cookieLinkName: req.t('cookieLinkName')
+    cookieLinkName: req.t('cookies.linkName')
   })
 }
 

--- a/src/web/routes/application/middleware/render-view/render-view.js
+++ b/src/web/routes/application/middleware/render-view/render-view.js
@@ -9,7 +9,8 @@ const renderView = (template, getPageContent, redirect) => (req, res) => {
   res.render(template, {
     ...getPageContent({ translate: req.t }),
     csrfToken: req.csrfToken(),
-    htmlLang: req.language
+    htmlLang: req.language,
+    cookieLinkName: req.t('cookieLinkName')
   })
 }
 

--- a/src/web/routes/application/middleware/render-view/render-view.js
+++ b/src/web/routes/application/middleware/render-view/render-view.js
@@ -10,7 +10,7 @@ const renderView = (template, getPageContent, redirect) => (req, res) => {
     ...getPageContent({ translate: req.t }),
     csrfToken: req.csrfToken(),
     htmlLang: req.language,
-    cookieLinkName: req.t('cookieLinkName')
+    cookieLinkName: req.t('cookies.linkName')
   })
 }
 

--- a/src/web/routes/cookies.js
+++ b/src/web/routes/cookies.js
@@ -1,13 +1,12 @@
 const { getLanguageBase } = require('./application/common/language')
 
-const pageContent = ({ language }) => ({
-  // TODO setup cookies page to handle translations HTBHF-586
-  heading: 'Cookies',
+const pageContent = ({ language, translate }) => ({
+  title: translate('cookies.title'),
   language: language
 })
 
 const getCookiesPage = (req, res) => {
-  res.render('cookies', pageContent({ language: getLanguageBase(req.language) }))
+  res.render('cookies', pageContent({ language: getLanguageBase(req.language), translate: req.t }))
 }
 
 const registerCookiesRoute = (app) => {

--- a/src/web/routes/start.js
+++ b/src/web/routes/start.js
@@ -1,6 +1,7 @@
 const pageContent = {
   title: 'Overview',
-  heading: 'Overview'
+  heading: 'Overview',
+  cookieLinkName: 'Cookies'
 }
 
 const getStartPage = (req, res) => {

--- a/src/web/server/error-handlers.js
+++ b/src/web/server/error-handlers.js
@@ -15,7 +15,8 @@ const errorHandler = (err, req, res, next) => {
   res.render('error', {
     title: req.t('errors:problemWithTheServiceTitle'),
     heading: req.t('errors:problemWithTheServiceTitle'),
-    content: req.t('errors:problemWithTheServiceContent')
+    content: req.t('errors:problemWithTheServiceContent'),
+    cookieLinkName: req.t('cookies.linkName')
   })
 }
 

--- a/src/web/server/locales/cy/common.json
+++ b/src/web/server/locales/cy/common.json
@@ -58,5 +58,6 @@
     "subTitle": "Dui faucibus in ornare\n£3.10 ut labore"
   },
   "yes": "Diam",
-  "no": "Sed"
+  "no": "Sed",
+  "cookieLinkName": "Cwci"
 }

--- a/src/web/server/locales/cy/common.json
+++ b/src/web/server/locales/cy/common.json
@@ -57,7 +57,10 @@
     "title": "Ullamcorper malesuada",
     "subTitle": "Dui faucibus in ornare\n£3.10 ut labore"
   },
+  "cookies": {
+    "title": "Cwcis",
+    "linkName": "Cwcis"
+  },
   "yes": "Diam",
-  "no": "Sed",
-  "cookieLinkName": "Cwci"
+  "no": "Sed"
 }

--- a/src/web/server/locales/en/common.json
+++ b/src/web/server/locales/en/common.json
@@ -58,5 +58,6 @@
     "subTitle": "You are entitled to\n£3.10 per week"
   },
   "yes": "Yes",
-  "no": "No"
+  "no": "No",
+  "cookieLinkName": "Cookies"
 }

--- a/src/web/server/locales/en/common.json
+++ b/src/web/server/locales/en/common.json
@@ -57,7 +57,10 @@
     "title": "Application complete",
     "subTitle": "You are entitled to\n£3.10 per week"
   },
+  "cookies": {
+    "title": "Cookies",
+    "linkName": "Cookies"
+  },
   "yes": "Yes",
-  "no": "No",
-  "cookieLinkName": "Cookies"
+  "no": "No"
 }

--- a/src/web/views/locales/cy/cookies.html
+++ b/src/web/views/locales/cy/cookies.html
@@ -1,0 +1,78 @@
+<h1 class="govuk-heading-xl">Cwci</h1>
+
+<p class="govuk-body">In hac habitasse platea dictumst donec in purus et enim sodales pharetra 'cwcis'
+    nisi vitae faucibus.</p>
+<p class="govuk-body">Duis ac dui elementum fermentum nisi vitae:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+    <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit sed do eiusmod</li>
+    <li>Eget felis eget nunc lobortis mattis</li>
+    <li>Urna condimentum mattis nunc imperdiet ipsum a condimentum pretium leo neque</li>
+</ul>
+<p class="govuk-body">Donec sit <a class="govuk-link" href="https://ico.org.uk/for-the-public/online/cookies/">leo nunc imperdiet ipsum a condimentum pretium leo.</a></p>
+
+<h2 class="govuk-heading-m">Urna condimentum cwci</h2>
+
+<p class="govuk-body">Tempus egestas sed sed risus pretium quam vulputate dignissim suspendisse. Lectus quam id leo in.</p>
+
+<p class="govuk-body">In hac habitasse platea dictumst donec in purus et enim sodales pharetra:</p>
+<ul class="govuk-list govuk-list--bullet">
+    <li>Sed nisl felis, commodo eu bibendum</li>
+    <li>In hac habitasse platea dictumst donec</li>
+    <li>Quisque vel ex porttitor accumsan massa egestas</li>
+</ul>
+
+<table class="govuk-table">
+    <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col">Nominus</th>
+            <th class="govuk-table__header" scope="col">Bibendum</th>
+            <th class="govuk-table__header" scope="col">Porttitor</th>
+        </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell">_ga</td>
+            <td class="govuk-table__cell">Maecenas id molestie orci nec suscipit neque vivamus.</td>
+            <td class="govuk-table__cell">2 annus</td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell">_gid</td>
+            <td class="govuk-table__cell">Maecenas id molestie orci nec suscipit neque vivamus</td>
+            <td class="govuk-table__cell">24 horrors</td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell">_gat_UA-133839203_4</td>
+            <td class="govuk-table__cell">Dui elementum fermentum nisi vitae faucibus at duis tristique</td>
+            <td class="govuk-table__cell">1 momento</td>
+    </tr>
+    </tbody>
+</table>
+
+<p class="govuk-body">Tempus egestas sed sed risus pretium quam vulputate dignissim suspendisse.</p>
+
+<h2 class="govuk-heading-m">Septimus cwcis</h2>
+
+<p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+
+<table class="govuk-table">
+    <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col">Nominus</th>
+            <th class="govuk-table__header" scope="col">Bibendum</th>
+            <th class="govuk-table__header" scope="col">Porttitor</th>
+        </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell">htbhf.sid</td>
+            <td class="govuk-table__cell">Duis ac dui elementum fermentum.</td>
+            <td class="govuk-table__cell">Quisque vel ex porttitor.</td>
+        </tr>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell">lang</td>
+            <td class="govuk-table__cell">Morbi porta tellus diam.</td>
+            <td class="govuk-table__cell">Quisque vel ex porttitor.</td>
+        </tr>
+    </tbody>
+</table>

--- a/src/web/views/templates/page.njk
+++ b/src/web/views/templates/page.njk
@@ -4,6 +4,7 @@
 {% from "phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "header/macro.njk" import govukHeader %}
 {% from "footer/macro.njk" import govukFooter %}
+{% from "back-link/macro.njk" import govukBackLink %}
 
 {% block pageTitle %}GOV.UK - {{ title }}{% endblock %}
 
@@ -50,6 +51,10 @@
         text: "beta"
       },
       html: 'This is a new service.'
+    }) }}
+    {{ govukBackLink({
+      text: "Back",
+      href: "/"
     }) }}
 {% endblock %}
 

--- a/src/web/views/templates/page.njk
+++ b/src/web/views/templates/page.njk
@@ -67,7 +67,7 @@
       items: [
         {
           href: "/cookies",
-          text: "Cookies"
+          text: cookieLinkName
         }
       ]
     }


### PR DESCRIPTION
 - Add cookie page for Welsh language
 - Make the Cookie link also be translatable.
 - Also add Back button so that we can return from the Cookie page. This will also be present on all other pages, the destination is currently always the Overview page as this link will be revisited in the Back button story (including translation of the Back link text).