### PR TITLE
HTBHF-1712 Resend code if a user changes their contact details used t…

### DIFF
--- a/src/web/routes/application/common/confirmation-code.js
+++ b/src/web/routes/application/common/confirmation-code.js
@@ -1,7 +1,7 @@
-// reset confirmation code and reset state to in progress so that the user is not taken straight back to check details.
 const { CONFIRMATION_CODE_ENTERED_SESSION_PROPERTY } = require('./constants')
 const { stateMachine, states } = require('../common/state-machine')
 
+// reset confirmation code and reset state to in progress so that the user is not taken straight back to check details.
 const handleConfirmationCodeReset = req => {
   req.session[CONFIRMATION_CODE_ENTERED_SESSION_PROPERTY] = false
   req.session.claim.confirmationCode = null

--- a/src/web/routes/application/common/confirmation-code.js
+++ b/src/web/routes/application/common/confirmation-code.js
@@ -1,0 +1,16 @@
+// reset confirmation code and reset state to in progress so that the user is not taken straight back to check details.
+const { CONFIRMATION_CODE_ENTERED_SESSION_PROPERTY } = require('./constants')
+const { stateMachine, states } = require('../common/state-machine')
+
+const handleConfirmationCodeReset = req => {
+  req.session[CONFIRMATION_CODE_ENTERED_SESSION_PROPERTY] = false
+  req.session.claim.confirmationCode = null
+  stateMachine.setState(states.IN_PROGRESS, req)
+}
+
+const getConfirmationCodeChannel = req => req.session.claim.channelForCode
+
+module.exports = {
+  handleConfirmationCodeReset,
+  getConfirmationCodeChannel
+}

--- a/src/web/routes/application/common/confirmation-code.test.js
+++ b/src/web/routes/application/common/confirmation-code.test.js
@@ -1,0 +1,23 @@
+const test = require('tape')
+
+const { handleConfirmationCodeReset } = require('./confirmation-code')
+const { states } = require('../common/state-machine')
+
+test('handleConfirmationCodeReset', (t) => {
+  const req = {
+    session: {
+      confirmationCodeEntered: true,
+      claim: {
+        confirmationCode: '123456'
+      },
+      state: states.IN_REVIEW
+    }
+  }
+
+  handleConfirmationCodeReset(req)
+
+  t.equal(req.session.confirmationCodeEntered, false)
+  t.equal(req.session.claim.confirmationCode, null)
+  t.equal(req.session.state, states.IN_PROGRESS)
+  t.end()
+})

--- a/src/web/routes/application/email-address/email-address.js
+++ b/src/web/routes/application/email-address/email-address.js
@@ -40,5 +40,6 @@ const emailAddress = {
 
 module.exports = {
   contentSummary,
-  emailAddress
+  emailAddress,
+  behaviourForPost
 }

--- a/src/web/routes/application/email-address/email-address.js
+++ b/src/web/routes/application/email-address/email-address.js
@@ -1,4 +1,6 @@
 const { validate } = require('./validate')
+const { getConfirmationCodeChannel, handleConfirmationCodeReset } = require('../common/confirmation-code')
+const { EMAIL } = require('../common/constants')
 
 const pageContent = ({ translate }) => ({
   title: translate('emailAddress.title'),
@@ -14,13 +16,26 @@ const contentSummary = (req) => ({
   value: req.session.claim.emailAddress.trim()
 })
 
+const emailAddressHasBeenUpdated = req => req.body.emailAddress !== req.session.claim.emailAddress
+
+const confirmationChannelIsEmail = req => getConfirmationCodeChannel(req) === EMAIL
+
+const behaviourForPost = (req, res, next) => {
+  if (confirmationChannelIsEmail(req) && emailAddressHasBeenUpdated(req)) {
+    handleConfirmationCodeReset(req)
+  }
+
+  next()
+}
+
 const emailAddress = {
   path: '/email-address',
   next: () => '/send-code',
   template: 'email-address',
   validate,
   pageContent,
-  contentSummary
+  contentSummary,
+  behaviourForPost
 }
 
 module.exports = {

--- a/src/web/routes/application/email-address/email-address.test.js
+++ b/src/web/routes/application/email-address/email-address.test.js
@@ -1,5 +1,13 @@
 const test = require('tape')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
 const { contentSummary } = require('./email-address')
+
+const { TEXT, EMAIL } = require('../common/constants')
+
+const handleConfirmationCodeReset = sinon.spy()
+
+const { behaviourForPost } = proxyquire('./email-address', { '../common/confirmation-code': { handleConfirmationCodeReset } })
 
 const req = {
   t: string => string,
@@ -19,5 +27,65 @@ test('Enter name contentSummary() should return content summary in correct forma
   }
 
   t.deepEqual(result, expected, 'should return content summary in correct format')
+  t.end()
+})
+
+test('behaviourForPost() resets confirmation code if the user updated their email address and received confirmation code via email', (t) => {
+  const req = {
+    session: {
+      claim: {
+        channelForCode: EMAIL,
+        emailAddress: 'test@email.com'
+      }
+    },
+    body: {
+      emailAddress: 'different-email-adddress@email.com'
+    }
+  }
+
+  behaviourForPost(req, {}, () => {})
+
+  t.equal(handleConfirmationCodeReset.called, true)
+  handleConfirmationCodeReset.resetHistory()
+  t.end()
+})
+
+test('behaviourForPost() does not reset confirmation code if the user updated their email address and received confirmation code via text', (t) => {
+  const req = {
+    session: {
+      claim: {
+        channelForCode: TEXT,
+        emailAddress: 'test@email.com'
+      }
+    },
+    body: {
+      phoneNumber: 'different-email-adddress@email.com'
+    }
+  }
+
+  behaviourForPost(req, {}, () => {})
+
+  t.equal(handleConfirmationCodeReset.called, false)
+  handleConfirmationCodeReset.resetHistory()
+  t.end()
+})
+
+test('behaviourForPost() does not reset confirmation code if the user has not updated their email address', (t) => {
+  const req = {
+    session: {
+      claim: {
+        channelForCode: EMAIL,
+        emailAddress: 'test@email.com'
+      }
+    },
+    body: {
+      emailAddress: 'test@email.com'
+    }
+  }
+
+  behaviourForPost(req, {}, () => {})
+
+  t.equal(handleConfirmationCodeReset.called, false)
+  handleConfirmationCodeReset.resetHistory()
   t.end()
 })

--- a/src/web/routes/application/phone-number/phone-number.js
+++ b/src/web/routes/application/phone-number/phone-number.js
@@ -42,5 +42,6 @@ const phoneNumber = {
 
 module.exports = {
   contentSummary,
-  phoneNumber
+  phoneNumber,
+  behaviourForPost
 }

--- a/src/web/views/enter-code.njk
+++ b/src/web/views/enter-code.njk
@@ -34,5 +34,5 @@
 
     {# TODO DW HTBHF-1712 update link to send new confirmationCode  #}
     <p class="govuk-body-m"><a href="/send-code" id="request-new-code">{{ requestANewCode }}</a> {{ ifItDoesNotArrive }}</p>
-s
+
 {% endblock %}


### PR DESCRIPTION
After entering a confirmation code, the user now has to confirm a new code if they change the contact details used to receive a code.
i.e. changing your phone number will cause a new code to be send, only if the original code was texted.

Acceptance tests to come in next PR.