### PR TITLE
Childrens‘ date of birth validation

### DIFF
--- a/src/test/common/steps/are-you-pregnant.js
+++ b/src/test/common/steps/are-you-pregnant.js
@@ -85,7 +85,7 @@ Then(/^I am informed that I need to select an option for are you pregnant$/, asy
 
 Then(/^I am informed that I need to enter an expected delivery date$/, async function () {
   await assertErrorHeaderTextPresent(pages.areYouPregnant)
-  await assertExpectedDeliveryDateErrorPresent('Enter the due date in the correct format')
+  await assertExpectedDeliveryDateErrorPresent('Enter the due date')
 })
 
 Then(/^I am informed that the date is too far in the past$/, async function () {

--- a/src/web/routes/application/children-dob/validate.test.js
+++ b/src/web/routes/application/children-dob/validate.test.js
@@ -1,16 +1,31 @@
 const test = require('tape')
-const { fieldExistsWithPrefix, buildDateStringForPrefix, convertDateFieldsToDateStrings } = require('./validate')
+const { dateAsString } = require('../common/formatters')
+const {
+  fieldExistsWithPrefix,
+  buildDateStringForPrefix,
+  convertDateFieldsToDateStrings,
+  isChildNameKey,
+  getChildrenNameKeys,
+  validateDateOfBirth
+} = require('./validate')
 
 const fields = {
+  'childName-1': 'Lisa',
   'childDob-1-day': '1',
   'childDob-1-month': '2',
   'childDob-1-year': '2001',
+  'childName-2': 'Bart',
   'childDob-2-day': '3',
   'childDob-2-month': '4',
   'childDob-2-year': '2002',
+  'childName-3': 'Maggie',
   'childDob-3-day': '5',
   'childDob-3-month': '6',
   'childDob-3-year': '2003'
+}
+
+const req = {
+  t: (string) => string
 }
 
 test('fieldExistsWithPrefix() returns true if field exists starting with prefix', (t) => {
@@ -42,5 +57,44 @@ test('convertDateFieldsToDateStrings() converts individual date fields to compos
   }
 
   t.deepEqual(result, expected, 'converts individual date fields to composite date string')
+  t.end()
+})
+
+test('isChildNameKey() returns true if key contains child name prefix', (t) => {
+  const result = isChildNameKey(undefined, 'childName-')
+  t.equal(result, true, 'returns true if key contains child name prefix')
+  t.end()
+})
+
+test('isChildNameKey() returns false if key does not contain child name prefix', (t) => {
+  const result = isChildNameKey(undefined, 'notAChildName-')
+  t.equal(result, false, 'returns false if key does not contain child name prefix')
+  t.end()
+})
+
+test('getChildrenNameKeys() returns an array of keys for children names', (t) => {
+  const result = getChildrenNameKeys(fields)
+  const expected = ['childName-1', 'childName-2', 'childName-3']
+
+  t.deepEqual(result, expected, 'returns an array of keys for children names')
+  t.end()
+})
+
+test('validateDateOfBirth() throws an error for an invalid date of birth', (t) => {
+  const result = validateDateOfBirth.bind(null, 'invalid-date-2019', { req })
+  t.throws(result, /validation:childDateOfBirthInvalid/, 'throws an error for an invalid date of birth')
+  t.end()
+})
+
+test('validateDateOfBirth() throws an error for a date of birth more than four years in the past', (t) => {
+  const result = validateDateOfBirth.bind(null, '2003-06-05', { req })
+  t.throws(result, /validation:childDateOfBirthFourYearsOrOlder/, 'throws an error for a date of birth more than four years in the past')
+  t.end()
+})
+
+test('validateDateOfBirth() returns true for a valid date less than four years in the past', (t) => {
+  const dob = dateAsString({ yearAdjustment: -2 })
+  const result = validateDateOfBirth(dob, { req })
+  t.equal(result, true, 'returns true for a valid date less than four years in the past')
   t.end()
 })

--- a/src/web/routes/application/common/formatters/dates.js
+++ b/src/web/routes/application/common/formatters/dates.js
@@ -11,12 +11,18 @@ const toDateString = (day, month, year) => {
   return [year, parseMonth, parseDay].join('-')
 }
 
-const dateAsString = ({ date = new Date(), monthAdjustment = 0 } = {}) => {
+const dateAsString = ({ date = new Date(), monthAdjustment = 0, yearAdjustment = 0 } = {}) => {
   if (typeof monthAdjustment !== 'number') {
     throw new Error('Month adjustment must be numeric')
   }
+
+  if (typeof yearAdjustment !== 'number') {
+    throw new Error('Year adjustment must be numeric')
+  }
+
   const dateToChange = new Date(date)
   dateToChange.setMonth(dateToChange.getMonth() + monthAdjustment)
+  dateToChange.setFullYear(dateToChange.getFullYear() + yearAdjustment)
   const dd = dateToChange.getDate()
   const mm = dateToChange.getMonth() + 1
   const yyyy = dateToChange.getFullYear()

--- a/src/web/routes/application/common/formatters/dates.test.js
+++ b/src/web/routes/application/common/formatters/dates.test.js
@@ -33,6 +33,10 @@ test('dateAsString', (t) => {
   t.equal(dateAsString({ date: date }), '1999-12-31', '1999-12-31 is not formatted correctly')
   t.equal(dateAsString({ date: date, monthAdjustment: -2 }), '1999-10-31', '2 months from 1999-12-31 should ne 1999-10-31')
   t.throws(dateAsString.bind(null, { monthAdjustment: 'foo' }), /Month adjustment must be numeric/, 'not a valid month adjustment value')
+
+  t.equal(dateAsString({ date: date, yearAdjustment: 4 }), '2003-12-31', '4 years from 1999-12-31 should be 2003-12-31')
+  t.equal(dateAsString({ date: date, yearAdjustment: -2 }), '1997-12-31', '2 years from 1999-12-31 should ne 1997-12-31')
+  t.throws(dateAsString.bind(null, { yearAdjustment: 'foo' }), /Year adjustment must be numeric/, 'not a valid year adjustment value')
   t.end()
 })
 

--- a/src/web/routes/application/common/validators.js
+++ b/src/web/routes/application/common/validators.js
@@ -34,10 +34,18 @@ const isDateMoreThanEightMonthsInTheFuture = (dateString) => {
 const validateIsYesOrNo = (fieldName, validationMessage) =>
   check(fieldName).isIn([YES, NO]).withMessage(translateValidationMessage(validationMessage))
 
+const isDateMoreThanFourYearsAgo = (dateString) => {
+  if (isValidDate(dateString)) {
+    return validator.isBefore(dateString, dateAsString({ yearAdjustment: -4 }))
+  }
+  return true
+}
+
 module.exports = {
   isValidDate,
   isDateInPast,
   isDateMoreThanOneMonthAgo,
   isDateMoreThanEightMonthsInTheFuture,
-  validateIsYesOrNo
+  validateIsYesOrNo,
+  isDateMoreThanFourYearsAgo
 }

--- a/src/web/routes/application/common/validators.test.js
+++ b/src/web/routes/application/common/validators.test.js
@@ -4,7 +4,8 @@ const {
   isValidDate,
   isDateInPast,
   isDateMoreThanOneMonthAgo,
-  isDateMoreThanEightMonthsInTheFuture
+  isDateMoreThanEightMonthsInTheFuture,
+  isDateMoreThanFourYearsAgo
 } = require('./validators')
 
 test('isValidDate', (t) => {
@@ -52,5 +53,17 @@ test('isDateMoreThanEightMonthsInTheFuture', (t) => {
   t.equal(isDateMoreThanEightMonthsInTheFuture(''), true, 'blank string should not be validated')
   t.equal(isDateMoreThanEightMonthsInTheFuture(null), true, 'null string should not be validated')
   t.equal(isDateMoreThanEightMonthsInTheFuture('12-12-1999'), true, 'invalid format string "12-12-1999" should not be validated')
+  t.end()
+})
+
+test('isDateMoreThanFourYearsAgo', (t) => {
+  const fourYearsAgo = dateAsString({ yearAdjustment: -4 })
+
+  t.equal(isDateMoreThanFourYearsAgo('9999-12-12'), false, '"9999-12-12" is not more than four years ago')
+  t.equal(isDateMoreThanFourYearsAgo('1900-12-12'), true, '"1900-12-12" is more than four years ago')
+  t.equal(isDateMoreThanFourYearsAgo(fourYearsAgo), false, `"${fourYearsAgo}" is exactly four years ago`)
+  t.equal(isDateMoreThanFourYearsAgo(''), true, 'blank string should not be validated')
+  t.equal(isDateMoreThanFourYearsAgo(null), true, 'null string should not be validated')
+  t.equal(isDateMoreThanFourYearsAgo('12-12-1999'), true, 'invalid format string "12-12-1999" should not be validated')
   t.end()
 })

--- a/src/web/server/locales/cy/validation.json
+++ b/src/web/server/locales/cy/validation.json
@@ -21,6 +21,8 @@
   "invalidEmail": "Interdum velit laoreet, ekil name@example.com",
   "acceptTermsAndConditions": "Dictum fusce ut placerat orci nulla pellentesqu",
   "selectTextOrEmailChannel": "Nisi lacus sed viverra tellus in",
-  "childsDateOfBirthInvalid": "Dictum fusce ut placerat orci nulla pellentesqu",
-  "enterTheSixDigitCodeWeSentYou": "Interdum velit 6 laoreet id donec"
+  "enterTheSixDigitCodeWeSentYou": "Interdum velit 6 laoreet id donec",
+  "childDateOfBirthInvalid": "Dictum fusce ut placerat orci nulla pellentesqu",
+  "childDateOfBirthFourYearsOrOlder": "Sed lacus sed nisi viverr ovunoo",
+  "childNameTooLong": "Pitorus quo ba villus"
 }

--- a/src/web/server/locales/en/validation.json
+++ b/src/web/server/locales/en/validation.json
@@ -21,6 +21,8 @@
   "invalidEmail": "Enter an email address in the correct format, like name@example.com",
   "acceptTermsAndConditions": "Confirm that you’ve read and will comply with these terms and conditions",
   "selectTextOrEmailChannel": "Select if you want to receive a code by text or email",
-  "childsDateOfBirthInvalid": "Enter your child’s date of birth in the correct format",
-  "enterTheSixDigitCodeWeSentYou": "Enter the 6 digit code we sent you"
+  "enterTheSixDigitCodeWeSentYou": "Enter the 6 digit code we sent you",
+  "childDateOfBirthInvalid": "Enter your child’s date of birth in the correct format",
+  "childDateOfBirthFourYearsOrOlder": "You can only apply for children who are 3 years old or younger",
+  "childNameTooLong": "Enter a shorter name"
 }

--- a/src/web/server/locales/en/validation.json
+++ b/src/web/server/locales/en/validation.json
@@ -14,7 +14,7 @@
   "invalidPostcode": "Enter a correct postcode, like AA1 1AA",
   "informationTooLong": "The information you entered is too long",
   "missingAddressField": "Tell us your address",
-  "expectedDeliveryDateInvalid": "Enter the due date in the correct format",
+  "expectedDeliveryDateInvalid": "Enter the due date",
   "expectedDeliveryDateTooFarInPast": "Enter a due date to show you’re at least 10 weeks pregnant",
   "expectedDeliveryDateTooFarInFuture": "Enter a due date to show you’re at least 10 weeks pregnant",
   "invalidPhoneNumber": "Enter a UK mobile number",
@@ -22,7 +22,7 @@
   "acceptTermsAndConditions": "Confirm that you’ve read and will comply with these terms and conditions",
   "selectTextOrEmailChannel": "Select if you want to receive a code by text or email",
   "enterTheSixDigitCodeWeSentYou": "Enter the 6 digit code we sent you",
-  "childDateOfBirthInvalid": "Enter your child’s date of birth in the correct format",
+  "childDateOfBirthInvalid": "Enter your child’s date of birth",
   "childDateOfBirthFourYearsOrOlder": "You can only apply for children who are 3 years old or younger",
   "childNameTooLong": "Enter a shorter name"
 }

--- a/src/web/views/macros/htbhf-child-dob-input.njk
+++ b/src/web/views/macros/htbhf-child-dob-input.njk
@@ -23,7 +23,7 @@
       id: 'child-name-' + params.index,
       name: 'childName-' + params.index,
       value: params.children['childName-'  + params.index],
-      errorMessage: params.errors | getErrorForField('childName'),
+      errorMessage: params.errors | getErrorForField('childName-'  + params.index),
       autocomplete: "off"
     }) }}
 


### PR DESCRIPTION
- Fix error message in child dob macro
- Add validation translations for child date of birth
- Add validator for date more than four months in the past
- Add extra validation for childrens‘ date of birth:
1. date more than four years in the past
2. name too long