### PR TITLE
HTBHF-854 clear session data on start page if required

### DIFF
--- a/src/test/acceptance/features/overview.feature
+++ b/src/test/acceptance/features/overview.feature
@@ -7,3 +7,10 @@ Feature: Temporary overview page
     Given I navigate to the HTBHF overview page
     When I select to start the process
     Then I am shown the enter name page
+
+  # Test fix for bug HTBHF-854
+  Scenario: The overview page allows a claimant to start a new application
+    Given I have completed my application
+    When I navigate to the HTBHF overview page
+    And I select to start the process
+    Then I am shown the enter name page

--- a/src/web/routes/register-routes.js
+++ b/src/web/routes/register-routes.js
@@ -27,8 +27,8 @@ const registerRoutes = (config, app) => {
     registerHoldingRoute(config, app)
   } else {
     const csrfProtection = csrf({})
+    registerStartRoute(config, steps, app)
     registerFormRoutes(config, csrfProtection, steps, app)
-    registerStartRoute(app)
     registerCheckRoutes(csrfProtection, steps, config, app)
     registerConfirmRoute(config, steps, app)
     registerCookiesRoute(app)

--- a/src/web/routes/start.js
+++ b/src/web/routes/start.js
@@ -1,3 +1,5 @@
+const { handleRequestForPath } = require('./application/middleware')
+
 const pageContent = {
   title: 'Overview',
   heading: 'Overview'
@@ -7,8 +9,12 @@ const getStartPage = (req, res) => {
   res.render('start', pageContent)
 }
 
-const registerStartRoute = (app) => {
-  app.get('/', getStartPage)
+const registerStartRoute = (config, steps, app) => {
+  /**
+   * `handleRequestForPath()` ensures the session is cleared when the start page
+   * is requested after an apply journey has been completed.
+   */
+  app.get('/', handleRequestForPath(config, steps), getStartPage)
 }
 
 module.exports = {


### PR DESCRIPTION
This is a fix for bug: start page redirecting to itself after COMPLETE apply journey