### PR TITLE
HTBHF-1839 Fix date validation boundary errors

### DIFF
--- a/src/web/routes/application/are-you-pregnant/test/validate.test.js
+++ b/src/web/routes/application/are-you-pregnant/test/validate.test.js
@@ -42,9 +42,9 @@ test('validateExpectedDeliveryDate() one month in the past', (t) => {
     }
   }
 
-  const result = validateExpectedDeliveryDate(res)({}, { req })
+  const result = validateExpectedDeliveryDate(res).bind(null, {}, { req })
 
-  t.equal(result, true, 'should return true for exactly one month in past')
+  t.throws(result, /validation:expectedDeliveryDateTooFarInPast/, 'not in valid date range')
   t.end()
 })
 

--- a/src/web/routes/application/are-you-pregnant/validate.js
+++ b/src/web/routes/application/are-you-pregnant/validate.js
@@ -6,7 +6,7 @@ const { NO } = require('../common/constants')
 
 const {
   isValidDate,
-  isDateMoreThanOneMonthAgo,
+  isDateOneOrMoreMonthsInThePast,
   isDateMoreThanEightMonthsInTheFuture,
   validateIsYesOrNo
 } = require('../common/validators')
@@ -28,7 +28,7 @@ const validateExpectedDeliveryDate = (res) => (_, { req }) => {
     throw new Error(req.t('validation:expectedDeliveryDateInvalid'))
   }
 
-  if (isDateMoreThanOneMonthAgo(expectedDeliveryDate)) {
+  if (isDateOneOrMoreMonthsInThePast(expectedDeliveryDate)) {
     throw new Error(req.t('validation:expectedDeliveryDateTooFarInPast'))
   }
 

--- a/src/web/routes/application/children-dob/validate.js
+++ b/src/web/routes/application/children-dob/validate.js
@@ -1,7 +1,7 @@
 const { check } = require('express-validator')
 const { compose, keys, any, startsWith, pickBy } = require('ramda')
 const { toDateString } = require('../common/formatters')
-const { isValidDate, isDateMoreThanFourYearsAgo, isDateInTheFuture } = require('../common/validators')
+const { isValidDate, isDateFourOrMoreYearsInThePast, isDateInTheFuture } = require('../common/validators')
 const { translateValidationMessage } = require('../common/translate-validation-message')
 
 const FIELD_PREFIX = 'childDob-'
@@ -51,7 +51,7 @@ const validateDateOfBirth = (dob, { req }) => {
     throw new Error(req.t('validation:childDateOfBirthInvalid'))
   }
 
-  if (isDateMoreThanFourYearsAgo(dob)) {
+  if (isDateFourOrMoreYearsInThePast(dob)) {
     throw new Error(req.t('validation:childDateOfBirthFourYearsOrOlder'))
   }
 

--- a/src/web/routes/application/children-dob/validate.test.js
+++ b/src/web/routes/application/children-dob/validate.test.js
@@ -105,3 +105,10 @@ test('validateDateOfBirth() returns true for a valid date less than four years i
   t.equal(result, true, 'returns true for a valid date less than four years in the past')
   t.end()
 })
+
+test('validateDateOfBirth() throws an error for a date of birth exactly four years in the past', (t) => {
+  const dobExactlyFourYearsAgo = dateAsString({ yearAdjustment: -4 })
+  const result = validateDateOfBirth.bind(null, dobExactlyFourYearsAgo, { req })
+  t.throws(result, /validation:childDateOfBirthFourYearsOrOlder/, 'throws an error for a date of birth exactly four years ago')
+  t.end()
+})

--- a/src/web/routes/application/common/validators.js
+++ b/src/web/routes/application/common/validators.js
@@ -17,9 +17,9 @@ const isDateInPast = (dateString) => {
   return true
 }
 
-const isDateMoreThanOneMonthAgo = (dateString) => {
+const isDateOneOrMoreMonthsInThePast = (dateString) => {
   if (isValidDate(dateString)) {
-    return validator.isBefore(dateString, dateAsString({ monthAdjustment: -1 }))
+    return !validator.isAfter(dateString, dateAsString({ monthAdjustment: -1 }))
   }
   return true
 }
@@ -41,9 +41,9 @@ const isDateInTheFuture = (dateString) => {
 const validateIsYesOrNo = (fieldName, validationMessage) =>
   check(fieldName).isIn([YES, NO]).withMessage(translateValidationMessage(validationMessage))
 
-const isDateMoreThanFourYearsAgo = (dateString) => {
+const isDateFourOrMoreYearsInThePast = (dateString) => {
   if (isValidDate(dateString)) {
-    return validator.isBefore(dateString, dateAsString({ yearAdjustment: -4 }))
+    return !validator.isAfter(dateString, dateAsString({ yearAdjustment: -4 }))
   }
   return true
 }
@@ -51,9 +51,9 @@ const isDateMoreThanFourYearsAgo = (dateString) => {
 module.exports = {
   isValidDate,
   isDateInPast,
-  isDateMoreThanOneMonthAgo,
+  isDateOneOrMoreMonthsInThePast,
   isDateMoreThanEightMonthsInTheFuture,
   validateIsYesOrNo,
-  isDateMoreThanFourYearsAgo,
+  isDateFourOrMoreYearsInThePast,
   isDateInTheFuture
 }

--- a/src/web/routes/application/common/validators.test.js
+++ b/src/web/routes/application/common/validators.test.js
@@ -3,9 +3,9 @@ const { dateAsString } = require('./formatters')
 const {
   isValidDate,
   isDateInPast,
-  isDateMoreThanOneMonthAgo,
+  isDateOneOrMoreMonthsInThePast,
   isDateMoreThanEightMonthsInTheFuture,
-  isDateMoreThanFourYearsAgo,
+  isDateFourOrMoreYearsInThePast,
   isDateInTheFuture
 } = require('./validators')
 
@@ -36,12 +36,12 @@ test('isDateInPast', (t) => {
 test('isDateMoreThanOneMonthAgo', (t) => {
   const oneMonthAgo = dateAsString({ monthAdjustment: -1 })
 
-  t.equal(isDateMoreThanOneMonthAgo('1999-12-12'), true, '"1999-12-12" is more than one month ago')
-  t.equal(isDateMoreThanOneMonthAgo('9999-12-12'), false, '"9999-12-12" is not more than one month ago')
-  t.equal(isDateMoreThanOneMonthAgo(oneMonthAgo), false, `"${oneMonthAgo}" is exactly one month ago`)
-  t.equal(isDateMoreThanOneMonthAgo(''), true, 'blank string should not be validated')
-  t.equal(isDateMoreThanOneMonthAgo(null), true, 'null string should not be validated')
-  t.equal(isDateMoreThanOneMonthAgo('12-12-1999'), true, 'invalid format string "12-12-1999" should not be validated')
+  t.equal(isDateOneOrMoreMonthsInThePast('1999-12-12'), true, '"1999-12-12" is more than one month ago')
+  t.equal(isDateOneOrMoreMonthsInThePast('9999-12-12'), false, '"9999-12-12" is not more than one month ago')
+  t.equal(isDateOneOrMoreMonthsInThePast(oneMonthAgo), true, `"${oneMonthAgo}" is exactly one month ago`)
+  t.equal(isDateOneOrMoreMonthsInThePast(''), true, 'blank string should not be validated')
+  t.equal(isDateOneOrMoreMonthsInThePast(null), true, 'null string should not be validated')
+  t.equal(isDateOneOrMoreMonthsInThePast('12-12-1999'), true, 'invalid format string "12-12-1999" should not be validated')
   t.end()
 })
 
@@ -60,12 +60,12 @@ test('isDateMoreThanEightMonthsInTheFuture', (t) => {
 test('isDateMoreThanFourYearsAgo', (t) => {
   const fourYearsAgo = dateAsString({ yearAdjustment: -4 })
 
-  t.equal(isDateMoreThanFourYearsAgo('9999-12-12'), false, '"9999-12-12" is not more than four years ago')
-  t.equal(isDateMoreThanFourYearsAgo('1900-12-12'), true, '"1900-12-12" is more than four years ago')
-  t.equal(isDateMoreThanFourYearsAgo(fourYearsAgo), false, `"${fourYearsAgo}" is exactly four years ago`)
-  t.equal(isDateMoreThanFourYearsAgo(''), true, 'blank string should not be validated')
-  t.equal(isDateMoreThanFourYearsAgo(null), true, 'null string should not be validated')
-  t.equal(isDateMoreThanFourYearsAgo('12-12-1999'), true, 'invalid format string "12-12-1999" should not be validated')
+  t.equal(isDateFourOrMoreYearsInThePast('9999-12-12'), false, '"9999-12-12" is not more than four years ago')
+  t.equal(isDateFourOrMoreYearsInThePast('1900-12-12'), true, '"1900-12-12" is more than four years ago')
+  t.equal(isDateFourOrMoreYearsInThePast(fourYearsAgo), true, `"${fourYearsAgo}" is exactly four years ago`)
+  t.equal(isDateFourOrMoreYearsInThePast(''), true, 'blank string should not be validated')
+  t.equal(isDateFourOrMoreYearsInThePast(null), true, 'null string should not be validated')
+  t.equal(isDateFourOrMoreYearsInThePast('12-12-1999'), true, 'invalid format string "12-12-1999" should not be validated')
   t.end()
 })
 


### PR DESCRIPTION
- Fix error where a child with a DOB exactly four years ago would pass validation for “three years old or younger”
- Update validator for “one month in the past” to follow the same format