### PR TITLE
HTBHF-1680 use DOB prefix for child's name

### DIFF
--- a/src/test/common/page/enter-children-dob.js
+++ b/src/test/common/page/enter-children-dob.js
@@ -49,7 +49,7 @@ class EnterChildrenDOB extends SubmittablePage {
   }
 
   async getNameField () {
-    return this.findById(`child-name-${this.childIndex}`)
+    return this.findById(`childDob-name-${this.childIndex}`)
   }
 
   async getDayField () {
@@ -114,11 +114,11 @@ class EnterChildrenDOB extends SubmittablePage {
   }
 
   getChildNameFieldErrorId (index) {
-    return `child-name-${index}-error`
+    return `childDob-name-${index}-error`
   }
 
   getChildNameErrorLinkCss (index) {
-    return `a[href="#child-name-${index}-error"]`
+    return `a[href="#child-dob-name-${index}-error"]`
   }
 }
 

--- a/src/web/routes/application/children-dob/predicates.js
+++ b/src/web/routes/application/children-dob/predicates.js
@@ -1,7 +1,7 @@
 const { compose, not } = require('ramda')
 const { getIndexFromKey } = require('./decrement-keys')
 
-const CHID_DOB_PREFIX = 'childDob-'
+const CHID_DOB_PREFIX = 'childDob'
 
 const isChildEntry = (val, key) => key.startsWith(CHID_DOB_PREFIX)
 

--- a/src/web/routes/application/children-dob/validate.js
+++ b/src/web/routes/application/children-dob/validate.js
@@ -5,7 +5,7 @@ const { isValidDate, isDateMoreThanFourYearsAgo, isDateInTheFuture } = require('
 const { translateValidationMessage } = require('../common/translate-validation-message')
 
 const FIELD_PREFIX = 'childDob-'
-const CHILD_NAME_PREFIX = 'childName-'
+const CHILD_NAME_PREFIX = 'childDobName-'
 const CHILD_NAME_MAX_LENGTH = 500
 
 const fieldExistsWithPrefix = (prefix) => compose(any(startsWith(prefix)), keys)

--- a/src/web/routes/application/children-dob/validate.test.js
+++ b/src/web/routes/application/children-dob/validate.test.js
@@ -10,15 +10,15 @@ const {
 } = require('./validate')
 
 const fields = {
-  'childName-1': 'Lisa',
+  'childDobName-1': 'Lisa',
   'childDob-1-day': '1',
   'childDob-1-month': '2',
   'childDob-1-year': '2001',
-  'childName-2': 'Bart',
+  'childDobName-2': 'Bart',
   'childDob-2-day': '3',
   'childDob-2-month': '4',
   'childDob-2-year': '2002',
-  'childName-3': 'Maggie',
+  'childDobName-3': 'Maggie',
   'childDob-3-day': '5',
   'childDob-3-month': '6',
   'childDob-3-year': '2003'
@@ -61,7 +61,7 @@ test('convertDateFieldsToDateStrings() converts individual date fields to compos
 })
 
 test('isChildNameKey() returns true if key contains child name prefix', (t) => {
-  const result = isChildNameKey(undefined, 'childName-')
+  const result = isChildNameKey(undefined, 'childDobName-')
   t.equal(result, true, 'returns true if key contains child name prefix')
   t.end()
 })
@@ -74,7 +74,7 @@ test('isChildNameKey() returns false if key does not contain child name prefix',
 
 test('getChildrenNameKeys() returns an array of keys for children names', (t) => {
   const result = getChildrenNameKeys(fields)
-  const expected = ['childName-1', 'childName-2', 'childName-3']
+  const expected = ['childDobName-1', 'childDobName-2', 'childDobName-3']
 
   t.deepEqual(result, expected, 'returns an array of keys for children names')
   t.end()

--- a/src/web/views/macros/htbhf-child-dob-input.njk
+++ b/src/web/views/macros/htbhf-child-dob-input.njk
@@ -21,10 +21,10 @@
       label: {
         text: params.nameLabel
       },
-      id: 'child-name-' + params.index,
-      name: 'childName-' + params.index,
-      value: params.children['childName-'  + params.index],
-      errorMessage: params.errors | getErrorForField('childName-'  + params.index),
+      id: 'childDob-name-' + params.index,
+      name: 'childDobName-' + params.index,
+      value: params.children['childDobName-'  + params.index],
+      errorMessage: params.errors | getErrorForField('childDobName-'  + params.index),
       autocomplete: "off"
     }) }}
 


### PR DESCRIPTION
Update child name prefix for child DOB input to include `Dob`. This is required for removing a child from the session.