### PR TITLE
NO-JIRA Fix express-validator deprecation warning after recent upgrade.

### DIFF
--- a/src/web/routes/application/are-you-pregnant/validate.js
+++ b/src/web/routes/application/are-you-pregnant/validate.js
@@ -1,4 +1,4 @@
-const { check } = require('express-validator/check')
+const { check } = require('express-validator')
 const { isNil } = require('ramda')
 
 const { toDateString } = require('../common/formatters')

--- a/src/web/routes/application/card-address/validate.js
+++ b/src/web/routes/application/card-address/validate.js
@@ -1,4 +1,4 @@
-const { check } = require('express-validator/check')
+const { check } = require('express-validator')
 const { translateValidationMessage } = require('../common/translate-validation-message')
 
 /*

--- a/src/web/routes/application/common/test/apply-express-validation.js
+++ b/src/web/routes/application/common/test/apply-express-validation.js
@@ -1,4 +1,4 @@
-const { validationResult } = require('express-validator/check')
+const { validationResult } = require('express-validator')
 
 const callMiddleware = (req, res) => async (middleware) => {
   try {

--- a/src/web/routes/application/common/validators.js
+++ b/src/web/routes/application/common/validators.js
@@ -1,6 +1,6 @@
 const { isNil } = require('ramda')
 const validator = require('validator')
-const { check } = require('express-validator/check')
+const { check } = require('express-validator')
 const { dateAsString } = require('./formatters')
 const { translateValidationMessage } = require('./translate-validation-message')
 const { YES, NO } = require('./constants')

--- a/src/web/routes/application/email-address/validate.js
+++ b/src/web/routes/application/email-address/validate.js
@@ -1,4 +1,4 @@
-const { check } = require('express-validator/check')
+const { check } = require('express-validator')
 const { translateValidationMessage } = require('../common/translate-validation-message')
 
 // See https://stackoverflow.com/questions/201323/how-to-validate-an-email-address-using-a-regular-expression for regex explanation

--- a/src/web/routes/application/enter-dob/validate.js
+++ b/src/web/routes/application/enter-dob/validate.js
@@ -1,4 +1,4 @@
-const { check } = require('express-validator/check')
+const { check } = require('express-validator')
 const { toDateString } = require('../common/formatters')
 const { isValidDate, isDateInPast } = require('../common/validators')
 

--- a/src/web/routes/application/enter-name/validate.js
+++ b/src/web/routes/application/enter-name/validate.js
@@ -1,4 +1,4 @@
-const { check } = require('express-validator/check')
+const { check } = require('express-validator')
 const { translateValidationMessage } = require('../common/translate-validation-message')
 
 const FIRST_NAME_MAX_LENGTH = 500

--- a/src/web/routes/application/enter-nino/validate.js
+++ b/src/web/routes/application/enter-nino/validate.js
@@ -1,4 +1,4 @@
-const { check } = require('express-validator/check')
+const { check } = require('express-validator')
 const { translateValidationMessage } = require('../common/translate-validation-message')
 
 const NINO_PATTERN = /^[a-zA-Z]{2}[\d]{6}[a-dA-D]$/

--- a/src/web/routes/application/middleware/handle-post.js
+++ b/src/web/routes/application/middleware/handle-post.js
@@ -1,5 +1,5 @@
 const httpStatus = require('http-status-codes')
-const { validationResult } = require('express-validator/check')
+const { validationResult } = require('express-validator')
 const { wrapError } = require('../common/formatters')
 const { stateMachine, actions } = require('../common/state-machine')
 

--- a/src/web/routes/application/middleware/handle-post.test.js
+++ b/src/web/routes/application/middleware/handle-post.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
 const defaultValidator = {
-  'express-validator/check': {
+  'express-validator': {
     validationResult: () => ({
       isEmpty: () => true
     })
@@ -14,7 +14,7 @@ test('handlePost() should add errors and claim to locals if errors exist', (t) =
   const errors = ['error']
 
   const { handlePost } = proxyquire('./handle-post', {
-    'express-validator/check': {
+    'express-validator': {
       validationResult: () => ({
         isEmpty: () => false,
         array: () => errors
@@ -69,7 +69,7 @@ test('handlePost() adds body to the session if no errors exist', (t) => {
 
 test('handlePost() calls next() with error on error', (t) => {
   const { handlePost } = proxyquire('./handle-post', {
-    'express-validator/check': {
+    'express-validator': {
       validationResult: () => ({
         isEmpty: () => { throw new Error('error') },
         array: () => []

--- a/src/web/routes/application/phone-number/validate.js
+++ b/src/web/routes/application/phone-number/validate.js
@@ -1,4 +1,4 @@
-const { check } = require('express-validator/check')
+const { check } = require('express-validator')
 const { parsePhoneNumberFromString } = require('libphonenumber-js')
 
 const PHONE_NUMBER_REGEX = /^\+?[\d()\- ]+$/

--- a/src/web/routes/application/terms-and-conditions/post.js
+++ b/src/web/routes/application/terms-and-conditions/post.js
@@ -1,7 +1,7 @@
 const httpStatus = require('http-status-codes')
 const request = require('request-promise')
 const { path } = require('ramda')
-const { validationResult } = require('express-validator/check')
+const { validationResult } = require('express-validator')
 
 const { wrapError } = require('../common/formatters')
 const { logger } = require('../../../logger')

--- a/src/web/routes/application/terms-and-conditions/post.test.js
+++ b/src/web/routes/application/terms-and-conditions/post.test.js
@@ -63,7 +63,7 @@ test('failure to agree to terms and conditions returns to the terms-and-conditio
   const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
 
   const { postTermsAndConditions } = proxyquire('./post', {
-    'express-validator/check': {
+    'express-validator': {
       validationResult: () => ({
         isEmpty: () => false,
         array: () => errors

--- a/src/web/routes/application/terms-and-conditions/terms-and-conditions.js
+++ b/src/web/routes/application/terms-and-conditions/terms-and-conditions.js
@@ -1,4 +1,4 @@
-const { check } = require('express-validator/check')
+const { check } = require('express-validator')
 const { getTermsAndConditions } = require('./get')
 const { postTermsAndConditions } = require('./post')
 const { TERMS_AND_CONDITIONS_URL } = require('../common/constants')


### PR DESCRIPTION
This stops the following deprecation warning which has appeared after the recent upgrade to express validator:

`express-validator: requires to express-validator/check are deprecated.You should just use require("express-validator") instead`