### PR TITLE
HTBHF-1680 Add functions for removing all child entries from the session

### DIFF
--- a/src/web/routes/application/children-dob/decrement-keys.js
+++ b/src/web/routes/application/children-dob/decrement-keys.js
@@ -1,9 +1,9 @@
 const { isNil } = require('ramda')
 
-const INDEX_FROM_KEY_REG_EXP = /.*-(\d+).*/
+const KEY_INDEX_REG_EXP = /.*-(\d+).*/
 
 const getIndexFromKey = (key) => {
-  const groups = INDEX_FROM_KEY_REG_EXP.exec(key)
+  const groups = KEY_INDEX_REG_EXP.exec(key)
 
   if (isNil(groups)) {
     throw new Error(`Could not find index for key ${key}`)

--- a/src/web/routes/application/children-dob/decrement-keys.js
+++ b/src/web/routes/application/children-dob/decrement-keys.js
@@ -1,0 +1,34 @@
+const { isNil } = require('ramda')
+
+const INDEX_FROM_KEY_REG_EXP = /.*-(\d+).*/
+
+const getIndexFromKey = (key) => {
+  const groups = INDEX_FROM_KEY_REG_EXP.exec(key)
+
+  if (isNil(groups)) {
+    throw new Error(`Could not find index for key ${key}`)
+  }
+
+  return parseInt(groups[1], 10)
+}
+
+const isKeyAfterRemoved = (key, index) => getIndexFromKey(key) > index
+
+const decrementKey = (key) => {
+  const index = getIndexFromKey(key)
+
+  if (index <= 1) {
+    throw new Error(`Unable to decrement index for key ${key}`)
+  }
+
+  return key.replace(index, index - 1)
+}
+
+const handleDecrement = (index) => ([key, value]) => isKeyAfterRemoved(key, index) ? [decrementKey(key), value] : [key, value]
+
+module.exports = {
+  handleDecrement,
+  decrementKey,
+  getIndexFromKey,
+  isKeyAfterRemoved
+}

--- a/src/web/routes/application/children-dob/decrement-keys.test.js
+++ b/src/web/routes/application/children-dob/decrement-keys.test.js
@@ -25,6 +25,7 @@ test('isKeyAfterRemoved()', (t) => {
 
 test('decrementKey()', (t) => {
   t.equal(decrementKey('childDob-2-day'), 'childDob-1-day')
+  t.equal(decrementKey('childDob-10-day'), 'childDob-9-day')
   t.equal(decrementKey('childDob-11-day'), 'childDob-10-day')
 
   t.throws(() => decrementKey('childDob-day'), /Could not find index for key childDob-day/)

--- a/src/web/routes/application/children-dob/decrement-keys.test.js
+++ b/src/web/routes/application/children-dob/decrement-keys.test.js
@@ -1,0 +1,34 @@
+const test = require('tape')
+const { isKeyAfterRemoved, decrementKey } = require('./decrement-keys')
+
+test('isKeyAfterRemoved()', (t) => {
+  t.equal(isKeyAfterRemoved('childDob-1-day', 1), false)
+  t.equal(isKeyAfterRemoved('childDob-1-day', 2), false)
+  t.equal(isKeyAfterRemoved('childDob-1-day', 3), false)
+
+  t.equal(isKeyAfterRemoved('childDob-2-day', 1), true)
+  t.equal(isKeyAfterRemoved('childDob-2-day', 2), false)
+  t.equal(isKeyAfterRemoved('childDob-2-day', 3), false)
+
+  t.equal(isKeyAfterRemoved('childDob-3-day', 1), true)
+  t.equal(isKeyAfterRemoved('childDob-3-day', 2), true)
+  t.equal(isKeyAfterRemoved('childDob-3-day', 3), false)
+
+  t.equal(isKeyAfterRemoved('childDob-11-day', 1), true)
+  t.equal(isKeyAfterRemoved('childDob-1', 1), false)
+  t.equal(isKeyAfterRemoved('childDob-5', 1), true)
+
+  t.throws(() => isKeyAfterRemoved('childDob-day', 1), /Could not find index for key childDob-day/)
+  t.throws(() => isKeyAfterRemoved('inputCount', 1), /Could not find index for key inputCount/)
+  t.end()
+})
+
+test('decrementKey()', (t) => {
+  t.equal(decrementKey('childDob-2-day'), 'childDob-1-day')
+  t.equal(decrementKey('childDob-11-day'), 'childDob-10-day')
+
+  t.throws(() => decrementKey('childDob-day'), /Could not find index for key childDob-day/)
+  t.throws(() => decrementKey('inputCount'), /Could not find index for key inputCount/)
+  t.throws(() => decrementKey('childDob-1-day'), /Unable to decrement index for key childDob-1-day/)
+  t.end()
+})

--- a/src/web/routes/application/children-dob/predicates.js
+++ b/src/web/routes/application/children-dob/predicates.js
@@ -1,0 +1,16 @@
+const { compose, not } = require('ramda')
+const { getIndexFromKey } = require('./decrement-keys')
+
+const CHID_DOB_PREFIX = 'childDob-'
+
+const isChildEntry = (val, key) => key.startsWith(CHID_DOB_PREFIX)
+
+const isNotChildEntry = compose(not, isChildEntry)
+
+const keyDoesNotContainIndex = (index) => (val, key) => getIndexFromKey(key) !== index
+
+module.exports = {
+  keyDoesNotContainIndex,
+  isNotChildEntry,
+  isChildEntry
+}

--- a/src/web/routes/application/children-dob/predicates.test.js
+++ b/src/web/routes/application/children-dob/predicates.test.js
@@ -1,0 +1,22 @@
+const test = require('tape')
+const { keyDoesNotContainIndex, isNotChildEntry, isChildEntry } = require('./predicates')
+
+test('keyDoesNotContainIndex()', (t) => {
+  t.equal(keyDoesNotContainIndex(1)('value', 'childDob-1-day'), false)
+  t.equal(keyDoesNotContainIndex(2)('value', 'childDob-1-day'), true)
+  t.end()
+})
+
+test('isChildEntry()', (t) => {
+  t.equal(isChildEntry('1', 'childDob-1-day'), true)
+  t.equal(isChildEntry('1', 'inputCount'), false)
+  t.equal(isChildEntry('', ''), false)
+  t.end()
+})
+
+test('isNotChildEntry()', (t) => {
+  t.equal(isNotChildEntry('1', 'childDob-1-day'), false)
+  t.equal(isNotChildEntry('1', 'inputCount'), true)
+  t.equal(isNotChildEntry('', ''), true)
+  t.end()
+})

--- a/src/web/routes/application/children-dob/predicates.test.js
+++ b/src/web/routes/application/children-dob/predicates.test.js
@@ -3,6 +3,8 @@ const { keyDoesNotContainIndex, isNotChildEntry, isChildEntry } = require('./pre
 
 test('keyDoesNotContainIndex()', (t) => {
   t.equal(keyDoesNotContainIndex(1)('value', 'childDob-1-day'), false)
+  t.equal(keyDoesNotContainIndex(1)('value', 'childDob-11-day'), true)
+  t.equal(keyDoesNotContainIndex(1)('value', 'childDob-10-day'), true)
   t.equal(keyDoesNotContainIndex(2)('value', 'childDob-1-day'), true)
   t.end()
 })

--- a/src/web/routes/application/children-dob/remove-child-by-index.js
+++ b/src/web/routes/application/children-dob/remove-child-by-index.js
@@ -1,16 +1,30 @@
 const { isNil } = require('ramda')
 
-const isKeyAfterRemoved = (key, index) => {
-  const getIndexFromKeyRegExp = /.*-(\d+).*/
-  const match = getIndexFromKeyRegExp.exec(key)
+const INDEX_FROM_KEY_REG_EXP = /.*-(\d+).*/
 
-  if (isNil(match)) {
-    throw new Error(`Could not find index ${index} for key ${key}`)
+const getIndexFromKey = (key) => {
+  const groups = INDEX_FROM_KEY_REG_EXP.exec(key)
+
+  if (isNil(groups)) {
+    throw new Error(`Could not find index for key ${key}`)
   }
 
-  return parseInt(match[1], 10) > index
+  return parseInt(groups[1], 10)
+}
+
+const isKeyAfterRemoved = (key, index) => getIndexFromKey(key) > index
+
+const decrementKey = (key) => {
+  const index = getIndexFromKey(key)
+
+  if (index <= 1) {
+    throw new Error(`Unable to decrement index for key ${key}`)
+  }
+
+  return key.replace(index, index - 1)
 }
 
 module.exports = {
-  isKeyAfterRemoved
+  isKeyAfterRemoved,
+  decrementKey
 }

--- a/src/web/routes/application/children-dob/remove-child-by-index.js
+++ b/src/web/routes/application/children-dob/remove-child-by-index.js
@@ -1,6 +1,6 @@
 const { compose, map, toPairs, fromPairs } = require('ramda')
 const { handleDecrement } = require('./decrement-keys')
-const { getChildEntries, getNonChildEntries, getEntriesWithoutIndex } = require('./selectors')
+const { getChildEntries, getNonChildEntries, omitKeysWithIndex } = require('./selectors')
 
 const reIndexChildren = (children, index) => compose(fromPairs, map(handleDecrement(index)), toPairs)(children)
 
@@ -12,7 +12,7 @@ const reIndexChildren = (children, index) => compose(fromPairs, map(handleDecrem
  */
 const removeChildByIndex = (children, index) => {
   const childEntries = getChildEntries(children)
-  const filteredChildren = getEntriesWithoutIndex(childEntries, index)
+  const filteredChildren = omitKeysWithIndex(childEntries, index)
 
   return {
     ...reIndexChildren(filteredChildren, index),

--- a/src/web/routes/application/children-dob/remove-child-by-index.js
+++ b/src/web/routes/application/children-dob/remove-child-by-index.js
@@ -1,0 +1,16 @@
+const { isNil } = require('ramda')
+
+const isKeyAfterRemoved = (key, index) => {
+  const getIndexFromKeyRegExp = /.*-(\d+).*/
+  const match = getIndexFromKeyRegExp.exec(key)
+
+  if (isNil(match)) {
+    throw new Error(`Could not find index ${index} for key ${key}`)
+  }
+
+  return parseInt(match[1], 10) > index
+}
+
+module.exports = {
+  isKeyAfterRemoved
+}

--- a/src/web/routes/application/children-dob/remove-child-by-index.js
+++ b/src/web/routes/application/children-dob/remove-child-by-index.js
@@ -1,4 +1,4 @@
-const { isNil } = require('ramda')
+const { compose, map, isNil, pickBy, toPairs, fromPairs } = require('ramda')
 
 const INDEX_FROM_KEY_REG_EXP = /.*-(\d+).*/
 
@@ -24,7 +24,37 @@ const decrementKey = (key) => {
   return key.replace(index, index - 1)
 }
 
+const keyDoesNotContainIndex = (index) => (val, key) => getIndexFromKey(key) !== index
+
+const handleDecrement = (index) => (pair) => {
+  const key = pair[0]
+
+  if (isKeyAfterRemoved(key, index)) {
+    return [decrementKey(key), pair[1]]
+  }
+
+  return pair
+}
+
+const reIndexChildren = (children, index) => compose(fromPairs, map(handleDecrement(index)), toPairs)(children)
+
+const removeChildByIndex = (children, index) => {
+  const childDobPrefix = 'childDob-'
+
+  const metaEntries = pickBy((val, key) => !key.startsWith(childDobPrefix), children)
+  const childEntries = pickBy((val, key) => key.startsWith(childDobPrefix), children)
+
+  const filteredChildren = pickBy(keyDoesNotContainIndex(index), childEntries)
+
+  return {
+    ...reIndexChildren(filteredChildren, index),
+    ...metaEntries
+  }
+}
+
 module.exports = {
   isKeyAfterRemoved,
-  decrementKey
+  decrementKey,
+  keyDoesNotContainIndex,
+  removeChildByIndex
 }

--- a/src/web/routes/application/children-dob/remove-child-by-index.js
+++ b/src/web/routes/application/children-dob/remove-child-by-index.js
@@ -1,60 +1,25 @@
-const { compose, map, isNil, pickBy, toPairs, fromPairs } = require('ramda')
-
-const INDEX_FROM_KEY_REG_EXP = /.*-(\d+).*/
-
-const getIndexFromKey = (key) => {
-  const groups = INDEX_FROM_KEY_REG_EXP.exec(key)
-
-  if (isNil(groups)) {
-    throw new Error(`Could not find index for key ${key}`)
-  }
-
-  return parseInt(groups[1], 10)
-}
-
-const isKeyAfterRemoved = (key, index) => getIndexFromKey(key) > index
-
-const decrementKey = (key) => {
-  const index = getIndexFromKey(key)
-
-  if (index <= 1) {
-    throw new Error(`Unable to decrement index for key ${key}`)
-  }
-
-  return key.replace(index, index - 1)
-}
-
-const keyDoesNotContainIndex = (index) => (val, key) => getIndexFromKey(key) !== index
-
-const handleDecrement = (index) => (pair) => {
-  const key = pair[0]
-
-  if (isKeyAfterRemoved(key, index)) {
-    return [decrementKey(key), pair[1]]
-  }
-
-  return pair
-}
+const { compose, map, toPairs, fromPairs } = require('ramda')
+const { handleDecrement } = require('./decrement-keys')
+const { getChildEntries, getNonChildEntries, getEntriesWithoutIndex } = require('./selectors')
 
 const reIndexChildren = (children, index) => compose(fromPairs, map(handleDecrement(index)), toPairs)(children)
 
+/**
+ * Remove all 'childDob-x' entries from the session object (children) where x matches the index by:
+ *  - Get all the entries from the session that start with 'childDob-'
+ *  - Remove all entries which are for the given index ('childDob-x')
+ *  - Rebuild the object with the remaining children entries re-indexed plus everything else (non-'childDob-x' entries)
+ */
 const removeChildByIndex = (children, index) => {
-  const childDobPrefix = 'childDob-'
-
-  const metaEntries = pickBy((val, key) => !key.startsWith(childDobPrefix), children)
-  const childEntries = pickBy((val, key) => key.startsWith(childDobPrefix), children)
-
-  const filteredChildren = pickBy(keyDoesNotContainIndex(index), childEntries)
+  const childEntries = getChildEntries(children)
+  const filteredChildren = getEntriesWithoutIndex(childEntries, index)
 
   return {
     ...reIndexChildren(filteredChildren, index),
-    ...metaEntries
+    ...getNonChildEntries(children)
   }
 }
 
 module.exports = {
-  isKeyAfterRemoved,
-  decrementKey,
-  keyDoesNotContainIndex,
   removeChildByIndex
 }

--- a/src/web/routes/application/children-dob/remove-child-by-index.test.js
+++ b/src/web/routes/application/children-dob/remove-child-by-index.test.js
@@ -1,45 +1,7 @@
 const test = require('tape')
-const { isKeyAfterRemoved, decrementKey, keyDoesNotContainIndex, removeChildByIndex } = require('./remove-child-by-index')
+const { removeChildByIndex } = require('./remove-child-by-index')
 
-test('isKeyAfterRemoved()', (t) => {
-  t.equal(isKeyAfterRemoved('childDob-1-day', 1), false)
-  t.equal(isKeyAfterRemoved('childDob-1-day', 2), false)
-  t.equal(isKeyAfterRemoved('childDob-1-day', 3), false)
-
-  t.equal(isKeyAfterRemoved('childDob-2-day', 1), true)
-  t.equal(isKeyAfterRemoved('childDob-2-day', 2), false)
-  t.equal(isKeyAfterRemoved('childDob-2-day', 3), false)
-
-  t.equal(isKeyAfterRemoved('childDob-3-day', 1), true)
-  t.equal(isKeyAfterRemoved('childDob-3-day', 2), true)
-  t.equal(isKeyAfterRemoved('childDob-3-day', 3), false)
-
-  t.equal(isKeyAfterRemoved('childDob-11-day', 1), true)
-  t.equal(isKeyAfterRemoved('childDob-1', 1), false)
-  t.equal(isKeyAfterRemoved('childDob-5', 1), true)
-
-  t.throws(() => isKeyAfterRemoved('childDob-day', 1), /Could not find index for key childDob-day/)
-  t.throws(() => isKeyAfterRemoved('inputCount', 1), /Could not find index for key inputCount/)
-  t.end()
-})
-
-test('decrementKey()', (t) => {
-  t.equal(decrementKey('childDob-2-day'), 'childDob-1-day')
-  t.equal(decrementKey('childDob-11-day'), 'childDob-10-day')
-
-  t.throws(() => decrementKey('childDob-day'), /Could not find index for key childDob-day/)
-  t.throws(() => decrementKey('inputCount'), /Could not find index for key inputCount/)
-  t.throws(() => decrementKey('childDob-1-day'), /Unable to decrement index for key childDob-1-day/)
-  t.end()
-})
-
-test('keyDoesNotContainIndex()', (t) => {
-  t.equal(keyDoesNotContainIndex(1)('value', 'childDob-1-day'), false)
-  t.equal(keyDoesNotContainIndex(2)('value', 'childDob-1-day'), true)
-  t.end()
-})
-
-test.only('removeChildByIndex', (t) => {
+test('removeChildByIndex', (t) => {
   const children = {
     'childDob-1-day': '1',
     'childDob-1-month': '1',

--- a/src/web/routes/application/children-dob/remove-child-by-index.test.js
+++ b/src/web/routes/application/children-dob/remove-child-by-index.test.js
@@ -1,18 +1,5 @@
 const test = require('tape')
-const { isKeyAfterRemoved, decrementKey } = require('./remove-child-by-index')
-
-const children = {
-  'childDob-1-day': '1',
-  'childDob-1-month': '1',
-  'childDob-1-year': '2001',
-  'childDob-2-day': '2',
-  'childDob-2-month': '2',
-  'childDob-2-year': '2002',
-  'childDob-3-day': '3',
-  'childDob-3-month': '3',
-  'childDob-3-year': '2003',
-  'inputCount': 3
-}
+const { isKeyAfterRemoved, decrementKey, keyDoesNotContainIndex, removeChildByIndex } = require('./remove-child-by-index')
 
 test('isKeyAfterRemoved()', (t) => {
   t.equal(isKeyAfterRemoved('childDob-1-day', 1), false)
@@ -43,5 +30,39 @@ test('decrementKey()', (t) => {
   t.throws(() => decrementKey('childDob-day'), /Could not find index for key childDob-day/)
   t.throws(() => decrementKey('inputCount'), /Could not find index for key inputCount/)
   t.throws(() => decrementKey('childDob-1-day'), /Unable to decrement index for key childDob-1-day/)
+  t.end()
+})
+
+test('keyDoesNotContainIndex()', (t) => {
+  t.equal(keyDoesNotContainIndex(1)('value', 'childDob-1-day'), false)
+  t.equal(keyDoesNotContainIndex(2)('value', 'childDob-1-day'), true)
+  t.end()
+})
+
+test.only('removeChildByIndex', (t) => {
+  const children = {
+    'childDob-1-day': '1',
+    'childDob-1-month': '1',
+    'childDob-1-year': '2001',
+    'childDob-2-day': '2',
+    'childDob-2-month': '2',
+    'childDob-2-year': '2002',
+    'childDob-3-day': '3',
+    'childDob-3-month': '3',
+    'childDob-3-year': '2003',
+    'inputCount': 3
+  }
+
+  const expected = {
+    'childDob-1-day': '1',
+    'childDob-1-month': '1',
+    'childDob-1-year': '2001',
+    'childDob-2-day': '3',
+    'childDob-2-month': '3',
+    'childDob-2-year': '2003',
+    'inputCount': 3
+  }
+
+  t.deepEqual(removeChildByIndex(children, 2), expected)
   t.end()
 })

--- a/src/web/routes/application/children-dob/remove-child-by-index.test.js
+++ b/src/web/routes/application/children-dob/remove-child-by-index.test.js
@@ -1,0 +1,24 @@
+const test = require('tape')
+const { isKeyAfterRemoved } = require('./remove-child-by-index')
+
+test('isKeyAfterRemoved()', (t) => {
+  t.equal(isKeyAfterRemoved('childDob-1-day', 1), false)
+  t.equal(isKeyAfterRemoved('childDob-1-day', 2), false)
+  t.equal(isKeyAfterRemoved('childDob-1-day', 3), false)
+
+  t.equal(isKeyAfterRemoved('childDob-2-day', 1), true)
+  t.equal(isKeyAfterRemoved('childDob-2-day', 2), false)
+  t.equal(isKeyAfterRemoved('childDob-2-day', 3), false)
+
+  t.equal(isKeyAfterRemoved('childDob-3-day', 1), true)
+  t.equal(isKeyAfterRemoved('childDob-3-day', 2), true)
+  t.equal(isKeyAfterRemoved('childDob-3-day', 3), false)
+
+  t.equal(isKeyAfterRemoved('childDob-11-day', 1), true)
+  t.equal(isKeyAfterRemoved('childDob-1', 1), false)
+  t.equal(isKeyAfterRemoved('childDob-5', 1), true)
+
+  t.throws(() => isKeyAfterRemoved('childDob-day', 1), /Could not find index 1 for key childDob-day/)
+  t.throws(() => isKeyAfterRemoved('inputCount', 1), /Could not find index 1 for key inputCount/)
+  t.end()
+})

--- a/src/web/routes/application/children-dob/remove-child-by-index.test.js
+++ b/src/web/routes/application/children-dob/remove-child-by-index.test.js
@@ -1,5 +1,18 @@
 const test = require('tape')
-const { isKeyAfterRemoved } = require('./remove-child-by-index')
+const { isKeyAfterRemoved, decrementKey } = require('./remove-child-by-index')
+
+const children = {
+  'childDob-1-day': '1',
+  'childDob-1-month': '1',
+  'childDob-1-year': '2001',
+  'childDob-2-day': '2',
+  'childDob-2-month': '2',
+  'childDob-2-year': '2002',
+  'childDob-3-day': '3',
+  'childDob-3-month': '3',
+  'childDob-3-year': '2003',
+  'inputCount': 3
+}
 
 test('isKeyAfterRemoved()', (t) => {
   t.equal(isKeyAfterRemoved('childDob-1-day', 1), false)
@@ -18,7 +31,17 @@ test('isKeyAfterRemoved()', (t) => {
   t.equal(isKeyAfterRemoved('childDob-1', 1), false)
   t.equal(isKeyAfterRemoved('childDob-5', 1), true)
 
-  t.throws(() => isKeyAfterRemoved('childDob-day', 1), /Could not find index 1 for key childDob-day/)
-  t.throws(() => isKeyAfterRemoved('inputCount', 1), /Could not find index 1 for key inputCount/)
+  t.throws(() => isKeyAfterRemoved('childDob-day', 1), /Could not find index for key childDob-day/)
+  t.throws(() => isKeyAfterRemoved('inputCount', 1), /Could not find index for key inputCount/)
+  t.end()
+})
+
+test('decrementKey()', (t) => {
+  t.equal(decrementKey('childDob-2-day'), 'childDob-1-day')
+  t.equal(decrementKey('childDob-11-day'), 'childDob-10-day')
+
+  t.throws(() => decrementKey('childDob-day'), /Could not find index for key childDob-day/)
+  t.throws(() => decrementKey('inputCount'), /Could not find index for key inputCount/)
+  t.throws(() => decrementKey('childDob-1-day'), /Unable to decrement index for key childDob-1-day/)
   t.end()
 })

--- a/src/web/routes/application/children-dob/selectors.js
+++ b/src/web/routes/application/children-dob/selectors.js
@@ -1,0 +1,14 @@
+const { pickBy } = require('ramda')
+const { isNotChildEntry, isChildEntry, keyDoesNotContainIndex } = require('./predicates')
+
+const getNonChildEntries = pickBy(isNotChildEntry)
+
+const getChildEntries = pickBy(isChildEntry)
+
+const getEntriesWithoutIndex = (entries, index) => pickBy(keyDoesNotContainIndex(index), entries)
+
+module.exports = {
+  getChildEntries,
+  getNonChildEntries,
+  getEntriesWithoutIndex
+}

--- a/src/web/routes/application/children-dob/selectors.js
+++ b/src/web/routes/application/children-dob/selectors.js
@@ -5,10 +5,10 @@ const getNonChildEntries = pickBy(isNotChildEntry)
 
 const getChildEntries = pickBy(isChildEntry)
 
-const getEntriesWithoutIndex = (entries, index) => pickBy(keyDoesNotContainIndex(index), entries)
+const omitKeysWithIndex = (entries, index) => pickBy(keyDoesNotContainIndex(index), entries)
 
 module.exports = {
   getChildEntries,
   getNonChildEntries,
-  getEntriesWithoutIndex
+  omitKeysWithIndex
 }


### PR DESCRIPTION
Add functions for removing all child entries from the session once the remove button has been clicked. Process is: 
- Get all the entries from the session that start with 'childDob-'
- Remove all entries which are for the given index ('childDob-x')
- Rebuild the object with the remaining children entries re-indexed plus everything else (non-'childDob-x' entries)
- This will be handed back to be added back into the session.

NOTE - this PR does not plumb it in yet and change what's in the session, this will be done in a subsequent PR.