### PR TITLE
Feature/refactor state machine

### DIFF
--- a/src/web/routes/application/common/state-machine/state-machine.js
+++ b/src/web/routes/application/common/state-machine/state-machine.js
@@ -47,8 +47,7 @@ const stateMachine = {
   },
 
   getState: (req) => {
-    const state = states.hasOwnProperty(req.session.state) ? states[req.session.state] : states.IN_PROGRESS
-    return stateMachine[state]
+    return states.hasOwnProperty(req.session.state) ? states[req.session.state] : states.IN_PROGRESS
   },
 
   setState: (state, req) => {
@@ -56,10 +55,15 @@ const stateMachine = {
     req.session.state = state
   },
 
-  dispatch: (action, req, ...args) => {
+  dispatch: (actionType, req, ...args) => {
     const state = stateMachine.getState(req)
+    const action = stateMachine[state][actionType]
 
-    return state[action](req, ...args)
+    if (typeof action !== 'undefined') {
+      return action(req, ...args)
+    }
+
+    return null
   }
 }
 

--- a/src/web/routes/application/common/state-machine/state-machine.test.js
+++ b/src/web/routes/application/common/state-machine/state-machine.test.js
@@ -35,6 +35,13 @@ test(`Dispatching ${GET_NEXT_PATH} should return confirm path when state of ${st
   t.end()
 })
 
+test(`Dispatching an invalid action should return null`, async (t) => {
+  const req = { method: 'POST', session: {}, path: '/first' }
+
+  t.equal(stateMachine.dispatch('INVALID_ACTION', req, steps), null)
+  t.end()
+})
+
 test('isPathAllowed() should return true if path is before allowed in sequence', (t) => {
   const result = isPathAllowed(paths, '/third', '/second')
   t.equal(result, true, 'returns true if path is before allowed in sequence')

--- a/src/web/routes/application/middleware/handle-path-request.js
+++ b/src/web/routes/application/middleware/handle-path-request.js
@@ -7,7 +7,7 @@ const getPathsInSequence = (steps) => [...steps.map(step => step.path), CHECK_UR
 
 const middleware = (config, pathsInSequence) => (req, res, next) => {
   // Destroy the session on navigating away from CONFIRM_URL
-  if (req.session.state === states.COMPLETED && req.path !== CONFIRM_URL) {
+  if (stateMachine.getState(req) === states.COMPLETED && req.path !== CONFIRM_URL) {
     req.session.destroy()
     res.clearCookie('lang')
     return res.redirect(config.environment.OVERVIEW_URL)


### PR DESCRIPTION
Refactor `getState()` to return a string in order to provide a consistent API for callers to determine the current state of the apply journey.