### PR TITLE
HTBHF-978 assert on total voucher value for four weeks

### DIFF
--- a/src/test/common/page/confirm.js
+++ b/src/test/common/page/confirm.js
@@ -30,6 +30,12 @@ class Confirm extends SubmittablePage {
     const panelBody = await this.findByClassName(PANEL_BODY_CLASS)
     return panelBody.getText()
   }
+
+  async getVoucherEntitlementRefsForDataAttr (property) {
+    const elements = await this.findAllByCSS(`[data-entitlement="${property}"]`)
+    const references = elements.map(async (element) => element.getText())
+    return Promise.all(references)
+  }
 }
 
 module.exports = Confirm

--- a/src/test/common/page/page.js
+++ b/src/test/common/page/page.js
@@ -103,6 +103,16 @@ class Page {
     }
   }
 
+  async findAllByCSS (selector) {
+    try {
+      await this.waitForElement(selector, CSS_TYPE)
+      return this.driver.findElements(webdriver.By.css(selector))
+    } catch (error) {
+      console.log(error)
+      throw new Error(error)
+    }
+  }
+
   async findByXPath (xpath) {
     try {
       return await this.driver.findElement(webdriver.By.xpath(xpath))

--- a/src/test/common/steps/confirm-details.js
+++ b/src/test/common/steps/confirm-details.js
@@ -23,6 +23,7 @@ Then(/^I am shown a successful confirmation page$/, async function () {
 Then(/^my entitlement is 12.40 per week$/, async function () {
   const totalVoucherValue = await pages.confirm.getPanelBodyText()
   expect(totalVoucherValue.toString().trim()).to.be.equal('You are entitled to\n£12.40 per week', 'expected total voucher value to be correct')
+  await assertVoucherEntitlementValuesForAttr('total-voucher-value-four-weeks', '49.60')
 })
 
 async function checkAllPageContentIsPresentAndCorrect () {
@@ -30,4 +31,15 @@ async function checkAllPageContentIsPresentAndCorrect () {
   expect(h2Text.toString().trim()).to.be.equal('What happens next', 'expected confirm page H2 text to be correct')
   const panelTitle = await pages.confirm.getPanelTitleText()
   expect(panelTitle.toString().trim()).to.be.equal('Application complete', 'expected confirmation header to be correct')
+}
+
+async function assertVoucherEntitlementValuesForAttr (attr, expectedValue) {
+  try {
+    const message = `expected all references to ${attr.replace('-', ' ')} to be correct`
+    const refs = await pages.confirm.getVoucherEntitlementRefsForDataAttr(attr)
+    const incorrectAmounts = refs.filter(value => value !== expectedValue)
+    expect(incorrectAmounts.length).to.be.equal(0, message)
+  } catch (error) {
+    console.log(error)
+  }
 }


### PR DESCRIPTION
The content of the confirm page is liable to change as we iterate the apply journey. When this content changes the function `assertVoucherEntitlementValuesForAttr()` will allow quick updates to the acceptance tests by wrapping voucher entitlement values in `data` attributes e.g:
```
<span data-entitlement="total-voucher-value-four-weeks">{{ totalVoucherValueForFourWeeks }}</span>
```
The above HTML was introduced in a previous commit in `src/web/views/locales/en/confirm.html`. This PR asserts that the total voucher value for four weeks is correct.