### PR TITLE
HTBHF-1680 enable remove action for children's DOB

### DIFF
--- a/src/web/routes/application/children-dob/children-dob.js
+++ b/src/web/routes/application/children-dob/children-dob.js
@@ -1,11 +1,11 @@
-const { pickBy, path } = require('ramda')
-const { countKeysContainingString } = require('./count-keys')
+const { path } = require('ramda')
 const { YES } = require('../common/constants')
 const { validate } = require('./validate')
 const { getExampleDate } = require('../common/formatters')
-
-const PATH = '/children-dob'
-const DAY_FIELD_SUFFIX = '-day'
+const { setChildrenInSessionForGet, setChildrenInSessionForPost } = require('./set-children-in-session')
+const { handleRemoveAction } = require('./handle-remove-action')
+const { handleAddAction } = require('./handle-add-action')
+const { PATH } = require('./constants')
 
 const pageContent = ({ translate }) => ({
   title: translate('childrenDob.title'),
@@ -23,49 +23,19 @@ const pageContent = ({ translate }) => ({
   removeChild: translate('buttons:removeChild')
 })
 
-const addActionRequested = body => body.hasOwnProperty('add')
-
-const extractChildrenEntries = (val, key) => key.startsWith('child')
-
-const initialiseChildrenInSession = (req) => {
-  if (!req.session.hasOwnProperty('children')) {
-    req.session.children = {
-      inputCount: 1,
-      childCount: 0
-    }
-  }
-
-  return req
-}
-
 const isNavigable = (session) => path(['claim', 'doYouHaveChildrenThreeOrYounger'], session) === YES
 
 const behaviourForGet = (req, res, next) => {
-  req = initialiseChildrenInSession(req)
+  req = setChildrenInSessionForGet(req)
   res.locals.children = req.session.children
   next()
 }
 
-const behaviourForPost = (req, res, next) => {
-  const childCount = countKeysContainingString(DAY_FIELD_SUFFIX, req.body)
-
-  req.session.children = {
-    ...pickBy(extractChildrenEntries, req.body),
-    inputCount: childCount,
-    childCount: childCount
-  }
-
-  // GET behaviour is not called on validation error so locals also need setting for POST
-  res.locals.children = req.session.children
-
-  if (addActionRequested(req.body)) {
-    const updatedCount = req.session.children.inputCount + 1
-    req.session.children.inputCount = updatedCount
-    return res.redirect(PATH)
-  }
-
-  next()
-}
+const behaviourForPost = [
+  setChildrenInSessionForPost,
+  handleAddAction,
+  handleRemoveAction
+]
 
 const childrenDob = {
   path: PATH,
@@ -81,6 +51,5 @@ const childrenDob = {
 module.exports = {
   behaviourForGet,
   behaviourForPost,
-  childrenDob,
-  countKeysContainingString
+  childrenDob
 }

--- a/src/web/routes/application/children-dob/children-dob.test.js
+++ b/src/web/routes/application/children-dob/children-dob.test.js
@@ -1,115 +1,13 @@
 const test = require('tape')
 const sinon = require('sinon')
-const { behaviourForPost, behaviourForGet } = require('./children-dob')
+const { behaviourForGet } = require('./children-dob')
 
 const child = {
-  'childName-01': 'Lisa',
-  'childDob-day-01': '14',
-  'childDob-month-01': '11',
-  'childDob-year-01': '1990'
+  'childDobName-1': 'Lisa',
+  'childDob-day-1': '14',
+  'childDob-month-1': '11',
+  'childDob-year-1': '1990'
 }
-
-const newChild = {
-  'childName-02': 'Bart',
-  'childDob-day-02': '2',
-  'childDob-month-02': '3',
-  'childDob-year-02': '2001'
-}
-
-test('behaviourForPost() initialises counters in session', (t) => {
-  const req = {
-    session: {},
-    body: {}
-  }
-  const res = { locals: {} }
-  const next = sinon.spy()
-
-  behaviourForPost(req, res, next)
-
-  t.equal(req.session.children.inputCount, 0, 'initialises input count in session')
-  t.equal(req.session.children.childCount, 0, 'initialises children count in session')
-  t.end()
-})
-
-test('behaviourForPost() adds childrens DOBs to session on add action', (t) => {
-  const req = {
-    session: {
-      children: {
-        ...child,
-        childCount: 1,
-        inputCount: 1
-      }
-    },
-    body: {
-      add: 'Add another child',
-      ...child,
-      ...newChild
-    }
-  }
-
-  const redirect = sinon.spy()
-
-  const res = {
-    redirect,
-    locals: {}
-  }
-
-  const next = sinon.spy()
-
-  const expected = {
-    ...child,
-    ...newChild,
-    childCount: 2,
-    inputCount: 3
-  }
-
-  behaviourForPost(req, res, next)
-
-  t.deepEqual(req.session.children, expected, 'adds childrens DOBs to session on add action')
-  t.equal(redirect.calledWith('/children-dob'), true, 'redirects on add action')
-  t.equal(next.called, false, 'does not call next')
-  t.end()
-})
-
-test('behaviourForPost() adds childrens DOBs to session on submit', (t) => {
-  const req = {
-    session: {
-      children: {
-        ...child,
-        childCount: 1,
-        inputCount: 1
-      }
-    },
-    body: {
-      ...child,
-      ...newChild
-    }
-  }
-
-  const redirect = sinon.spy()
-
-  const res = {
-    redirect,
-    locals: {}
-  }
-
-  const next = sinon.spy()
-
-  const expected = {
-    ...child,
-    ...newChild,
-    childCount: 2,
-    inputCount: 2
-  }
-
-  behaviourForPost(req, res, next)
-
-  t.deepEqual(req.session.children, expected, 'adds childrens DOBs to session on submit')
-  t.deepEqual(res.locals.children, expected, 'adds childrens DOBs to res.locals')
-  t.equal(redirect.called, false, 'does not redirect')
-  t.equal(next.called, true, 'calls next')
-  t.end()
-})
 
 test('behaviourForGet() initialises children in session', (t) => {
   const req = { session: {} }

--- a/src/web/routes/application/children-dob/constants.js
+++ b/src/web/routes/application/children-dob/constants.js
@@ -1,0 +1,2 @@
+module.exports.PATH = '/children-dob'
+module.exports.DAY_FIELD_SUFFIX = '-day'

--- a/src/web/routes/application/children-dob/constants.js
+++ b/src/web/routes/application/children-dob/constants.js
@@ -1,2 +1,4 @@
 module.exports.PATH = '/children-dob'
 module.exports.DAY_FIELD_SUFFIX = '-day'
+module.exports.ADD_CHILD_KEY = 'addChild'
+module.exports.REMOVE_CHILD_INDEX_KEY = 'removeChildIndex'

--- a/src/web/routes/application/children-dob/handle-add-action.js
+++ b/src/web/routes/application/children-dob/handle-add-action.js
@@ -1,6 +1,6 @@
-const { PATH } = require('./constants')
+const { PATH, ADD_CHILD_KEY } = require('./constants')
 
-const addActionRequested = body => body.hasOwnProperty('add')
+const addActionRequested = body => body.hasOwnProperty(ADD_CHILD_KEY)
 
 const handleAddAction = (req, res, next) => {
   if (!addActionRequested(req.body)) {

--- a/src/web/routes/application/children-dob/handle-add-action.js
+++ b/src/web/routes/application/children-dob/handle-add-action.js
@@ -1,0 +1,16 @@
+const { PATH } = require('./constants')
+
+const addActionRequested = body => body.hasOwnProperty('add')
+
+const handleAddAction = (req, res, next) => {
+  if (!addActionRequested(req.body)) {
+    return next()
+  }
+
+  req.session.children.inputCount = req.session.children.childCount + 1
+  return res.redirect(PATH)
+}
+
+module.exports = {
+  handleAddAction
+}

--- a/src/web/routes/application/children-dob/handle-add-action.test.js
+++ b/src/web/routes/application/children-dob/handle-add-action.test.js
@@ -1,6 +1,7 @@
 const test = require('tape')
 const sinon = require('sinon')
 const { handleAddAction } = require('./handle-add-action')
+const { ADD_CHILD_KEY } = require('./constants')
 
 const child = {
   'childDobName-1': 'Lisa',
@@ -19,7 +20,7 @@ test('handleAddAction() increments the input count in session on add action', (t
       }
     },
     body: {
-      add: 'Add another child',
+      [ADD_CHILD_KEY]: 'Add another child',
       ...child
     }
   }

--- a/src/web/routes/application/children-dob/handle-add-action.test.js
+++ b/src/web/routes/application/children-dob/handle-add-action.test.js
@@ -1,0 +1,85 @@
+const test = require('tape')
+const sinon = require('sinon')
+const { handleAddAction } = require('./handle-add-action')
+
+const child = {
+  'childDobName-1': 'Lisa',
+  'childDob-day-1': '14',
+  'childDob-month-1': '11',
+  'childDob-year-1': '1990'
+}
+
+test('handleAddAction() increments the input count in session on add action', (t) => {
+  const req = {
+    session: {
+      children: {
+        ...child,
+        childCount: 1,
+        inputCount: 1
+      }
+    },
+    body: {
+      add: 'Add another child',
+      ...child
+    }
+  }
+
+  const redirect = sinon.spy()
+
+  const res = {
+    redirect,
+    locals: {}
+  }
+
+  const next = sinon.spy()
+
+  const expected = {
+    ...child,
+    childCount: 1,
+    inputCount: 2
+  }
+
+  handleAddAction(req, res, next)
+
+  t.deepEqual(req.session.children, expected, 'increments input count')
+  t.equal(redirect.calledWith('/children-dob'), true, 'calls redirect')
+  t.equal(next.called, false, 'does not call next')
+  t.end()
+})
+
+test('handleAddAction() does nothing when not an add action', (t) => {
+  const req = {
+    session: {
+      children: {
+        ...child,
+        childCount: 1,
+        inputCount: 1
+      }
+    },
+    body: {
+      ...child
+    }
+  }
+
+  const redirect = sinon.spy()
+
+  const res = {
+    redirect,
+    locals: {}
+  }
+
+  const next = sinon.spy()
+
+  const expected = {
+    ...child,
+    childCount: 1,
+    inputCount: 1
+  }
+
+  handleAddAction(req, res, next)
+
+  t.deepEqual(req.session.children, expected, 'does not mutate children')
+  t.equal(redirect.calledWith('/children-dob'), false, 'does not call redirect')
+  t.equal(next.called, true, 'calls next')
+  t.end()
+})

--- a/src/web/routes/application/children-dob/handle-remove-action.js
+++ b/src/web/routes/application/children-dob/handle-remove-action.js
@@ -1,0 +1,28 @@
+const { removeChildByIndex } = require('./remove-child-by-index')
+const { PATH } = require('./constants')
+
+const removeActionRequested = body => body.hasOwnProperty('remove')
+
+const decrementInputCount = childCount => childCount === 1 ? 1 : childCount - 1
+
+const handleRemoveAction = (req, res, next) => {
+  if (!removeActionRequested(req.body)) {
+    return next()
+  }
+
+  const { childCount } = req.session.children
+  const index = req.body.remove
+
+  if (index <= 0) {
+    throw new Error(`Unable to remove index ${index}`)
+  }
+
+  req.session.children = removeChildByIndex(req.session.children, index)
+  req.session.children.inputCount = decrementInputCount(childCount)
+  req.session.children.childCount = childCount - 1
+  return res.redirect(PATH)
+}
+
+module.exports = {
+  handleRemoveAction
+}

--- a/src/web/routes/application/children-dob/handle-remove-action.js
+++ b/src/web/routes/application/children-dob/handle-remove-action.js
@@ -1,7 +1,7 @@
 const { removeChildByIndex } = require('./remove-child-by-index')
-const { PATH } = require('./constants')
+const { PATH, REMOVE_CHILD_INDEX_KEY } = require('./constants')
 
-const removeActionRequested = body => body.hasOwnProperty('remove')
+const removeActionRequested = body => body.hasOwnProperty(REMOVE_CHILD_INDEX_KEY)
 
 const decrementInputCount = childCount => childCount === 1 ? 1 : childCount - 1
 
@@ -11,7 +11,7 @@ const handleRemoveAction = (req, res, next) => {
   }
 
   const { childCount } = req.session.children
-  const index = req.body.remove
+  const index = req.body[REMOVE_CHILD_INDEX_KEY]
 
   if (index <= 0) {
     throw new Error(`Unable to remove index ${index}`)

--- a/src/web/routes/application/children-dob/handle-remove-action.test.js
+++ b/src/web/routes/application/children-dob/handle-remove-action.test.js
@@ -1,0 +1,161 @@
+const test = require('tape')
+const sinon = require('sinon')
+const { handleRemoveAction } = require('./handle-remove-action')
+
+const child = {
+  'childDobName-1': 'Lisa',
+  'childDob-day-1': '14',
+  'childDob-month-1': '11',
+  'childDob-year-1': '1990'
+}
+
+const newChild = {
+  'childDobName-2': 'Bart',
+  'childDob-day-2': '2',
+  'childDob-month-2': '3',
+  'childDob-year-2': '2001'
+}
+
+test('handleRemoveAction() removes child’s DOB from session on remove action', (t) => {
+  const req = {
+    session: {
+      children: {
+        ...child,
+        ...newChild,
+        childCount: 2,
+        inputCount: 2
+      }
+    },
+    body: {
+      ...child,
+      ...newChild,
+      remove: '1'
+    }
+  }
+
+  const redirect = sinon.spy()
+
+  const res = {
+    redirect,
+    locals: {}
+  }
+
+  const next = sinon.spy()
+
+  const expected = {
+    'childDobName-1': 'Bart',
+    'childDob-day-1': '2',
+    'childDob-month-1': '3',
+    'childDob-year-1': '2001',
+    'childCount': 1,
+    'inputCount': 1
+  }
+
+  handleRemoveAction(req, res, next)
+
+  t.deepEqual(req.session.children, expected, 'removes child’s DOB from session on remove action')
+  t.equal(redirect.calledWith('/children-dob'), true, 'redirects on remove action')
+  t.equal(next.called, false, 'does not call next')
+  t.end()
+})
+
+test('handleRemoveAction() does nothing when no remove action', (t) => {
+  const req = {
+    session: {
+      children: {
+        ...child,
+        childCount: 1,
+        inputCount: 1
+      }
+    },
+    body: {
+      ...child
+    }
+  }
+
+  const redirect = sinon.spy()
+
+  const res = {
+    redirect,
+    locals: {}
+  }
+
+  const next = sinon.spy()
+
+  const expected = {
+    'childDobName-1': 'Lisa',
+    'childDob-day-1': '14',
+    'childDob-month-1': '11',
+    'childDob-year-1': '1990',
+    'childCount': 1,
+    'inputCount': 1
+  }
+
+  handleRemoveAction(req, res, next)
+
+  t.deepEqual(req.session.children, expected, 'does not mutate children')
+  t.equal(redirect.calledWith('/children-dob'), false, 'does not redirect')
+  t.equal(next.called, true, 'calls next')
+  t.end()
+})
+
+test('handleRemoveAction() removes child’s DOB from session on remove action when only one child exists', (t) => {
+  const req = {
+    session: {
+      children: {
+        ...child,
+        childCount: 1,
+        inputCount: 1
+      }
+    },
+    body: {
+      ...child,
+      remove: '1'
+    }
+  }
+
+  const redirect = sinon.spy()
+
+  const res = {
+    redirect,
+    locals: {}
+  }
+
+  const next = sinon.spy()
+
+  const expected = {
+    'childCount': 0,
+    'inputCount': 1
+  }
+
+  handleRemoveAction(req, res, next)
+
+  t.deepEqual(req.session.children, expected, 'removes child’s DOB from session on remove action')
+  t.equal(redirect.calledWith('/children-dob'), true, 'redirects on remove action')
+  t.equal(next.called, false, 'does not call next')
+  t.end()
+})
+
+test('handleRemoveAction() throws an error on remove action when index is less than 1', (t) => {
+  const req = {
+    session: {
+      children: {
+        childCount: 0,
+        inputCount: 1
+      }
+    },
+    body: {
+      remove: '0'
+    }
+  }
+
+  const redirect = sinon.spy()
+
+  const res = {
+    redirect,
+    locals: {}
+  }
+
+  t.throws(() => handleRemoveAction(req, res, () => {}), /Unable to remove index 0/)
+  t.end()
+})

--- a/src/web/routes/application/children-dob/handle-remove-action.test.js
+++ b/src/web/routes/application/children-dob/handle-remove-action.test.js
@@ -1,6 +1,7 @@
 const test = require('tape')
 const sinon = require('sinon')
 const { handleRemoveAction } = require('./handle-remove-action')
+const { REMOVE_CHILD_INDEX_KEY } = require('./constants')
 
 const child = {
   'childDobName-1': 'Lisa',
@@ -29,7 +30,7 @@ test('handleRemoveAction() removes child’s DOB from session on remove action',
     body: {
       ...child,
       ...newChild,
-      remove: '1'
+      [REMOVE_CHILD_INDEX_KEY]: '1'
     }
   }
 
@@ -110,7 +111,7 @@ test('handleRemoveAction() removes child’s DOB from session on remove action w
     },
     body: {
       ...child,
-      remove: '1'
+      [REMOVE_CHILD_INDEX_KEY]: '1'
     }
   }
 
@@ -145,7 +146,7 @@ test('handleRemoveAction() throws an error on remove action when index is less t
       }
     },
     body: {
-      remove: '0'
+      [REMOVE_CHILD_INDEX_KEY]: '0'
     }
   }
 

--- a/src/web/routes/application/children-dob/remove-child-by-index.js
+++ b/src/web/routes/application/children-dob/remove-child-by-index.js
@@ -12,7 +12,7 @@ const reIndexChildren = (children, index) => compose(fromPairs, map(handleDecrem
  */
 const removeChildByIndex = (children, index) => {
   const childEntries = getChildEntries(children)
-  const filteredChildren = omitKeysWithIndex(childEntries, index)
+  const filteredChildren = omitKeysWithIndex(childEntries, parseInt(index, 10))
 
   return {
     ...reIndexChildren(filteredChildren, index),

--- a/src/web/routes/application/children-dob/set-children-in-session.js
+++ b/src/web/routes/application/children-dob/set-children-in-session.js
@@ -1,0 +1,34 @@
+const { pickBy } = require('ramda')
+const { countKeysContainingString } = require('./count-keys')
+const { DAY_FIELD_SUFFIX } = require('./constants')
+const { isChildEntry } = require('./predicates')
+
+const setChildrenInSessionForGet = (req) => {
+  if (!req.session.hasOwnProperty('children')) {
+    req.session.children = {
+      inputCount: 1,
+      childCount: 0
+    }
+  }
+
+  return req
+}
+
+const setChildrenInSessionForPost = (req, res, next) => {
+  const childCount = countKeysContainingString(DAY_FIELD_SUFFIX, req.body)
+
+  req.session.children = {
+    ...pickBy(isChildEntry, req.body),
+    inputCount: childCount,
+    childCount: childCount
+  }
+
+  // GET behaviour is not called on validation error so locals also need setting for POST
+  res.locals.children = req.session.children
+  return next()
+}
+
+module.exports = {
+  setChildrenInSessionForGet,
+  setChildrenInSessionForPost
+}

--- a/src/web/routes/application/children-dob/set-children-in-session.test.js
+++ b/src/web/routes/application/children-dob/set-children-in-session.test.js
@@ -1,0 +1,69 @@
+const test = require('tape')
+const sinon = require('sinon')
+const { setChildrenInSessionForPost } = require('./set-children-in-session')
+
+const child = {
+  'childDobName-1': 'Lisa',
+  'childDob-day-1': '14',
+  'childDob-month-1': '11',
+  'childDob-year-1': '1990'
+}
+
+const newChild = {
+  'childDobName-2': 'Bart',
+  'childDob-day-2': '2',
+  'childDob-month-2': '3',
+  'childDob-year-2': '2001'
+}
+
+test('setChildrenInSessionForPost() initialises counters in session', (t) => {
+  const req = {
+    session: {},
+    body: {}
+  }
+  const res = { locals: {} }
+  const next = sinon.spy()
+
+  setChildrenInSessionForPost(req, res, next)
+
+  t.equal(req.session.children.inputCount, 0, 'initialises input count in session')
+  t.equal(req.session.children.childCount, 0, 'initialises children count in session')
+  t.equal(next.called, true, 'calls next')
+  t.end()
+})
+
+test('setChildrenInSessionForPost() sets childrens DOBs in session', (t) => {
+  const req = {
+    session: {
+      children: {
+        ...child,
+        childCount: 1,
+        inputCount: 1
+      }
+    },
+    body: {
+      ...child,
+      ...newChild
+    }
+  }
+
+  const res = {
+    locals: {}
+  }
+
+  const next = sinon.spy()
+
+  const expected = {
+    ...child,
+    ...newChild,
+    childCount: 2,
+    inputCount: 2
+  }
+
+  setChildrenInSessionForPost(req, res, next)
+
+  t.deepEqual(req.session.children, expected, 'adds childrens DOBs to session')
+  t.deepEqual(res.locals.children, expected, 'adds childrens DOBs to locals')
+  t.equal(next.called, true, 'calls next')
+  t.end()
+})

--- a/src/web/views/children-dob.njk
+++ b/src/web/views/children-dob.njk
@@ -31,7 +31,7 @@
 
   {% endcall %}
 
-  <input class="c-htbhf-button c-htbhf-button--link u-htbhf-focus" type="submit" value="{{ addChild }}" name="add" id="add-another-child">
+  <button class="c-htbhf-button c-htbhf-button--link u-htbhf-focus" type="submit" name="addChild" id="add-another-child">{{ addChild }}</button>
 
 {{ govukInsetText({
   text: explanation

--- a/src/web/views/macros/htbhf-child-dob-input.njk
+++ b/src/web/views/macros/htbhf-child-dob-input.njk
@@ -49,7 +49,7 @@
       classes: "govuk-button--secondary",
       type: "submit",
       value: params.index,
-      name: "remove",
+      name: "removeChildIndex",
       attributes: {
         id: "remove-child-" + params.index
       }


### PR DESCRIPTION
- Handle remove action when remove action is present on POST
- Refactor `behaviourForPost` into three distinct middleware functions (`setChildrenInSessionForPost`, `handleAddAction`, `handleRemoveAction`)
- Update unit tests to reflect this refactor

The main functional changes exist in `handleRemoveAction.js`. The remaining updates are mainly refactoring code to separate files.