### PR TITLE
HTBHF-1845 Renamed card-address url to address. Some renames in the c…

### DIFF
--- a/src/test/a11y/test-suite.js
+++ b/src/test/a11y/test-suite.js
@@ -19,7 +19,7 @@ const ENTER_DOB_URL = `${BASE_URL}/enter-dob`
 const DO_YOU_HAVE_CHILDREN_THREE_OR_YOUNGER_URL = `${BASE_URL}/do-you-have-children-three-or-younger`
 const CHILDREN_DOB_URL = `${BASE_URL}/children-dob`
 const ARE_YOU_PREGNANT_URL = `${BASE_URL}/are-you-pregnant`
-const CARD_ADDRESS_URL = `${BASE_URL}/card-address`
+const ADDRESS_URL = `${BASE_URL}/address`
 const PHONE_NUMBER_URL = `${BASE_URL}/phone-number`
 const EMAIL_ADDRESS_URL = `${BASE_URL}/email-address`
 const CHECK_URL = `${BASE_URL}/check`
@@ -82,8 +82,8 @@ const runEndToEndTest = async (results) => {
     results.push(await pa11y(ENTER_NINO_URL))
     await postFormData(ENTER_NINO_URL, { ...formData, nino: VALID_ELIGIBLE_NINO }, requestCookie)
 
-    results.push(await pa11y(CARD_ADDRESS_URL))
-    await postFormData(CARD_ADDRESS_URL, {
+    results.push(await pa11y(ADDRESS_URL))
+    await postFormData(ADDRESS_URL, {
       ...formData,
       'addressLine1': 'Flat B',
       'addressLine2': 'Baker Street',

--- a/src/test/acceptance/features/card-address.feature
+++ b/src/test/acceptance/features/card-address.feature
@@ -1,10 +1,11 @@
-Feature: Card address
+#TODO DW HTBHF-1845 rename filename (not doing in current pr as rename and content change will appear as new file)
+Feature: Address
   In order to apply for the HTBHF programme
   As a potential claimant
-  I want to enter the address to send the card to
+  I want to enter my address
 
   Background:
-    Given I have entered my details up to the card address page
+    Given I have entered my details up to the address page
 
   Scenario Outline: Enter a valid address with all fields entered
     When I enter an address with postcode <postcode>

--- a/src/test/acceptance/features/enter-nino.feature
+++ b/src/test/acceptance/features/enter-nino.feature
@@ -8,7 +8,7 @@ Feature: Enter National Insurance number
 
   Scenario: Enter in a valid national insurance number
     When I enter a valid national insurance number
-    Then I am shown the card address page
+    Then I am shown the address page
 
   Scenario: Do not enter in a "national insurance number"
     When I do not enter a national insurance number

--- a/src/test/acceptance/features/navigation.feature
+++ b/src/test/acceptance/features/navigation.feature
@@ -36,7 +36,7 @@ Feature: Application process navigation is controlled
     Then I am shown the <application page> page
     Examples:
       | application page    | navigation page |
-      | enter name          | card address    |
+      | enter name          | address         |
       | enter date of birth | check details   |
       | are you pregnant    | confirmation    |
 

--- a/src/test/common/page/card-address.js
+++ b/src/test/common/page/card-address.js
@@ -17,15 +17,16 @@ const TOWN_OR_CITY_ERROR_LINK_CSS = 'a[href="#town-or-city-error"]'
 const POSTCODE_ERROR_LINK_CSS = 'a[href="#postcode-error"]'
 
 /**
- * Page object for CardAddress page where the card card-address is entered.
+ * Page object for Address page where the address is entered.
  */
+// TODO DW HTBHF-1845 rename class and filename (not doing in current pr as rename and content change will appear as new file)
 class CardAddress extends SubmittablePage {
   getPath () {
-    return '/card-address'
+    return '/address'
   }
 
   getPageName () {
-    return 'card address'
+    return 'address'
   }
 
   async waitForPageLoad (lang = 'en') {

--- a/src/test/common/steps/card-address-steps.js
+++ b/src/test/common/steps/card-address-steps.js
@@ -42,7 +42,7 @@ When(/^I do not enter in any address fields$/, async function () {
   await enterCardAddressAndSubmit(BLANK_STRING, BLANK_STRING, BLANK_STRING, BLANK_STRING)
 })
 
-Then(/^I am shown the card address page$/, async function () {
+Then(/^I am shown the address page$/, async function () {
   await pages.cardAddress.waitForPageLoad()
 })
 

--- a/src/test/common/steps/navigation.js
+++ b/src/test/common/steps/navigation.js
@@ -23,7 +23,7 @@ const ENTER_NINO_PAGE = 'enter national insurance'
 const ENTER_DOB_PAGE = 'enter date of birth'
 const DO_YOU_HAVE_CHILDREN_THREE_OR_YOUNGER_PAGE = 'do you have children three or younger'
 const ARE_YOU_PREGNANT_PAGE = 'are you pregnant'
-const CARD_ADDRESS_PAGE = 'card address'
+const ADDRESS_PAGE = 'address'
 const PHONE_NUMBER_PAGE = 'phone number'
 const EMAIL_ADDRESS_PAGE = 'email address'
 const SEND_CODE_PAGE = 'send code'
@@ -79,7 +79,7 @@ const pageActions = [
     }
   },
   {
-    page: CARD_ADDRESS_PAGE,
+    page: ADDRESS_PAGE,
     action: async () => {
       await enterNinoAndSubmit()
       await pages.cardAddress.waitForPageLoad()

--- a/src/web/routes/application/card-address/card-address.js
+++ b/src/web/routes/application/card-address/card-address.js
@@ -28,8 +28,8 @@ const contentSummary = (req) => ({
   ])
 })
 
-const cardAddress = {
-  path: '/card-address',
+const address = {
+  path: '/address',
   next: () => '/phone-number',
   template: 'card-address',
   pageContent,
@@ -40,5 +40,5 @@ const cardAddress = {
 
 module.exports = {
   contentSummary,
-  cardAddress
+  address
 }

--- a/src/web/routes/application/card-address/card-address.test.js
+++ b/src/web/routes/application/card-address/card-address.test.js
@@ -14,7 +14,7 @@ const req = {
   }
 }
 
-test('Card address contentSummary() should return content summary in correct format', (t) => {
+test('Address contentSummary() should return content summary in correct format', (t) => {
   const result = contentSummary(req)
   const expected = {
     key: 'cardAddress.summaryKey',
@@ -25,7 +25,7 @@ test('Card address contentSummary() should return content summary in correct for
   t.end()
 })
 
-test('Card address contentSummary() should return content summary in correct format without address line 2', (t) => {
+test('Address contentSummary() should return content summary in correct format without address line 2', (t) => {
   const testReq = assocPath(['session', 'claim', 'addressLine2'], undefined, req)
   const result = contentSummary(testReq)
   const expected = {
@@ -37,7 +37,7 @@ test('Card address contentSummary() should return content summary in correct for
   t.end()
 })
 
-test('Card address contentSummary() should return content summary in correct format with address line 2 undefined', (t) => {
+test('Address contentSummary() should return content summary in correct format with address line 2 undefined', (t) => {
   const testReq = assocPath(['session', 'claim', 'addressLine2'], '', req)
   const result = contentSummary(testReq)
   const expected = {

--- a/src/web/routes/application/card-address/index.js
+++ b/src/web/routes/application/card-address/index.js
@@ -1,5 +1,5 @@
-const { cardAddress } = require('./card-address')
+const { address } = require('./card-address')
 
 module.exports = {
-  cardAddress
+  address
 }

--- a/src/web/routes/application/enter-nino/enter-nino.js
+++ b/src/web/routes/application/enter-nino/enter-nino.js
@@ -17,7 +17,7 @@ const contentSummary = (req) => ({
 
 const enterNino = {
   path: '/enter-nino',
-  next: () => '/card-address',
+  next: () => '/address',
   template: 'enter-nino',
   sanitize,
   validate,

--- a/src/web/routes/application/steps.js
+++ b/src/web/routes/application/steps.js
@@ -2,7 +2,7 @@ const { enterNino } = require('./enter-nino')
 const { enterName } = require('./enter-name')
 const { enterDob } = require('./enter-dob')
 const { areYouPregnant } = require('./are-you-pregnant')
-const { cardAddress } = require('./card-address')
+const { address } = require('./card-address')
 const { phoneNumber } = require('./phone-number')
 const { doYouLiveInScotland } = require('./do-you-live-in-scotland')
 const { iLiveInScotland } = require('./i-live-in-scotland')
@@ -21,7 +21,7 @@ const steps = [
   areYouPregnant,
   enterName,
   enterNino,
-  cardAddress,
+  address,
   phoneNumber,
   emailAddress,
   sendCode,


### PR DESCRIPTION
- The address page url has been changed from /card-address to /address.
- Along with this some parts of the code have removed their reference to the word card. 
- File renames will be done in their own PR with no content changes
- Future PRs will remove the use of the word card in other parts of the code
- The word card is in many places, so I've tried to get the best balance of PR size vs number of PRs.