### PR TITLE
HTBHF-485 apply req as first argument to state machine functions

### DIFF
--- a/src/web/routes/application/common/state-machine/state-machine.js
+++ b/src/web/routes/application/common/state-machine/state-machine.js
@@ -29,22 +29,20 @@ const getNextPath = (steps, path) => {
 const isPathAllowed = (sequence, allowed, path) =>
   sequence.findIndex(equals(path)) <= sequence.findIndex(equals(allowed))
 
-const getNextAllowedPath = (path) => path
-
 const stateMachine = {
   [states.IN_PROGRESS]: {
-    getNextPath,
-    isPathAllowed,
-    getNextAllowedPath
+    getNextPath: (req, steps) => getNextPath(steps, req.path),
+    isPathAllowed: (req, sequence) => isPathAllowed(sequence, req.session.nextAllowedStep, req.path),
+    getNextAllowedPath: (req) => req.session.nextAllowedStep
   },
   [states.IN_REVIEW]: {
     getNextPath: () => CHECK_URL,
-    isPathAllowed,
-    getNextAllowedPath
+    isPathAllowed: (req, sequence) => isPathAllowed(sequence, req.session.nextAllowedStep, req.path),
+    getNextAllowedPath: (req) => req.session.nextAllowedStep
   },
   [states.COMPLETED]: {
     getNextPath: () => CONFIRM_URL,
-    isPathAllowed: (sequence, allowed, path) => path === CONFIRM_URL,
+    isPathAllowed: (req) => req.path === CONFIRM_URL,
     getNextAllowedPath: () => CONFIRM_URL
   },
 
@@ -61,7 +59,7 @@ const stateMachine = {
   dispatch: (action, req, ...args) => {
     const state = stateMachine.getState(req)
 
-    return state[action](...args)
+    return state[action](req, ...args)
   }
 }
 

--- a/src/web/routes/application/common/state-machine/state-machine.test.js
+++ b/src/web/routes/application/common/state-machine/state-machine.test.js
@@ -8,30 +8,30 @@ const steps = [{ path: '/first', next: '/second' }, { path: '/second' }]
 const paths = ['/first', '/second', '/third', '/fourth']
 
 test(`Dispatching ${GET_NEXT_PATH} should return next property of associated step when no state defined in session`, async (t) => {
-  const req = { method: 'POST', session: {} }
+  const req = { method: 'POST', session: {}, path: '/first' }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps, '/first'), '/second')
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps), '/second')
   t.end()
 })
 
 test(`Dispatching ${GET_NEXT_PATH} should return should return next property of associated step when state of ${states.IN_PROGRESS} defined in session`, async (t) => {
-  const req = { method: 'POST', session: { state: states.IN_PROGRESS } }
+  const req = { method: 'POST', session: { state: states.IN_PROGRESS }, path: '/first' }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps, '/first'), '/second')
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps), '/second')
   t.end()
 })
 
 test(`Dispatching ${GET_NEXT_PATH} should return check path when state of ${states.IN_REVIEW} defined in session`, async (t) => {
-  const req = { method: 'POST', session: { state: states.IN_REVIEW } }
+  const req = { method: 'POST', session: { state: states.IN_REVIEW }, path: '/first' }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps, '/first'), CHECK_URL)
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps), CHECK_URL)
   t.end()
 })
 
 test(`Dispatching ${GET_NEXT_PATH} should return confirm path when state of ${states.COMPLETED} defined in session`, async (t) => {
-  const req = { method: 'POST', session: { state: states.COMPLETED } }
+  const req = { method: 'POST', session: { state: states.COMPLETED }, path: '/first' }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps, '/first'), CONFIRM_URL)
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps), CONFIRM_URL)
   t.end()
 })
 

--- a/src/web/routes/application/middleware/handle-path-request.js
+++ b/src/web/routes/application/middleware/handle-path-request.js
@@ -18,8 +18,8 @@ const middleware = (config, pathsInSequence) => (req, res, next) => {
     req.session.nextAllowedStep = pathsInSequence[0]
   }
 
-  const isPathAllowed = stateMachine.dispatch(IS_PATH_ALLOWED, req, pathsInSequence, req.session.nextAllowedStep, req.path)
-  const nextAllowedPath = stateMachine.dispatch(GET_NEXT_ALLOWED_PATH, req, req.session.nextAllowedStep)
+  const isPathAllowed = stateMachine.dispatch(IS_PATH_ALLOWED, req, pathsInSequence)
+  const nextAllowedPath = stateMachine.dispatch(GET_NEXT_ALLOWED_PATH, req)
 
   // Redirect to nextAllowedPath on invalid path request
   if (!isPathAllowed) {

--- a/src/web/routes/application/middleware/handle-post-redirects.js
+++ b/src/web/routes/application/middleware/handle-post-redirects.js
@@ -5,7 +5,7 @@ const handlePostRedirects = (steps) => (req, res, next) => {
     return next()
   }
 
-  const nextPage = stateMachine.dispatch(actions.GET_NEXT_PATH, req, steps, req.path)
+  const nextPage = stateMachine.dispatch(actions.GET_NEXT_PATH, req, steps)
   return res.redirect(nextPage)
 }
 

--- a/src/web/routes/application/middleware/handle-post.js
+++ b/src/web/routes/application/middleware/handle-post.js
@@ -20,7 +20,7 @@ const handlePost = (steps) => (req, res, next) => {
       ...req.body
     }
 
-    req.session.nextAllowedStep = stateMachine.dispatch(GET_NEXT_PATH, req, steps, req.path)
+    req.session.nextAllowedStep = stateMachine.dispatch(GET_NEXT_PATH, req, steps)
 
     return next()
   } catch (error) {


### PR DESCRIPTION
Apply req as first argument to state machine functions.

This allows us to remove arguments that are properties of the `req` object as a reference to `req` is always passed to a state machine action. This reduces the number of parameters passed to dispatch.