### PR TITLE
Allow conditional next paths for step

### DIFF
--- a/src/web/routes/application/are-you-pregnant/are-you-pregnant.js
+++ b/src/web/routes/application/are-you-pregnant/are-you-pregnant.js
@@ -41,7 +41,7 @@ const pageContent = ({ translate }) => ({
 
 const areYouPregnant = {
   path: '/are-you-pregnant',
-  next: '/enter-name',
+  next: () => '/enter-name',
   template: 'are-you-pregnant',
   pageContent,
   validate,

--- a/src/web/routes/application/card-address/card-address.js
+++ b/src/web/routes/application/card-address/card-address.js
@@ -30,7 +30,7 @@ const contentSummary = (req) => ({
 
 const cardAddress = {
   path: '/card-address',
-  next: '/phone-number',
+  next: () => '/phone-number',
   template: 'card-address',
   pageContent,
   validate,

--- a/src/web/routes/application/common/state-machine/get-next-for-step.js
+++ b/src/web/routes/application/common/state-machine/get-next-for-step.js
@@ -1,0 +1,25 @@
+const { path } = require('ramda')
+
+const getNextForStep = (req, step) => {
+  const next = path(['next'], step)
+
+  if (typeof next !== 'function') {
+    throw new Error('Next property for step must be a function')
+  }
+
+  const nextPath = next(req)
+
+  if (typeof nextPath !== 'string') {
+    throw new Error('Next function must return a string')
+  }
+
+  if (!nextPath.startsWith('/')) {
+    throw new Error('Next path must start with a forward slash')
+  }
+
+  return nextPath
+}
+
+module.exports = {
+  getNextForStep
+}

--- a/src/web/routes/application/common/state-machine/get-next-for-step.test.js
+++ b/src/web/routes/application/common/state-machine/get-next-for-step.test.js
@@ -1,0 +1,50 @@
+const test = require('tape')
+const sinon = require('sinon')
+const { getNextForStep } = require('./get-next-for-step')
+
+test('getNextForStep() throws error if next is not a function', (t) => {
+  const step = { next: 'This is not a function' }
+  const req = {}
+  const result = () => getNextForStep(req, step)
+
+  t.throws(result, /Next property for step must be a function/, 'throws error if next is not a function')
+  t.end()
+})
+
+test('getNextForStep() throws error if result of calling next is not a string', (t) => {
+  const step = { next: () => null }
+  const req = {}
+  const result = () => getNextForStep(req, step)
+
+  t.throws(result, /Next function must return a string/, 'throws error if result of calling next is not a string')
+  t.end()
+})
+
+test('getNextForStep() throws error if result of calling next does not start with forward slash', (t) => {
+  const step = { next: () => 'path-without-forward-slash' }
+  const req = {}
+  const result = () => getNextForStep(req, step)
+
+  t.throws(result, /Next path must start with a forward slash/, 'throws error if result of calling next does not start with forward slash')
+  t.end()
+})
+
+test('getNextForStep() should return the result of calling next', (t) => {
+  const step = { next: () => '/the-next-path' }
+  const req = {}
+  const result = getNextForStep(req, step)
+
+  t.equals(result, '/the-next-path', 'return the result of calling next')
+  t.end()
+})
+
+test('getNextForStep() passes request as an argument when calling next function', (t) => {
+  const next = sinon.stub().returns('/the-next-path')
+  const req = { session: { some: 'data' } }
+  const step = { next }
+
+  getNextForStep(req, step)
+
+  t.equals(next.getCall(0).args[0], req, 'passes request as an argument when calling next function')
+  t.end()
+})

--- a/src/web/routes/application/common/state-machine/get-next-for-step.test.js
+++ b/src/web/routes/application/common/state-machine/get-next-for-step.test.js
@@ -1,5 +1,4 @@
 const test = require('tape')
-const sinon = require('sinon')
 const { getNextForStep } = require('./get-next-for-step')
 
 test('getNextForStep() throws error if next is not a function', (t) => {
@@ -39,12 +38,12 @@ test('getNextForStep() should return the result of calling next', (t) => {
 })
 
 test('getNextForStep() passes request as an argument when calling next function', (t) => {
-  const next = sinon.stub().returns('/the-next-path')
-  const req = { session: { some: 'data' } }
+  const req = { session: { some: '/path' } }
+  const next = (req) => req.session.some
   const step = { next }
 
-  getNextForStep(req, step)
+  const result = getNextForStep(req, step)
 
-  t.equals(next.getCall(0).args[0], req, 'passes request as an argument when calling next function')
+  t.equals(result, '/path', 'passes request as an argument when calling next function')
   t.end()
 })

--- a/src/web/routes/application/common/state-machine/state-machine.js
+++ b/src/web/routes/application/common/state-machine/state-machine.js
@@ -1,4 +1,5 @@
 const { equals } = require('ramda')
+const { getNextForStep } = require('./get-next-for-step')
 const { CHECK_URL, CONFIRM_URL } = require('../constants')
 const { logger } = require('../../../../logger')
 
@@ -13,17 +14,11 @@ const actions = {
   GET_NEXT_ALLOWED_PATH: 'getNextAllowedPath'
 }
 
-const getStepByPath = (steps, path) => steps.find(step => step.path === path)
+const getStepForPath = (path, steps) => steps.find(step => step.path === path)
 
-const getNextPath = (steps, path) => {
-  const step = getStepByPath(steps, path)
-  const nextPath = step.next
-
-  if (!nextPath) {
-    throw new Error(`No next step defined for ${path}`)
-  }
-
-  return nextPath
+const getNext = (req, steps) => {
+  const nextStep = getStepForPath(req.path, steps)
+  return getNextForStep(req, nextStep)
 }
 
 const isPathAllowed = (sequence, allowed, path) =>
@@ -31,7 +26,7 @@ const isPathAllowed = (sequence, allowed, path) =>
 
 const stateMachine = {
   [states.IN_PROGRESS]: {
-    getNextPath: (req, steps) => getNextPath(steps, req.path),
+    getNextPath: getNext,
     isPathAllowed: (req, sequence) => isPathAllowed(sequence, req.session.nextAllowedStep, req.path),
     getNextAllowedPath: (req) => req.session.nextAllowedStep
   },

--- a/src/web/routes/application/common/state-machine/state-machine.test.js
+++ b/src/web/routes/application/common/state-machine/state-machine.test.js
@@ -4,7 +4,7 @@ const { CHECK_URL, CONFIRM_URL } = require('../../common/constants')
 
 const { GET_NEXT_PATH } = actions
 
-const steps = [{ path: '/first', next: '/second' }, { path: '/second' }]
+const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
 const paths = ['/first', '/second', '/third', '/fourth']
 
 test(`Dispatching ${GET_NEXT_PATH} should return next property of associated step when no state defined in session`, async (t) => {

--- a/src/web/routes/application/do-you-live-in-scotland/do-you-live-in-scotland.js
+++ b/src/web/routes/application/do-you-live-in-scotland/do-you-live-in-scotland.js
@@ -15,7 +15,7 @@ const pageContent = ({ translate }) => ({
 
 const doYouLiveInScotland = {
   path: '/do-you-live-in-scotland',
-  next: '/enter-dob',
+  next: () => '/enter-dob',
   template: 'do-you-live-in-scotland',
   pageContent,
   contentSummary,

--- a/src/web/routes/application/enter-dob/enter-dob.js
+++ b/src/web/routes/application/enter-dob/enter-dob.js
@@ -23,7 +23,7 @@ const contentSummary = (req) => ({
 
 const enterDob = {
   path: '/enter-dob',
-  next: '/are-you-pregnant',
+  next: () => '/are-you-pregnant',
   template: 'enter-dob',
   pageContent,
   validate,

--- a/src/web/routes/application/enter-name/enter-name.js
+++ b/src/web/routes/application/enter-name/enter-name.js
@@ -16,7 +16,7 @@ const contentSummary = (req) => ({
 
 const enterName = {
   path: '/enter-name',
-  next: '/enter-nino',
+  next: () => '/enter-nino',
   template: 'enter-name',
   validate,
   pageContent,

--- a/src/web/routes/application/enter-nino/enter-nino.js
+++ b/src/web/routes/application/enter-nino/enter-nino.js
@@ -20,7 +20,7 @@ const contentSummary = (req) => ({
 
 const enterNino = {
   path: '/enter-nino',
-  next: '/card-address',
+  next: () => '/card-address',
   template: 'enter-nino',
   sanitize,
   validate,

--- a/src/web/routes/application/middleware/handle-path-request.test.js
+++ b/src/web/routes/application/middleware/handle-path-request.test.js
@@ -4,7 +4,7 @@ const { CHECK_URL, CONFIRM_URL } = require('../common/constants')
 const { getPathsInSequence, handleRequestForPath } = require('./handle-path-request')
 const { states } = require('../common/state-machine')
 
-const steps = [{ path: '/first', next: '/second' }, { path: '/second' }]
+const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
 
 const config = {
   environment: {

--- a/src/web/routes/application/middleware/handle-post-redirects.test.js
+++ b/src/web/routes/application/middleware/handle-post-redirects.test.js
@@ -2,7 +2,7 @@ const test = require('tape')
 const sinon = require('sinon')
 const { handlePostRedirects } = require('./handle-post-redirects')
 
-const steps = [{ path: '/first', next: '/second' }, { path: '/second' }]
+const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
 
 test('handlePostRedirects() should redirect when no response errors', async (t) => {
   const redirect = sinon.spy()

--- a/src/web/routes/application/middleware/handle-post.test.js
+++ b/src/web/routes/application/middleware/handle-post.test.js
@@ -10,7 +10,7 @@ const defaultValidator = {
   }
 }
 
-const steps = [{ path: '/first', next: '/second' }, { path: '/second' }]
+const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
 
 test('handlePost() should add errors and claim to locals if errors exist', (t) => {
   const errors = ['error']

--- a/src/web/routes/application/phone-number/phone-number.js
+++ b/src/web/routes/application/phone-number/phone-number.js
@@ -20,7 +20,7 @@ const contentSummary = (req) => ({
 
 const phoneNumber = {
   path: '/phone-number',
-  next: '/check',
+  next: () => '/check',
   template: 'phone-number',
   validate,
   sanitize,


### PR DESCRIPTION
- Create a function that accepts the request object and returns a string in order to determine a path for the next step. This allows for conditional rendering of the next step in the sequence.
- Update the state machine to implement this function when determining the next step for the `IN_PROGRESS` state.
- Update the steps configuration objects to use a function for the `next` property.