### PR TITLE
HTBHF-1732 start app with NPM script

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: help-to-buy-healthy-foods((app-suffix))
   memory: 512M
-  command: node src/web
+  command: npm start
   env:
     SESSION_SECRET: '((session_secret))'
     CLAIMANT_SERVICE_URL: http://htbhf-claimant-service((space-suffix)).apps.internal:8080


### PR DESCRIPTION
Updated `manifest.yml` to start app using NPM instead of node directly. This will allow running other scripts when deploying the app.