### PR TITLE
HTBHF-640 Handle 404 responses from claimant service.

### DIFF
--- a/src/web/routes/application/check/post.js
+++ b/src/web/routes/application/check/post.js
@@ -22,19 +22,21 @@ const postCheck = (steps, config) => async (req, res, next) => {
         claimant: createRequestBody(req.session.claim)
       }
     })
-
-    logger.info('Sent claim', { req })
-
-    stateMachine.setState(states.COMPLETED, req)
-    req.session.nextAllowedStep = stateMachine.dispatch(actions.GET_NEXT_PATH, req, steps, req.path)
-    return res.redirect('confirm')
   } catch (error) {
-    next(wrapError({
-      cause: error,
-      message: 'Error posting to claimant service',
-      statusCode: httpStatus.INTERNAL_SERVER_ERROR
-    }))
+    if (error.statusCode !== 404) {
+      return next(wrapError({
+        cause: error,
+        message: 'Error posting to claimant service',
+        statusCode: httpStatus.INTERNAL_SERVER_ERROR
+      }))
+    }
   }
+
+  logger.info('Sent claim', { req })
+
+  stateMachine.setState(states.COMPLETED, req)
+  req.session.nextAllowedStep = stateMachine.dispatch(actions.GET_NEXT_PATH, req, steps, req.path)
+  return res.redirect('confirm')
 }
 
 module.exports = {

--- a/src/web/routes/application/check/post.test.js
+++ b/src/web/routes/application/check/post.test.js
@@ -20,14 +20,19 @@ const config = {
 }
 
 test('unsuccessful post calls next with error', async (t) => {
-  const req = {}
+  const req = {
+    headers: {},
+    session: {}
+  }
   const res = {}
   const next = sinon.spy()
 
-  post.returns(new Error('error'))
+  const error = new Error('error')
+  error.statusCode = 500
+  post.throws(error)
 
   try {
-    await postCheck(config)(req, res, next)
+    await postCheck({}, config)(req, res, next)
     t.equal(next.calledWith(sinon.match.instanceOf(Error)), true)
     t.end()
   } catch (error) {


### PR DESCRIPTION
Note, additional acceptance tests and content will be created in a future PR. This PR is up so that the service doesn't break when the api changes for the claimant service goes in.