### PR TITLE
HTBHF-1678 Add validation failure scenarios for Add Child DOB page, plus test for 10 children.

### DIFF
--- a/src/test/acceptance/features/children-dob.feature
+++ b/src/test/acceptance/features/children-dob.feature
@@ -17,12 +17,37 @@ Feature: Add your children’s dates of birth
 
   Scenario: Enter two children's details
     Given I have entered my details up to the add your childrens dates of birth page
-    When I enter the details of my two children who are three or younger
-    And I click continue
+    When I submit the details of my two children who are three or younger
+    Then I am shown the are you pregnant page
+
+  Scenario: Enter ten children's details
+    Given I have entered my details up to the add your childrens dates of birth page
+    When I submit the details of my ten children who are three or younger
     Then I am shown the are you pregnant page
 
   Scenario: Enter one child's details without a name, name is optional
     Given I have entered my details up to the add your childrens dates of birth page
-    When I enter the details of my child who is three or younger without a name
-    And I click continue
+    When I submit the details of my child who is three or younger without a name
     Then I am shown the are you pregnant page
+
+  Scenario: Invalid date entered for single child
+    Given I have entered my details up to the add your childrens dates of birth page
+    When I do not enter my child's date of birth
+    And I click continue
+    Then I am informed that I need to enter the date of birth for the first child
+
+  Scenario: Invalid dates entered for two children
+    Given I have entered my details up to the add your childrens dates of birth page
+    When I select to add another child
+    And I click continue
+    Then I am informed that I need to enter the date of birth for both children
+
+  Scenario: Child's name is too long
+    Given I have entered my details up to the add your childrens dates of birth page
+    When I submit the details of my child who is three or under with a very long name
+    Then I am informed that I need to enter a shorter name
+
+  Scenario: Both children's names are too long
+    Given I have entered my details up to the add your childrens dates of birth page
+    When I submit the details of my two children who are three or under both with very long names
+    Then I am informed that I need to enter a shorter name for both children

--- a/src/test/common/dates.js
+++ b/src/test/common/dates.js
@@ -5,8 +5,9 @@ const dateIn3Months = () => {
   return dueDate
 }
 
-const dateLastYear = () => {
+const dateLastYear = (dayIncrement = 0) => {
   const date = new Date()
+  date.setDate(date.getDate() + dayIncrement)
   date.setFullYear(date.getFullYear() - 1)
   return date
 }

--- a/src/test/common/page/add-children-dob.js
+++ b/src/test/common/page/add-children-dob.js
@@ -35,19 +35,13 @@ class AddChildrenDOB extends SubmittablePage {
     await addAnotherChildButton.click()
   }
 
-  async enterChildUnder3DetailsWithoutAName () {
-    await this.enterChildUnder3DateOfBirth()
+  async enterChild3OrUnderDetails (name = `Child${this.childIndex}`, dayIncrement = 0) {
+    await this.enterChild3OrUnderDateOfBirth(dayIncrement)
+    await this.enterChildName(name)
     this.childIndex++
   }
-
-  async enterChildUnder3Details () {
-    await this.enterChildName()
-    await this.enterChildUnder3DateOfBirth()
-    this.childIndex++
-  }
-
-  async enterChildUnder3DateOfBirth () {
-    const dateOfBirth = dateLastYear()
+  async enterChild3OrUnderDateOfBirth (dayIncrement = 0) {
+    const dateOfBirth = dateLastYear(dayIncrement)
     await this.enterDay(dateOfBirth.getDate())
     await this.enterMonth(dateOfBirth.getMonth() + 1)
     await this.enterYear(dateOfBirth.getFullYear())
@@ -69,9 +63,9 @@ class AddChildrenDOB extends SubmittablePage {
     return this.findById(`childDob-${this.childIndex}-year`)
   }
 
-  async enterChildName () {
+  async enterChildName (name) {
     const dayField = await this.getNameField()
-    return dayField.sendKeys(`Child${this.childIndex}`)
+    return dayField.sendKeys(name)
   }
 
   async enterDay (day) {
@@ -87,6 +81,22 @@ class AddChildrenDOB extends SubmittablePage {
   async enterYear (year) {
     const yearField = await this.getYearField()
     return yearField.sendKeys(year)
+  }
+
+  getChildDateOfBirthFieldErrorId (index) {
+    return `child-dob-${index}-error`
+  }
+
+  getChildDateOfBirthErrorLinkCss (index) {
+    return `a[href="#child-dob-${index}-error"]`
+  }
+
+  getChildNameFieldErrorId (index) {
+    return `child-name-${index}-error`
+  }
+
+  getChildNameErrorLinkCss (index) {
+    return `a[href="#child-name-${index}-error"]`
   }
 }
 

--- a/src/test/common/steps/add-children-dob-steps.js
+++ b/src/test/common/steps/add-children-dob-steps.js
@@ -1,21 +1,42 @@
 const { When, Then } = require('cucumber')
 const { assert } = require('chai')
-const { assertBackLinkPointsToPage } = require('./common-assertions')
-const { enterChildUnder3Details } = require('./common-steps')
+const { assertBackLinkPointsToPage, assertErrorHeaderTextPresent, assertFieldErrorAndLinkTextPresentAndCorrect } = require('./common-assertions')
+const { submitChild3OrUnderDetails } = require('./common-steps')
+const { LONG_STRING } = require('./constants')
 
 const pages = require('./pages')
 
 When(/^I submit the details of my child who is three or younger$/, async function () {
-  await enterChildUnder3Details()
+  await submitChild3OrUnderDetails()
   await pages.genericPage.submitForm()
 })
 
-When(/^I enter the details of my child who is three or younger without a name$/, async function () {
-  await enterChildUnder3DetailsWithoutAName()
+When(/^I submit the details of my child who is three or younger without a name$/, async function () {
+  await submitChild3OrUnderDetails('')
 })
 
-When(/^I enter the details of my two children who are three or younger/, async function () {
-  await enterTwoSetsOfChildrensDatesOfBirth()
+When(/^I submit the details of my child who is three or under with a very long name$/, async function () {
+  await submitChild3OrUnderDetails(LONG_STRING)
+})
+
+When(/^I submit the details of my two children who are three or younger/, async function () {
+  await submitTwoSetsOfChildren3OrUnderDetails()
+})
+
+When(/^I submit the details of my ten children who are three or younger/, async function () {
+  await submitTenSetsOfChildren3OrUnderDetails()
+})
+
+When(/^I submit the details of my two children who are three or under both with very long names/, async function () {
+  await submitTwoSetsOfChildren3OrUnderDetails(LONG_STRING, LONG_STRING)
+})
+
+When(/^I do not enter my child's date of birth/, async function () {
+  // intentionally does nothing
+})
+
+When(/^I select to add another child/, async function () {
+  await pages.addChildrenDOB.clickAddAnotherChild()
 })
 
 Then(/^I am shown the add your childrens dates of birth page$/, async function () {
@@ -26,22 +47,73 @@ Then(/^The back link points to the Add your children’s dates of birth page$/, 
   await assertBackLinkPointsToPage(pages.addChildrenDOB)
 })
 
-async function enterTwoSetsOfChildrensDatesOfBirth () {
+Then(/^I am informed that I need to enter the date of birth for the first child$/, async function () {
+  await assertDateOfBirthErrorPresentForChild(1)
+})
+
+Then(/^I am informed that I need to enter the date of birth for both children$/, async function () {
+  await assertDateOfBirthErrorPresentForChild(1)
+  await assertDateOfBirthErrorPresentForChild(2)
+})
+
+Then(/^I am informed that I need to enter a shorter name for both children$/, async function () {
+  await assertNameTooLongErrorPresentForChild(1)
+  await assertNameTooLongErrorPresentForChild(2)
+})
+
+Then(/^I am informed that I need to enter a shorter name$/, async function () {
+  await assertNameTooLongErrorPresentForChild(1)
+})
+
+async function assertNameTooLongErrorPresentForChild (index) {
   try {
-    await pages.addChildrenDOB.enterChildUnder3Details()
+    await assertErrorHeaderTextPresent(pages.addChildrenDOB)
+    await assertFieldErrorAndLinkTextPresentAndCorrect(
+      pages.addChildrenDOB.getChildNameFieldErrorId(index),
+      pages.addChildrenDOB.getChildNameErrorLinkCss(index),
+      'Enter a shorter name')
+  } catch (error) {
+    assert.fail(`Unexpected error caught trying to assert the too long name error present for child with index ${index} - ${error}`)
+  }
+}
+
+async function assertDateOfBirthErrorPresentForChild (index) {
+  try {
+    await assertErrorHeaderTextPresent(pages.addChildrenDOB)
+    await assertFieldErrorAndLinkTextPresentAndCorrect(
+      pages.addChildrenDOB.getChildDateOfBirthFieldErrorId(index),
+      pages.addChildrenDOB.getChildDateOfBirthErrorLinkCss(index),
+      'Enter your child’s date of birth')
+  } catch (error) {
+    assert.fail(`Unexpected error caught trying to assert the date of birth error present for child with index ${index} - ${error}`)
+  }
+}
+
+async function submitTwoSetsOfChildren3OrUnderDetails (firstChildName = 'Joe', secondChildName = 'Joanne') {
+  try {
+    await pages.addChildrenDOB.enterChild3OrUnderDetails(firstChildName, 0)
     await pages.addChildrenDOB.clickAddAnotherChild()
-    await pages.addChildrenDOB.enterChildUnder3Details()
+    await pages.addChildrenDOB.enterChild3OrUnderDetails(secondChildName, 0)
     await pages.addChildrenDOB.submitForm()
   } catch (error) {
     assert.fail(`Unexpected error caught trying to enter two sets of children details and submit the page - ${error}`)
   }
 }
 
-async function enterChildUnder3DetailsWithoutAName () {
+async function submitTenSetsOfChildren3OrUnderDetails () {
   try {
-    await pages.addChildrenDOB.enterChildUnder3DetailsWithoutAName()
+    for (let childIndex = 1; childIndex <= 10; childIndex++) {
+      await enterChildDetailsAndClickAddAnother(childIndex, (childIndex < 10))
+    }
     await pages.addChildrenDOB.submitForm()
   } catch (error) {
-    assert.fail(`Unexpected error caught trying to enter child details and submit the page - ${error}`)
+    assert.fail(`Unexpected error caught trying to enter ten sets of children details and submit the page - ${error}`)
+  }
+}
+
+async function enterChildDetailsAndClickAddAnother (childIndex, shouldClickAddAnother) {
+  await pages.addChildrenDOB.enterChild3OrUnderDetails(`Child${childIndex}`, childIndex)
+  if (shouldClickAddAnother) {
+    await pages.addChildrenDOB.clickAddAnotherChild()
   }
 }

--- a/src/test/common/steps/common-steps.js
+++ b/src/test/common/steps/common-steps.js
@@ -135,9 +135,9 @@ async function selectYesOnChildrenThreeOrYoungerPage () {
   }
 }
 
-async function enterChildUnder3Details () {
+async function submitChild3OrUnderDetails (name = 'Joe') {
   try {
-    await pages.addChildrenDOB.enterChildUnder3Details()
+    await pages.addChildrenDOB.enterChild3OrUnderDetails(name)
     await pages.addChildrenDOB.submitForm()
   } catch (error) {
     assert.fail(`Unexpected error caught trying to enter child details and submit the page - ${error}`)
@@ -177,7 +177,7 @@ async function completeTheApplicationAsAPregnantWoman () {
   await enterDoYouLiveInScotlandNoAndSubmit()
   await enterDateOfBirthAndSubmit()
   await selectYesOnChildrenThreeOrYoungerPage()
-  await enterChildUnder3Details()
+  await submitChild3OrUnderDetails()
   await selectYesOnPregnancyPage()
   await enterNameAndSubmit()
   await enterNinoAndSubmit()
@@ -192,7 +192,7 @@ async function completeTheApplicationAsAWomanWhoIsNotPregnant () {
   await enterDoYouLiveInScotlandNoAndSubmit()
   await enterDateOfBirthAndSubmit()
   await selectYesOnChildrenThreeOrYoungerPage()
-  await enterChildUnder3Details()
+  await submitChild3OrUnderDetails()
   await selectNoOnPregnancyPage()
   await enterNameAndSubmit()
   await enterNinoAndSubmit()
@@ -264,5 +264,5 @@ module.exports = {
   selectTextOnSendCode,
   enterConfirmationCodeAndSubmit,
   selectYesOnChildrenThreeOrYoungerPage,
-  enterChildUnder3Details
+  submitChild3OrUnderDetails
 }

--- a/src/test/common/steps/navigation.js
+++ b/src/test/common/steps/navigation.js
@@ -12,7 +12,7 @@ const {
   enterDoYouLiveInScotlandNoAndSubmit,
   enterEmailAddressAndSubmit,
   selectYesOnChildrenThreeOrYoungerPage,
-  enterChildUnder3Details,
+  submitChild3OrUnderDetails,
   selectTextOnSendCode,
   enterConfirmationCodeAndSubmit
 } = require('./common-steps')
@@ -60,7 +60,7 @@ const pageActions = [
   {
     page: ARE_YOU_PREGNANT_PAGE,
     action: async () => {
-      await enterChildUnder3Details()
+      await submitChild3OrUnderDetails()
       await pages.areYouPregnant.waitForPageLoad()
     }
   },


### PR DESCRIPTION
- I've also made some changes around the wording of steps and the methods they use to prefer the word 'submit' over 'enter' when those steps enter the details and also click the continue button as a part of the one step.
- I'm also aware that adding the test for 10 children isn't a failure scenario and could possibly have been in a subsequent PR, I'm happy to remove it if people feel strongly enough.
- I've also added the ability to add a day increment to the date creation method so that the children can each have different dates of birth based on the current index value.
- The majority of the methods now allow providing a child name, but also have a default if the test doesn't care (which is also index based).