### PR TITLE
HTBHF-1358 add address field to request body

### DIFF
--- a/src/web/routes/application/check/create-request-body.js
+++ b/src/web/routes/application/check/create-request-body.js
@@ -12,6 +12,7 @@ const createExpectedDeliveryDate = (claim) => {
   return null
 }
 
+// TODO HTBHF-842 remove cardDeliveryAddress once required updates have been implemented in the claimant service
 const createRequestBody = (claim) => {
   return {
     firstName: claim.firstName,
@@ -19,6 +20,12 @@ const createRequestBody = (claim) => {
     nino: claim.nino,
     dateOfBirth: claim.dateOfBirth,
     cardDeliveryAddress: {
+      addressLine1: claim.addressLine1,
+      addressLine2: claim.addressLine2,
+      townOrCity: claim.townOrCity,
+      postcode: claim.postcode
+    },
+    address: {
       addressLine1: claim.addressLine1,
       addressLine2: claim.addressLine2,
       townOrCity: claim.townOrCity,

--- a/src/web/routes/application/check/create-request-body.test.js
+++ b/src/web/routes/application/check/create-request-body.test.js
@@ -26,13 +26,18 @@ test('create claim body', (t) => {
     lastName: 'The third',
     nino: 'qq123456c',
     dateOfBirth: '1920-01-01',
-    cardDeliveryAddress:
-      {
-        addressLine1: 'Flat b',
-        addressLine2: '221 Baker street',
-        townOrCity: 'London',
-        postcode: 'aa1 1ab'
-      },
+    cardDeliveryAddress: {
+      addressLine1: 'Flat b',
+      addressLine2: '221 Baker street',
+      townOrCity: 'London',
+      postcode: 'aa1 1ab'
+    },
+    address: {
+      addressLine1: 'Flat b',
+      addressLine2: '221 Baker street',
+      townOrCity: 'London',
+      postcode: 'aa1 1ab'
+    },
     expectedDeliveryDate: '2019-03-01'
   }
 
@@ -67,13 +72,18 @@ test('create claim body without expectedDeliveryDate when not pregnant', (t) => 
     lastName: 'The third',
     nino: 'qq123456c',
     dateOfBirth: '1920-01-01',
-    cardDeliveryAddress:
-      {
-        addressLine1: 'Flat b',
-        addressLine2: '221 Baker street',
-        townOrCity: 'London',
-        postcode: 'aa1 1ab'
-      },
+    cardDeliveryAddress: {
+      addressLine1: 'Flat b',
+      addressLine2: '221 Baker street',
+      townOrCity: 'London',
+      postcode: 'aa1 1ab'
+    },
+    address: {
+      addressLine1: 'Flat b',
+      addressLine2: '221 Baker street',
+      townOrCity: 'London',
+      postcode: 'aa1 1ab'
+    },
     expectedDeliveryDate: null
   }
 


### PR DESCRIPTION
- Add `address` field to request body sent to claimant service
- `cardDeliveryAddress` has been left intact for backwards compatibility. Once the claimant service has been updated to accept `address` then `cardDeliveryAddress` can be removed