### PR TITLE
Feature/invalidate review state

### DIFF
--- a/src/test/acceptance/features/do-you-live-in-scotland.feature
+++ b/src/test/acceptance/features/do-you-live-in-scotland.feature
@@ -24,3 +24,10 @@ Feature: Do you live in Scotland?
     And I click continue
     Then I am shown the I live in Scotland page
     And I am informed that I cannot apply and should use the Scottish scheme
+
+  Scenario: I can change my answer to yes for 'Do you live in Scotland?' from the check details page
+    Given I am on the check details page having entered valid details for a pregnant woman
+    When I choose to change my answer to Do you live in Scotland
+    And I select the Yes option on the do you live in Scotland page
+    And I click continue
+    Then I am shown the I live in Scotland page

--- a/src/test/common/steps/check-details.js
+++ b/src/test/common/steps/check-details.js
@@ -55,6 +55,10 @@ When(/^I choose to change my answer to are you pregnant$/, async function () {
   await pages.check.clickChangeLinkFor('Are you pregnant?')
 })
 
+When(/^I choose to change my answer to Do you live in Scotland$/, async function () {
+  await pages.check.clickChangeLinkFor('Do you live in Scotland?')
+})
+
 Then(/^the check details page contains all data entered for a pregnant woman$/, async function () {
   const tableContents = await pages.check.getCheckDetailsTableContents()
   assertNameShown(tableContents)

--- a/src/web/routes/application/common/state-machine/state-machine.js
+++ b/src/web/routes/application/common/state-machine/state-machine.js
@@ -11,7 +11,8 @@ const states = {
 const actions = {
   GET_NEXT_PATH: 'getNextPath',
   IS_PATH_ALLOWED: 'isPathAllowed',
-  GET_NEXT_ALLOWED_PATH: 'getNextAllowedPath'
+  GET_NEXT_ALLOWED_PATH: 'getNextAllowedPath',
+  INVALIDATE_REVIEW: 'invalidateReview'
 }
 
 const getStepForPath = (path, steps) => steps.find(step => step.path === path)
@@ -33,7 +34,8 @@ const stateMachine = {
   [states.IN_REVIEW]: {
     getNextPath: () => CHECK_URL,
     isPathAllowed: (req, sequence) => isPathAllowed(sequence, req.session.nextAllowedStep, req.path),
-    getNextAllowedPath: (req) => req.session.nextAllowedStep
+    getNextAllowedPath: (req) => req.session.nextAllowedStep,
+    invalidateReview: (req) => stateMachine.setState(states.IN_PROGRESS, req)
   },
   [states.COMPLETED]: {
     getNextPath: () => CONFIRM_URL,

--- a/src/web/routes/application/do-you-live-in-scotland/do-you-live-in-scotland.js
+++ b/src/web/routes/application/do-you-live-in-scotland/do-you-live-in-scotland.js
@@ -14,11 +14,14 @@ const pageContent = ({ translate }) => ({
   no: translate('no')
 })
 
-const next = req => req.session.claim.doYouLiveInScotland === YES ? '/i-live-in-scotland' : '/enter-dob'
+const claimantLivesInScotland = claim => claim.doYouLiveInScotland === YES
+
+const next = req => claimantLivesInScotland(req.session.claim) ? '/i-live-in-scotland' : '/enter-dob'
 
 const doYouLiveInScotland = {
   path: '/do-you-live-in-scotland',
   next,
+  shouldInvalidateReview: claimantLivesInScotland,
   template: 'do-you-live-in-scotland',
   pageContent,
   contentSummary,

--- a/src/web/routes/application/register-form-routes.js
+++ b/src/web/routes/application/register-form-routes.js
@@ -38,7 +38,7 @@ const createRoute = (config, csrfProtection, steps, router) => (step) =>
       handleOptionalMiddleware(step.sanitize),
       handleOptionalMiddleware(step.validate),
       getSessionDetails,
-      handlePost(steps),
+      handlePost(steps, step),
       handleRequestForPath(config, steps, step),
       handlePostRedirects(steps),
       renderView(step)


### PR DESCRIPTION
 If a user has completed the application and changes their answer for 'Do you live in Scotland?' to 'yes', they should be shown the 'I live in Scotland' page rather than the 'check details' page.

This PR allows a step to invalidate the IN_REVIEW state based on the claim set in the session.