### PR TITLE
NOJIRA Updated session details app to close on sigint so a user closi…

### DIFF
--- a/src/test/session-details-provider/session-details-app.js
+++ b/src/test/session-details-provider/session-details-app.js
@@ -38,3 +38,10 @@ process.on('SIGTERM', () => {
     process.exit(0)
   })
 })
+
+process.on('SIGINT', () => {
+  server.close(() => {
+    logger.info('Session Details App closed.')
+    process.exit(0)
+  })
+})


### PR DESCRIPTION
Close the session details app when receiving a SIGINT. This assures that cancelling an `npm run test` or other npm command with ctrl-c will gracefully shutdown the application.

Without this, cancelling a build will leave the session details app running and the next build will fail due to the port being in use.