### PR TITLE
NO-JIRA add silent configuration to logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node src/web",
     "start:dev": "npm run build && nodemon $NODE_DEBUG_OPTION src/web -e js,json,html,njk",
-    "test": "cross-env LOG_LEVEL=warn CLAIMANT_SERVICE_URL=http://localhost:8090 npm-run-all build test:lint test:unit:coverage test:fail_if_test_only_found -p -r start test:browser",
+    "test": "cross-env LOG_LEVEL=silent CLAIMANT_SERVICE_URL=http://localhost:8090 npm-run-all build test:lint test:unit:coverage test:fail_if_test_only_found -p -r start test:browser",
     "test:lint": "standard",
     "test:unit": "tape -r './src/test/unit/setup' 'src/@(web|config)/**/*.test.js'",
     "test:unit:coverage": "nyc npm run test:unit",

--- a/src/web/logger/logger.js
+++ b/src/web/logger/logger.js
@@ -15,7 +15,9 @@ const logger = createLogger({
     formatLog
   ),
   transports: [
-    new transports.Console()
+    new transports.Console({
+      silent: config.environment.LOG_LEVEL === 'silent'
+    })
   ]
 })
 


### PR DESCRIPTION
Wiremock 500 responses are causing the app to log errors during acceptance tests that pollute the console output. Adding `LOG_LEVEL=silent` as an environment variable when running acceptance tests will now silence the logger.

A noisy console has caused us to ignore actual errors in our acceptance tests. Keeping the console noise free should force us to fix any future errors that appear.

Are there any situations where turning off logging during acceptance tests could be an issue?