### PR TITLE
HTBHF-1704 Add id to submit button so it can be unique identified when there are multiple buttons on the page.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:smoke:debug": "mkdir -p build/reports && cross-env TESTS=smoke node $NODE_DEBUG_OPTION node_modules/cucumber/bin/cucumber-js src/test/smoke/features/ --require 'src/test/common/steps/*.js' --require 'src/test/smoke/config' -f json:build/reports/smoke-report.json",
     "test:smoke:report": "node src/test/smoke/smoke-report.js",
     "test:compatibility:local": "npm-run-all -s test:compatibility:local:test test:compatibility:local:report",
-    "test:compatibility:local:test": "mkdir -p build/reports/compatibility && cross-env TESTS=localCompatibility cucumber-js src/test/compatibility/features/ --require 'src/test/common/steps/*.js' --require 'src/test/common/timeout.js' --require 'src/test/compatibility/config/environment.js' -f json:build/reports/compatibility-report.json",
+    "test:compatibility:local:test": "mkdir -p build/reports/compatibility && cross-env SESSION_DETAILS_PORT=8081 TESTS=localCompatibility cucumber-js src/test/compatibility/features/ --require 'src/test/common/steps/*.js' --require 'src/test/common/timeout.js' --require 'src/test/compatibility/config/environment.js' -f json:build/reports/compatibility-report.json",
     "test:compatibility:local:report": "node src/test/compatibility/local-compatibility-report.js",
     "test:accessibility": "node 'src/test/a11y/run-test-suite.js'",
     "test:browser": "npm run test:wait && npm run test:startWiremock && npm-run-all -s test:smoke test:accessibility test:compatibility:local test:acceptance test:acceptance:report test:stopWiremock",

--- a/src/test/common/page/submittable-page.js
+++ b/src/test/common/page/submittable-page.js
@@ -2,7 +2,7 @@ const Page = require('./page')
 
 class SubmittablePage extends Page {
   async getSubmitButton () {
-    return this.findByClassName('govuk-button')
+    return this.findById('submit-button')
   }
 
   async submitForm () {

--- a/src/web/views/check.njk
+++ b/src/web/views/check.njk
@@ -34,7 +34,10 @@
 
   {{ govukButton({
       text: buttonText,
-      href: "/terms-and-conditions"
+      href: "/terms-and-conditions",
+      attributes: {
+        id: 'submit-button'
+      }
   }) }}
 
 {% endblock %}

--- a/src/web/views/templates/form.njk
+++ b/src/web/views/templates/form.njk
@@ -16,7 +16,10 @@
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {% block formContent %}{% endblock %}
     {{ govukButton({
-      text: buttonText
+      text: buttonText,
+      attributes: {
+        id: 'submit-button'
+      }
     }) }}
   </form>
 {% endblock %}


### PR DESCRIPTION
We need this so we can differentiate the submit button from the remove child buttons, without this all the ATs fail on that page as they click the Remove child button.