### PR TITLE
HTBHF-1551 do not update next allowed step if not in sequence

### DIFF
--- a/src/web/routes/application/common/sequence/get-paths-in-sequence.js
+++ b/src/web/routes/application/common/sequence/get-paths-in-sequence.js
@@ -1,0 +1,7 @@
+const { CHECK_URL, CONFIRM_URL } = require('../constants')
+
+const getPathsInSequence = (steps) => [...steps.map(step => step.path), CHECK_URL, CONFIRM_URL]
+
+module.exports = {
+  getPathsInSequence
+}

--- a/src/web/routes/application/common/sequence/get-paths-in-sequence.test.js
+++ b/src/web/routes/application/common/sequence/get-paths-in-sequence.test.js
@@ -1,0 +1,12 @@
+const test = require('tape')
+const { CHECK_URL, CONFIRM_URL } = require('../constants')
+const { getPathsInSequence } = require('./get-paths-in-sequence')
+
+test('getPathsInSequence() returns the correct sequence of paths', (t) => {
+  const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
+  const expected = ['/first', '/second', CHECK_URL, CONFIRM_URL]
+  const result = getPathsInSequence(steps)
+
+  t.deepEqual(result, expected, 'returns the correct sequence of paths')
+  t.end()
+})

--- a/src/web/routes/application/common/sequence/index.js
+++ b/src/web/routes/application/common/sequence/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  ...require('./get-paths-in-sequence'),
+  ...require('./predicates')
+}

--- a/src/web/routes/application/common/sequence/predicates.js
+++ b/src/web/routes/application/common/sequence/predicates.js
@@ -1,0 +1,7 @@
+const { getPathsInSequence } = require('./get-paths-in-sequence')
+
+const isPathInSequence = (steps, path) => getPathsInSequence(steps).includes(path)
+
+module.exports = {
+  isPathInSequence
+}

--- a/src/web/routes/application/common/sequence/predicates.test.js
+++ b/src/web/routes/application/common/sequence/predicates.test.js
@@ -1,0 +1,16 @@
+const test = require('tape')
+const { isPathInSequence } = require('./predicates')
+
+test('isPathInSequence() returns true if path is in sequence', (t) => {
+  const steps = [{ path: '/first-in-sequence' }, { path: '/second-in-sequence' }, { path: '/third-in-sequence' }]
+  const result = isPathInSequence(steps, '/second-in-sequence')
+  t.equal(result, true, 'returns true if path is in sequence')
+  t.end()
+})
+
+test('isPathInSequence() returns false if path is not in sequence', (t) => {
+  const steps = [{ path: '/first-in-sequence' }, { path: '/second-in-sequence' }, { path: '/third-in-sequence' }]
+  const result = isPathInSequence(steps, '/not-in-sequence')
+  t.equal(result, false, 'returns false if path is not in sequence')
+  t.end()
+})

--- a/src/web/routes/application/common/state-machine/state-machine.js
+++ b/src/web/routes/application/common/state-machine/state-machine.js
@@ -1,6 +1,7 @@
 const { equals } = require('ramda')
 const { getNextForStep } = require('./get-next-for-step')
 const { CHECK_URL, CONFIRM_URL } = require('../constants')
+const { isPathInSequence } = require('../sequence')
 const { logger } = require('../../../../logger')
 
 const states = {
@@ -17,8 +18,9 @@ const actions = {
 const getStepForPath = (path, steps) => steps.find(step => step.path === path)
 
 const getNext = (req, steps) => {
-  const nextStep = getStepForPath(req.path, steps)
-  return getNextForStep(req, nextStep)
+  const step = getStepForPath(req.path, steps)
+  const nextPath = getNextForStep(req, step)
+  return isPathInSequence(steps, nextPath) ? nextPath : req.path
 }
 
 const isPathAllowed = (sequence, allowed, path) =>

--- a/src/web/routes/application/common/state-machine/state-machine.test.js
+++ b/src/web/routes/application/common/state-machine/state-machine.test.js
@@ -14,10 +14,21 @@ test(`Dispatching ${GET_NEXT_PATH} should return next property of associated ste
   t.end()
 })
 
-test(`Dispatching ${GET_NEXT_PATH} should return should return next property of associated step when state of ${states.IN_PROGRESS} defined in session`, async (t) => {
+test(`Dispatching ${GET_NEXT_PATH} should return next property of associated step when state of ${states.IN_PROGRESS} defined in session`, async (t) => {
   const req = { method: 'POST', session: { state: states.IN_PROGRESS }, path: '/first' }
 
   t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps), '/second')
+  t.end()
+})
+
+test(`Dispatching ${GET_NEXT_PATH} should return current path when next property is not in the sequence of steps and state of ${states.IN_PROGRESS} defined in session`, async (t) => {
+  const req = { method: 'POST', session: { state: states.IN_PROGRESS }, path: '/first-in-sequence' }
+  const testSteps = [
+    { path: '/first-in-sequence', next: () => '/not-in-sequence' },
+    { path: '/next-in-sequence' }
+  ]
+
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, testSteps), '/first-in-sequence')
   t.end()
 })
 

--- a/src/web/routes/application/middleware/handle-path-request.js
+++ b/src/web/routes/application/middleware/handle-path-request.js
@@ -1,9 +1,8 @@
-const { CHECK_URL, CONFIRM_URL } = require('../common/constants')
+const { CONFIRM_URL } = require('../common/constants')
 const { stateMachine, actions, states } = require('../common/state-machine')
+const { getPathsInSequence } = require('../common/sequence')
 
 const { IS_PATH_ALLOWED, GET_NEXT_ALLOWED_PATH } = actions
-
-const getPathsInSequence = (steps) => [...steps.map(step => step.path), CHECK_URL, CONFIRM_URL]
 
 const middleware = (config, pathsInSequence) => (req, res, next) => {
   // Destroy the session on navigating away from CONFIRM_URL

--- a/src/web/routes/application/middleware/handle-path-request.test.js
+++ b/src/web/routes/application/middleware/handle-path-request.test.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 const sinon = require('sinon')
-const { CHECK_URL, CONFIRM_URL } = require('../common/constants')
-const { getPathsInSequence, handleRequestForPath } = require('./handle-path-request')
+const { CONFIRM_URL } = require('../common/constants')
+const { handleRequestForPath } = require('./handle-path-request')
 const { states } = require('../common/state-machine')
 
 const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
@@ -11,14 +11,6 @@ const config = {
     OVERVIEW_URL: '/'
   }
 }
-
-test('getPathsInSequence() returns the correct sequence of paths', (t) => {
-  const expected = ['/first', '/second', CHECK_URL, CONFIRM_URL]
-  const result = getPathsInSequence(steps)
-
-  t.deepEqual(result, expected, 'returns the correct sequence of paths')
-  t.end()
-})
 
 test('handleRequestForPath() should set next allowed path to first in sequence if none exists on session', (t) => {
   const req = {


### PR DESCRIPTION
Currently, if the next path for a step in the application flow is not a path in the application then a user will not be able to re-enter the application due to the constraints of the next allowed step.

Some conditional routing in the application will direct users to pages that are outside of the application flow. In this case not updating the next allowed path allows the user to return to their last point in the application process when using the back button.

