### PR TITLE
HTBHF-1836 Refactor page objects to use InputField component

### DIFF
--- a/src/test/common/page/are-you-pregnant.js
+++ b/src/test/common/page/are-you-pregnant.js
@@ -2,6 +2,7 @@
 const webdriver = require('selenium-webdriver')
 
 const SubmittablePageWithRadioButtons = require('./submittable-page-with-radio-buttons')
+const InputField = require('./input-field')
 
 const PAGE_TITLES = {
   en: 'GOV.UK - Are you pregnant?',
@@ -12,14 +13,17 @@ const ARE_YOU_PREGNANT_ERROR_LINK_CSS = 'a[href="#are-you-pregnant-error"]'
 const ARE_YOU_PREGNANT_FIELD_ERROR_ID = 'areYouPregnant-error'
 const EXPECTED_DELIVERY_DATE_ERROR_LINK_CSS = 'a[href="#expected-delivery-date-error"]'
 const EXPECTED_DELIVERY_DATE_FIELD_ERROR_ID = 'expected-delivery-date-error'
-const EXPECTED_DELIVERY_DATE_DAY_INPUT_ID = 'expectedDeliveryDate-day'
-const EXPECTED_DELIVERY_DATE_MONTH_INPUT_ID = 'expectedDeliveryDate-month'
-const EXPECTED_DELIVERY_DATE_YEAR_INPUT_ID = 'expectedDeliveryDate-year'
 
 /**
  * Page object for the Are you pregnant? page.
  */
 class AreYouPregnant extends SubmittablePageWithRadioButtons {
+  constructor (driver) {
+    super(driver)
+    this.dayInputField = new InputField('expectedDeliveryDate-day', this)
+    this.monthInputField = new InputField('expectedDeliveryDate-month', this)
+    this.yearInputField = new InputField('expectedDeliveryDate-year', this)
+  }
   getPath () {
     return '/are-you-pregnant'
   }
@@ -33,9 +37,9 @@ class AreYouPregnant extends SubmittablePageWithRadioButtons {
   }
 
   async setExpectedDeliveryDate (day = 0, month = 0, year = 0) {
-    await this.enterExpectedDeliveryDateDay(day)
-    await this.enterExpectedDeliveryDateMonth(month)
-    await this.enterExpectedDeliveryDateYear(year)
+    await this.dayInputField.enterValue(day)
+    await this.monthInputField.enterValue(month)
+    await this.yearInputField.enterValue(year)
   }
 
   async enterExpectedDeliveryDate ({ incrementMonth = 0 } = {}) {
@@ -48,40 +52,12 @@ class AreYouPregnant extends SubmittablePageWithRadioButtons {
     await this.enterExpectedDeliveryDate({ incrementMonth: 6 })
   }
 
-  async enterTextInDeliveryDateFields () {
-    await this.setExpectedDeliveryDate('foo', 'bar', 'baz!')
-  }
-
   async enterExpectedDeliveryDateTooFarInThePast () {
     await this.enterExpectedDeliveryDate({ incrementMonth: -2 })
   }
 
   async enterExpectedDeliveryDateTooFarInTheFuture () {
     await this.enterExpectedDeliveryDate({ incrementMonth: 9 })
-  }
-
-  async getExpectedDeliveryDateDay () {
-    return this.getValueForInputWithId(EXPECTED_DELIVERY_DATE_DAY_INPUT_ID)
-  }
-
-  async enterExpectedDeliveryDateDay (day) {
-    await this.enterValueForInputWithId(EXPECTED_DELIVERY_DATE_DAY_INPUT_ID, day)
-  }
-
-  async getExpectedDeliveryDateMonth () {
-    return this.getValueForInputWithId(EXPECTED_DELIVERY_DATE_MONTH_INPUT_ID)
-  }
-
-  async enterExpectedDeliveryDateMonth (day) {
-    await this.enterValueForInputWithId(EXPECTED_DELIVERY_DATE_MONTH_INPUT_ID, day)
-  }
-
-  async getExpectedDeliveryDateYear () {
-    return this.getValueForInputWithId(EXPECTED_DELIVERY_DATE_YEAR_INPUT_ID)
-  }
-
-  async enterExpectedDeliveryDateYear (day) {
-    await this.enterValueForInputWithId(EXPECTED_DELIVERY_DATE_YEAR_INPUT_ID, day)
   }
 
   getAreYouPregnantFieldErrorId () {

--- a/src/test/common/page/card-address.js
+++ b/src/test/common/page/card-address.js
@@ -1,26 +1,25 @@
 'use strict'
 
 const SubmittablePage = require('./submittable-page')
+const InputField = require('./input-field')
 
 const PAGE_TITLES = {
   en: 'GOV.UK - What is your address?',
   cy: 'GOV.UK - Urna condimentum mattis?'
 }
 
-const POSTCODE_ERROR_ID = 'postcode-error'
-const ADDRESS_LINE_1_ERROR_ID = 'address-line-1-error'
-const ADDRESS_LINE_2_ERROR_ID = 'address-line-2-error'
-const TOWN_OR_CITY_ERROR_ID = 'town-or-city-error'
-const ADDRESS_LINE_1_ERROR_LINK_CSS = 'a[href="#address-line-1-error"]'
-const ADDRESS_LINE_2_ERROR_LINK_CSS = 'a[href="#address-line-2-error"]'
-const TOWN_OR_CITY_ERROR_LINK_CSS = 'a[href="#town-or-city-error"]'
-const POSTCODE_ERROR_LINK_CSS = 'a[href="#postcode-error"]'
-
 /**
  * Page object for Address page where the address is entered.
  */
 // TODO DW HTBHF-1845 rename class and filename (not doing in current pr as rename and content change will appear as new file)
 class CardAddress extends SubmittablePage {
+  constructor (driver) {
+    super(driver)
+    this.line1InputField = new InputField('address-line-1', this)
+    this.line2InputField = new InputField('address-line-2', this)
+    this.townOrCityInputField = new InputField('town-or-city', this)
+    this.postcodeInputField = new InputField('postcode', this)
+  }
   getPath () {
     return '/address'
   }
@@ -31,74 +30,6 @@ class CardAddress extends SubmittablePage {
 
   async waitForPageLoad (lang = 'en') {
     return super.waitForPageWithTitle(PAGE_TITLES[lang])
-  }
-
-  async getAddressLine1Field () {
-    return this.findById('address-line-1')
-  }
-
-  async getAddressLine2Field () {
-    return this.findById('address-line-2')
-  }
-
-  async getTownOrCityField () {
-    return this.findById('town-or-city')
-  }
-
-  async getPostcodeField () {
-    return this.findById('postcode')
-  }
-
-  async enterAddressLine1 (addressLine1) {
-    const addressLine1Field = await this.getAddressLine1Field()
-    return addressLine1Field.sendKeys(addressLine1)
-  }
-
-  async enterAddressLine2 (addressLine2) {
-    const addressLine2Field = await this.getAddressLine2Field()
-    return addressLine2Field.sendKeys(addressLine2)
-  }
-
-  async enterTownOrCity (townOrCity) {
-    const townOrCityField = await this.getTownOrCityField()
-    return townOrCityField.sendKeys(townOrCity)
-  }
-
-  async enterPostcode (postcode) {
-    const postcodeField = await this.getPostcodeField()
-    return postcodeField.sendKeys(postcode)
-  }
-
-  getPostcodeFieldErrorId () {
-    return POSTCODE_ERROR_ID
-  }
-
-  getAddressLine1FieldErrorId () {
-    return ADDRESS_LINE_1_ERROR_ID
-  }
-
-  getAddressLine2FieldErrorId () {
-    return ADDRESS_LINE_2_ERROR_ID
-  }
-
-  getTownOrCityFieldErrorId () {
-    return TOWN_OR_CITY_ERROR_ID
-  }
-
-  getAddressLine1ErrorLinkCss () {
-    return ADDRESS_LINE_1_ERROR_LINK_CSS
-  }
-
-  getAddressLine2ErrorLinkCss () {
-    return ADDRESS_LINE_2_ERROR_LINK_CSS
-  }
-
-  getTownOrCityErrorLinkCss () {
-    return TOWN_OR_CITY_ERROR_LINK_CSS
-  }
-
-  getPostcodeErrorLinkCss () {
-    return POSTCODE_ERROR_LINK_CSS
   }
 }
 

--- a/src/test/common/page/email-address.js
+++ b/src/test/common/page/email-address.js
@@ -1,19 +1,22 @@
 'use strict'
 
 const SubmittablePage = require('./submittable-page')
+const InputField = require('./input-field')
 
 const PAGE_TITLES = {
   en: 'GOV.UK - What’s your email address?',
   cy: 'GOV.UK - Urna condimentum mattis?'
 }
 
-const EMAIL_ADDRESS_FIELD_ERROR_ID = 'email-address-error'
-const EMAIL_ADDRESS_ERROR_LINK_CSS = 'a[href="#email-address-error"]'
-
 /**
  * Page object for Email address page where the email address is entered.
  */
 class EmailAddress extends SubmittablePage {
+  constructor (driver) {
+    super(driver)
+    this.inputField = new InputField('email-address', this)
+  }
+
   async waitForPageLoad (lang = 'en') {
     return super.waitForPageWithTitle(PAGE_TITLES[lang])
   }
@@ -24,33 +27,6 @@ class EmailAddress extends SubmittablePage {
 
   getPageName () {
     return 'email address'
-  }
-
-  async clearEmailAddress () {
-    const emailAddressField = await this.getEmailAddressField()
-    await emailAddressField.clear()
-  }
-
-  async enterEmailAddress (emailAddress) {
-    const emailAddressField = await this.getEmailAddressField()
-    await emailAddressField.sendKeys(emailAddress)
-  }
-
-  async getEmailAddressField () {
-    return this.findById('email-address')
-  }
-
-  async getEmailAddressValue () {
-    const emailAddress = await this.getEmailAddressField()
-    return emailAddress.getAttribute('value')
-  }
-
-  getEmailAddressFieldErrorId () {
-    return EMAIL_ADDRESS_FIELD_ERROR_ID
-  }
-
-  getEmailAddressLinkErrorCss () {
-    return EMAIL_ADDRESS_ERROR_LINK_CSS
   }
 }
 

--- a/src/test/common/page/enter-children-dob.js
+++ b/src/test/common/page/enter-children-dob.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const SubmittablePage = require('./submittable-page')
+const InputField = require('./input-field')
 
 const { dateLastYear } = require('../../common/dates')
 
@@ -55,19 +56,39 @@ class EnterChildrenDOB extends SubmittablePage {
   }
 
   async enterChildName (name) {
-    await this.enterValueForInputWithId(getNameInputIdForIndex(this.childIndex), name)
+    const inputField = this.getNameInputFieldForIndex(this.childIndex)
+    await inputField.enterValue(name)
   }
 
   async enterDay (day) {
-    await this.enterValueForInputWithId(getDayInputIdForIndex(this.childIndex), day)
+    const inputField = this.getDayInputFieldForIndex(this.childIndex)
+    await inputField.enterValue(day)
   }
 
   async enterMonth (month) {
-    await this.enterValueForInputWithId(getMonthInputIdForIndex(this.childIndex), month)
+    const inputField = this.getMonthInputFieldForIndex(this.childIndex)
+    await inputField.enterValue(month)
   }
 
   async enterYear (year) {
-    await this.enterValueForInputWithId(getYearInputIdForIndex(this.childIndex), year)
+    const inputField = this.getYearInputFieldForIndex(this.childIndex)
+    await inputField.enterValue(year)
+  }
+
+  getNameInputFieldForIndex (index) {
+    return new InputField(getNameInputIdForIndex(index), this)
+  }
+
+  getDayInputFieldForIndex (index) {
+    return new InputField(getDayInputIdForIndex(index), this)
+  }
+
+  getMonthInputFieldForIndex (index) {
+    return new InputField(getMonthInputIdForIndex(index), this)
+  }
+
+  getYearInputFieldForIndex (index) {
+    return new InputField(getYearInputIdForIndex(index), this)
   }
 
   async findAllRemoveChildButtons () {
@@ -80,27 +101,18 @@ class EnterChildrenDOB extends SubmittablePage {
   }
 
   async getChildDateOfBirthDay (childIndex) {
-    return this.getValueForInputWithId(getDayInputIdForIndex(childIndex))
+    const inputField = this.getDayInputFieldForIndex(childIndex)
+    return inputField.getValue()
   }
 
   async getChildDateOfBirthMonth (childIndex) {
-    return this.getValueForInputWithId(getMonthInputIdForIndex(childIndex))
+    const inputField = this.getMonthInputFieldForIndex(childIndex)
+    return inputField.getValue()
   }
 
   async getChildDateOfBirthYear (childIndex) {
-    return this.getValueForInputWithId(getYearInputIdForIndex(childIndex))
-  }
-
-  // TODO - Can this use InputField when there are a dynamic number of them?
-  async getValueForInputWithId (id) {
-    const elementWithId = await this.findById(id)
-    return elementWithId.getAttribute('value')
-  }
-
-  // TODO - Would like to get rid of this and use InputField
-  async enterValueForInputWithId (id, value) {
-    const input = await this.findById(id)
-    return input.sendKeys(value)
+    const inputField = this.getYearInputFieldForIndex(childIndex)
+    return inputField.getValue()
   }
 
   getChildDateOfBirthFieldErrorId (index) {
@@ -112,10 +124,13 @@ class EnterChildrenDOB extends SubmittablePage {
   }
 
   getChildNameFieldErrorId (index) {
-    return `childDob-name-${index}-error`
+    const inputField = this.getNameInputFieldForIndex(index)
+    return inputField.getInputErrorId()
   }
 
   getChildNameErrorLinkCss (index) {
+    // TODO Should the inconsistency in camel case vs kebab case in htbhf-date-input.njk be fixed, this will fail and
+    //  should be corrected to use this.getNameInputFieldForIndex(index) and getInputErrorLinkCss()
     return `a[href="#child-dob-name-${index}-error"]`
   }
 }

--- a/src/test/common/page/enter-children-dob.js
+++ b/src/test/common/page/enter-children-dob.js
@@ -91,6 +91,18 @@ class EnterChildrenDOB extends SubmittablePage {
     return this.getValueForInputWithId(getYearInputIdForIndex(childIndex))
   }
 
+  // TODO - Can this use InputField when there are a dynamic number of them?
+  async getValueForInputWithId (id) {
+    const elementWithId = await this.findById(id)
+    return elementWithId.getAttribute('value')
+  }
+
+  // TODO - Would like to get rid of this and use InputField
+  async enterValueForInputWithId (id, value) {
+    const input = await this.findById(id)
+    return input.sendKeys(value)
+  }
+
   getChildDateOfBirthFieldErrorId (index) {
     return `child-dob-${index}-error`
   }

--- a/src/test/common/page/enter-code.js
+++ b/src/test/common/page/enter-code.js
@@ -1,19 +1,22 @@
 'use strict'
 
 const SubmittablePage = require('./submittable-page')
+const InputField = require('./input-field')
 
 const PAGE_TITLES = {
   en: 'GOV.UK - Enter your code',
   cy: 'GOV.UK - Risus sed vulputate odio'
 }
 
-const CONFIRMATION_CODE_FIELD_ERROR_ID = 'confirmation-code-error'
-const CONFIRMATION_CODE_ERROR_LINK_CSS = 'a[href="#confirmation-code-error"]'
-
 /**
  * Page object for enter code page where the confirmation code sent to the claimant is entered.
  */
 class EnterCode extends SubmittablePage {
+  constructor (driver) {
+    super(driver)
+    this.inputField = new InputField('confirmation-code', this)
+  }
+
   async waitForPageLoad (lang = 'en') {
     return super.waitForPageWithTitle(PAGE_TITLES[lang])
   }
@@ -24,23 +27,6 @@ class EnterCode extends SubmittablePage {
 
   getPageName () {
     return 'enter code'
-  }
-
-  async enterConfirmationCode (confirmationCode) {
-    const confirmationCodeField = await this.getConfirmationCodeField()
-    await confirmationCodeField.sendKeys(confirmationCode)
-  }
-
-  async getConfirmationCodeField () {
-    return this.findById('confirmation-code')
-  }
-
-  getConfirmationCodeFieldErrorId () {
-    return CONFIRMATION_CODE_FIELD_ERROR_ID
-  }
-
-  getConfirmationCodeLinkErrorCss () {
-    return CONFIRMATION_CODE_ERROR_LINK_CSS
   }
 
   getRequestNewCodeLink () {

--- a/src/test/common/page/enter-dob.js
+++ b/src/test/common/page/enter-dob.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const SubmittablePage = require('./submittable-page')
+const InputField = require('./input-field')
 
 const PAGE_TITLES = {
   en: 'GOV.UK - What’s your date of birth?',
@@ -14,6 +15,12 @@ const DATE_OF_BIRTH_FIELD_ERROR_ID = 'date-of-birth-error'
  * Page object for the 'enter date of birth' page.
  */
 class EnterDOB extends SubmittablePage {
+  constructor (driver) {
+    super(driver)
+    this.dayInputField = new InputField('dateOfBirth-day', this)
+    this.monthInputField = new InputField('dateOfBirth-month', this)
+    this.yearInputField = new InputField('dateOfBirth-year', this)
+  }
   getPath () {
     return '/enter-dob'
   }
@@ -24,33 +31,6 @@ class EnterDOB extends SubmittablePage {
 
   async waitForPageLoad (lang = 'en') {
     return super.waitForPageWithTitle(PAGE_TITLES[lang])
-  }
-
-  async getDayField () {
-    return this.findById('dateOfBirth-day')
-  }
-
-  async getMonthField () {
-    return this.findById('dateOfBirth-month')
-  }
-
-  async getYearField () {
-    return this.findById('dateOfBirth-year')
-  }
-
-  async enterDay (day) {
-    const dayField = await this.getDayField()
-    return dayField.sendKeys(day)
-  }
-
-  async enterMonth (month) {
-    const monthField = await this.getMonthField()
-    return monthField.sendKeys(month)
-  }
-
-  async enterYear (year) {
-    const yearField = await this.getYearField()
-    return yearField.sendKeys(year)
   }
 
   getDateOfBirthFieldErrorId () {

--- a/src/test/common/page/enter-name.js
+++ b/src/test/common/page/enter-name.js
@@ -1,37 +1,21 @@
 'use strict'
 
 const SubmittablePage = require('./submittable-page')
+const InputField = require('./input-field')
 
 const PAGE_TITLES = {
   en: 'GOV.UK - What’s your name?',
   cy: 'GOV.UK - Vulputate dignissim suspendisse?'
 }
 
-const FIRST_NAME_ERROR_ID = 'first-name-error'
-const FIRST_NAME_ERROR_LINK_CSS = 'a[href="#first-name-error"]'
-const LAST_NAME_ERROR_ID = 'last-name-error'
-const LAST_NAME_ERROR_LINK_CSS = 'a[href="#last-name-error"]'
-const FIRST_NAME_INPUT_ID = 'first-name'
-const LAST_NAME_INPUT_ID = 'last-name'
-
 /**
  * Page object for EnterName page where the name is entered.
  */
 class EnterName extends SubmittablePage {
-  async getFirstNameValue () {
-    return this.getValueForInputWithId(FIRST_NAME_INPUT_ID)
-  }
-
-  async getLastNameValue () {
-    return this.getValueForInputWithId(LAST_NAME_INPUT_ID)
-  }
-
-  async enterFirstName (name) {
-    return this.enterValueForInputWithId(FIRST_NAME_INPUT_ID, name)
-  }
-
-  async enterLastName (name) {
-    return this.enterValueForInputWithId(LAST_NAME_INPUT_ID, name)
+  constructor (driver) {
+    super(driver)
+    this.firstNameInputField = new InputField('first-name', this)
+    this.lastNameInputField = new InputField('last-name', this)
   }
 
   getPath () {
@@ -44,22 +28,6 @@ class EnterName extends SubmittablePage {
 
   async waitForPageLoad (lang = 'en') {
     return super.waitForPageWithTitle(PAGE_TITLES[lang])
-  }
-
-  getFirstNameErrorFieldId () {
-    return FIRST_NAME_ERROR_ID
-  }
-
-  getFirstNameErrorLinkCss () {
-    return FIRST_NAME_ERROR_LINK_CSS
-  }
-
-  getLastNameErrorFieldId () {
-    return LAST_NAME_ERROR_ID
-  }
-
-  getLastNameErrorLinkCss () {
-    return LAST_NAME_ERROR_LINK_CSS
   }
 }
 

--- a/src/test/common/page/enter-nino.js
+++ b/src/test/common/page/enter-nino.js
@@ -1,20 +1,22 @@
 'use strict'
 
 const SubmittablePage = require('./submittable-page')
+const InputField = require('./input-field')
 
 const PAGE_TITLES = {
   en: 'GOV.UK - What’s your National Insurance number?',
   cy: 'GOV.UK - Excepteur sint occaecat cupidatat non proident?'
 }
 
-const NINO_FIELD_ERROR_ID = 'nino-error'
-const NINO_ERROR_LINK_CSS = 'a[href="#nino-error"]'
-const NINO_INPUT_ID = 'nino'
-
 /**
  * Page object for EnterNino page where the national insurance number is entered.
  */
 class EnterNino extends SubmittablePage {
+  constructor (driver) {
+    super(driver)
+    this.inputField = new InputField('nino', this)
+  }
+
   async waitForPageLoad (lang = 'en') {
     return super.waitForPageWithTitle(PAGE_TITLES[lang])
   }
@@ -25,22 +27,6 @@ class EnterNino extends SubmittablePage {
 
   getPageName () {
     return 'enter national insurance'
-  }
-
-  async enterNino (nino) {
-    await this.enterValueForInputWithId(NINO_INPUT_ID, nino)
-  }
-
-  async getNinoValue () {
-    return this.getValueForInputWithId(NINO_INPUT_ID)
-  }
-
-  getNinoFieldErrorId () {
-    return NINO_FIELD_ERROR_ID
-  }
-
-  getNinoLinkErrorCss () {
-    return NINO_ERROR_LINK_CSS
   }
 }
 

--- a/src/test/common/page/input-field.js
+++ b/src/test/common/page/input-field.js
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+'use strict'
+
+/**
+ * Class to represent use of and access to an input field identified by the id provided on construction.
+ */
+class InputField {
+  constructor (inputFieldId, page) {
+    this.inputFieldId = inputFieldId
+    this.page = page
+  }
+
+  async getValue () {
+    const input = await this.getElement()
+    return input.getAttribute('value')
+  }
+
+  async enterValue (value) {
+    const input = await this.getElement()
+    return input.sendKeys(value)
+  }
+
+  async clearValue () {
+    const input = await this.getElement()
+    return input.clear()
+  }
+
+  async getElement () {
+    return this.page.findById(this.inputFieldId)
+  }
+
+  getInputErrorId () {
+    return `${this.inputFieldId}-error`
+  }
+
+  getInputErrorLinkCss () {
+    return `a[href="#${this.inputFieldId}-error"]`
+  }
+}
+
+module.exports = InputField

--- a/src/test/common/page/page.js
+++ b/src/test/common/page/page.js
@@ -122,11 +122,13 @@ class Page {
     }
   }
 
+  // TODO - Remove this when done, we MUST get rid of this
   async getValueForInputWithId (id) {
     const elementWithId = await this.findById(id)
     return elementWithId.getAttribute('value')
   }
 
+  // TODO - Remove this when done, we MUST get rid of this
   async enterValueForInputWithId (id, value) {
     const input = await this.findById(id)
     return input.sendKeys(value)

--- a/src/test/common/page/page.js
+++ b/src/test/common/page/page.js
@@ -122,18 +122,6 @@ class Page {
     }
   }
 
-  // TODO - Remove this when done, we MUST get rid of this
-  async getValueForInputWithId (id) {
-    const elementWithId = await this.findById(id)
-    return elementWithId.getAttribute('value')
-  }
-
-  // TODO - Remove this when done, we MUST get rid of this
-  async enterValueForInputWithId (id, value) {
-    const input = await this.findById(id)
-    return input.sendKeys(value)
-  }
-
   async findH1 () {
     return this.findByCSS('h1')
   }

--- a/src/test/common/page/phone-number.js
+++ b/src/test/common/page/phone-number.js
@@ -1,20 +1,21 @@
 'use strict'
 
 const SubmittablePage = require('./submittable-page')
+const InputField = require('./input-field')
 
 const PAGE_TITLES = {
   en: 'GOV.UK - What’s your mobile telephone number?',
   cy: 'GOV.UK - Urna condimentum mattis?'
 }
 
-const PHONE_NUMBER_FIELD_ERROR_ID = 'phone-number-error'
-const PHONE_NUMBER_ERROR_LINK_CSS = 'a[href="#phone-number-error"]'
-const PHONE_NUMBER_INPUT_ID = 'phone-number'
-
 /**
  * Page object for PhoneNumber page where the phone number is entered.
  */
 class PhoneNumber extends SubmittablePage {
+  constructor (driver) {
+    super(driver)
+    this.inputField = new InputField('phone-number', this)
+  }
   async waitForPageLoad (lang = 'en') {
     return super.waitForPageWithTitle(PAGE_TITLES[lang])
   }
@@ -25,32 +26,6 @@ class PhoneNumber extends SubmittablePage {
 
   getPageName () {
     return 'phone number'
-  }
-
-  // TODO MS: HTBHF-1836 Refactor this and clearPhoneNumber into InputField Class
-  async getPhoneNumberField () {
-    return this.findById('phone-number')
-  }
-
-  async clearPhoneNumber () {
-    const phoneNumberField = await this.getPhoneNumberField()
-    await phoneNumberField.clear()
-  }
-
-  async enterPhoneNumber (phoneNumber) {
-    await this.enterValueForInputWithId(PHONE_NUMBER_INPUT_ID, phoneNumber)
-  }
-
-  async getPhoneNumberValue () {
-    return this.getValueForInputWithId(PHONE_NUMBER_INPUT_ID)
-  }
-
-  getPhoneNumberFieldErrorId () {
-    return PHONE_NUMBER_FIELD_ERROR_ID
-  }
-
-  getPhoneNumberLinkErrorCss () {
-    return PHONE_NUMBER_ERROR_LINK_CSS
   }
 }
 

--- a/src/test/common/steps/are-you-pregnant.js
+++ b/src/test/common/steps/are-you-pregnant.js
@@ -20,7 +20,7 @@ When(/^I enter a valid expected delivery date$/, async function () {
 })
 
 When(/^I enter text in the expected delivery date fields$/, async function () {
-  await pages.areYouPregnant.enterTextInDeliveryDateFields()
+  await pages.areYouPregnant.setExpectedDeliveryDate('foo', 'bar', 'baz!')
 })
 
 When(/^I enter my expected delivery date too far in the past$/, async function () {
@@ -58,13 +58,13 @@ Then(/^expected date of delivery instructional text is displayed$/, async functi
 
 Then(/^no values are present in the expected delivery date fields$/, async function () {
   try {
-    const dayValue = await pages.areYouPregnant.getExpectedDeliveryDateDay()
+    const dayValue = await pages.areYouPregnant.dayInputField.getValue()
     assert(dayValue.length === 0, 'expected delivery date day to be empty')
 
-    const monthValue = await pages.areYouPregnant.getExpectedDeliveryDateMonth()
+    const monthValue = await pages.areYouPregnant.monthInputField.getValue()
     assert(monthValue.length === 0, 'expected delivery date month to be empty')
 
-    const yearValue = await pages.areYouPregnant.getExpectedDeliveryDateYear()
+    const yearValue = await pages.areYouPregnant.yearInputField.getValue()
     assert(yearValue.length === 0, 'expected delivery date year to be empty')
   } catch (error) {
     assert.fail(`Unexpected error caught trying to assert no values are present in the expected delivery date fields - ${error}`)

--- a/src/test/common/steps/card-address-steps.js
+++ b/src/test/common/steps/card-address-steps.js
@@ -85,28 +85,28 @@ Then(/^I am informed that I need to enter an address on the 'address line 1', 'a
 
 const assertAddressLine1ErrorFieldAndLink = async (expectedErrorMessage) => {
   await assertFieldErrorAndLinkTextPresentAndCorrect(
-    pages.cardAddress.getAddressLine1FieldErrorId(),
-    pages.cardAddress.getAddressLine1ErrorLinkCss(),
+    pages.cardAddress.line1InputField.getInputErrorId(),
+    pages.cardAddress.line1InputField.getInputErrorLinkCss(),
     expectedErrorMessage)
 }
 
 const assertAddressLine2ErrorFieldAndLink = async (expectedErrorMessage) => {
   await assertFieldErrorAndLinkTextPresentAndCorrect(
-    pages.cardAddress.getAddressLine2FieldErrorId(),
-    pages.cardAddress.getAddressLine2ErrorLinkCss(),
+    pages.cardAddress.line2InputField.getInputErrorId(),
+    pages.cardAddress.line2InputField.getInputErrorLinkCss(),
     expectedErrorMessage)
 }
 
 const assertTownOrCityErrorFieldAndLink = async (expectedErrorMessage) => {
   await assertFieldErrorAndLinkTextPresentAndCorrect(
-    pages.cardAddress.getTownOrCityFieldErrorId(),
-    pages.cardAddress.getTownOrCityErrorLinkCss(),
+    pages.cardAddress.townOrCityInputField.getInputErrorId(),
+    pages.cardAddress.townOrCityInputField.getInputErrorLinkCss(),
     expectedErrorMessage)
 }
 
 const assertPostcodeErrorFieldAndLink = async (expectedErrorMessage) => {
   await assertFieldErrorAndLinkTextPresentAndCorrect(
-    pages.cardAddress.getPostcodeFieldErrorId(),
-    pages.cardAddress.getPostcodeErrorLinkCss(),
+    pages.cardAddress.postcodeInputField.getInputErrorId(),
+    pages.cardAddress.postcodeInputField.getInputErrorLinkCss(),
     expectedErrorMessage)
 }

--- a/src/test/common/steps/common-steps.js
+++ b/src/test/common/steps/common-steps.js
@@ -40,8 +40,8 @@ async function enterDoYouLiveInScotlandNoAndSubmit () {
 
 async function enterNameAndSubmit (firstName = FIRST_NAME, lastName = LAST_NAME) {
   try {
-    await pages.enterName.enterFirstName(firstName)
-    await pages.enterName.enterLastName(lastName)
+    await pages.enterName.firstNameInputField.enterValue(firstName)
+    await pages.enterName.lastNameInputField.enterValue(lastName)
     await pages.enterName.submitForm()
   } catch (error) {
     assert.fail(`Unexpected error caught trying to enter the name and submit the page - ${error}`)
@@ -50,7 +50,7 @@ async function enterNameAndSubmit (firstName = FIRST_NAME, lastName = LAST_NAME)
 
 async function enterNinoAndSubmit (nino = VALID_ELIGIBLE_NINO) {
   try {
-    await pages.enterNino.enterNino(nino)
+    await pages.enterNino.inputField.enterValue(nino)
     await pages.enterNino.submitForm()
   } catch (error) {
     assert.fail(`Unexpected error caught trying to enter the national insurance number and submit the page - ${error}`)
@@ -101,7 +101,7 @@ async function enterCardAddressAndSubmit (addressLine1 = ADDRESS_LINE_1, address
 
 async function enterPhoneNumberAndSubmit (phoneNumber = PHONE_NUMBER) {
   try {
-    await pages.phoneNumber.enterPhoneNumber(phoneNumber)
+    await pages.phoneNumber.inputField.enterValue(phoneNumber)
     await pages.phoneNumber.submitForm()
   } catch (error) {
     assert.fail(`Unexpected error caught trying to enter phone number and submit the page - ${error}`)
@@ -110,7 +110,7 @@ async function enterPhoneNumberAndSubmit (phoneNumber = PHONE_NUMBER) {
 
 async function enterEmailAddressAndSubmit (emailAddress = EMAIL_ADDRESS) {
   try {
-    await pages.emailAddress.enterEmailAddress(emailAddress)
+    await pages.emailAddress.inputField.enterValue(emailAddress)
     await pages.emailAddress.submitForm()
   } catch (error) {
     assert.fail(`Unexpected error caught trying to enter phone number and submit the page - ${error}`)
@@ -189,7 +189,7 @@ async function enterConfirmationCodeAndSubmit (confirmationCode) {
     const sessionCode = await getConfirmationCodeForSession(confirmationCode)
     // some browsers may have visited a different page in order to get the session id, so we must reload the enter code page
     await pages.enterCode.openDirect(pages.url)
-    await pages.enterCode.enterConfirmationCode(sessionCode)
+    await pages.enterCode.inputField.enterValue(sessionCode)
     await pages.enterCode.submitForm()
   } catch (error) {
     assert.fail(`Unexpected error caught trying to enter confirmation code for 'Enter code' and submit the page - ${error}`)

--- a/src/test/common/steps/common-steps.js
+++ b/src/test/common/steps/common-steps.js
@@ -59,9 +59,9 @@ async function enterNinoAndSubmit (nino = VALID_ELIGIBLE_NINO) {
 
 async function enterDateOfBirthAndSubmit (day = DAY, month = MONTH, year = YEAR) {
   try {
-    await pages.enterDOB.enterDay(day)
-    await pages.enterDOB.enterMonth(month)
-    await pages.enterDOB.enterYear(year)
+    await pages.enterDOB.dayInputField.enterValue(day)
+    await pages.enterDOB.monthInputField.enterValue(month)
+    await pages.enterDOB.yearInputField.enterValue(year)
     await pages.enterDOB.submitForm()
   } catch (error) {
     assert.fail(`Unexpected error caught trying to enter the date of birth and submit the page - ${error}`)
@@ -89,10 +89,10 @@ async function selectNoOnPregnancyPage () {
 
 async function enterCardAddressAndSubmit (addressLine1 = ADDRESS_LINE_1, addressLine2 = ADDRESS_LINE_2, townOrCity = TOWN, postcode = POSTCODE) {
   try {
-    await pages.cardAddress.enterAddressLine1(addressLine1)
-    await pages.cardAddress.enterAddressLine2(addressLine2)
-    await pages.cardAddress.enterTownOrCity(townOrCity)
-    await pages.cardAddress.enterPostcode(postcode)
+    await pages.cardAddress.line1InputField.enterValue(addressLine1)
+    await pages.cardAddress.line2InputField.enterValue(addressLine2)
+    await pages.cardAddress.townOrCityInputField.enterValue(townOrCity)
+    await pages.cardAddress.postcodeInputField.enterValue(postcode)
     await pages.cardAddress.submitForm()
   } catch (error) {
     assert.fail(`Unexpected error caught trying to enter card address and submit the page - ${error}`)

--- a/src/test/common/steps/confirmation-code-navigation-steps.js
+++ b/src/test/common/steps/confirmation-code-navigation-steps.js
@@ -32,13 +32,13 @@ When(/^I complete the application with valid details, selecting to receive my co
 
 When(/^I enter in a new phone number$/, async function () {
   // the phone number text box will contain the previously entered number, need to clear it before entering new number
-  await pages.phoneNumber.clearPhoneNumber()
+  await pages.phoneNumber.inputField.clearValue()
   await enterPhoneNumberAndSubmit(PHONE_NUMBER_2)
 })
 
 When(/^I enter in a new email address/, async function () {
   // the email address text box will contain the previously entered email address, need to clear it before entering new email address
-  await pages.emailAddress.clearEmailAddress()
+  await pages.emailAddress.inputField.clearValue()
   await enterEmailAddressAndSubmit(EMAIL_ADDRESS_2)
 })
 

--- a/src/test/common/steps/email-address-steps.js
+++ b/src/test/common/steps/email-address-steps.js
@@ -32,13 +32,13 @@ Then(/^I am shown the email address page$/, async function () {
 
 Then(/^I am informed that I must enter in a valid email address$/, async function () {
   await assertFieldErrorAndLinkTextPresentAndCorrect(
-    pages.emailAddress.getEmailAddressFieldErrorId(),
-    pages.emailAddress.getEmailAddressLinkErrorCss(),
+    pages.emailAddress.inputField.getInputErrorId(),
+    pages.emailAddress.inputField.getInputErrorLinkCss(),
     'Enter an email address in the correct format, like name@example.com')
 })
 
 Then(/^I see the email address (.*) in the textbox$/, async function (emailAddress) {
-  const enteredEmailAddress = await pages.emailAddress.getEmailAddressValue()
+  const enteredEmailAddress = await pages.emailAddress.inputField.getValue()
   expect(enteredEmailAddress).to.be.equal(emailAddress)
 })
 

--- a/src/test/common/steps/enter-code-steps.js
+++ b/src/test/common/steps/enter-code-steps.js
@@ -25,8 +25,8 @@ Then(/^I am shown the enter code page$/, async function () {
 
 Then(/^I am informed that I must enter in the code that was sent to me$/, async function () {
   await assertFieldErrorAndLinkTextPresentAndCorrect(
-    pages.enterCode.getConfirmationCodeFieldErrorId(),
-    pages.enterCode.getConfirmationCodeLinkErrorCss(),
+    pages.enterCode.inputField.getInputErrorId(),
+    pages.enterCode.inputField.getInputErrorLinkCss(),
     'Enter the 6 digit code we sent you')
 })
 

--- a/src/test/common/steps/enter-name-steps.js
+++ b/src/test/common/steps/enter-name-steps.js
@@ -32,12 +32,12 @@ Then('I am informed that the first name is too long', async function () {
 })
 
 Then(/^I see the invalid first name I entered in the textbox$/, async function () {
-  const enteredFirstName = await pages.enterName.getFirstNameValue()
+  const enteredFirstName = await pages.enterName.firstNameInputField.getValue()
   expect(enteredFirstName).to.be.equal(LONG_STRING)
 })
 
 Then(/^I see the last name I entered in the textbox$/, async function () {
-  const enteredLastName = await pages.enterName.getLastNameValue()
+  const enteredLastName = await pages.enterName.lastNameInputField.getValue()
   expect(enteredLastName).to.be.equal(LONG_STRING)
 })
 
@@ -62,14 +62,14 @@ Then(/^I am shown the enter name page$/, async function () {
 
 async function assertFirstNameErrorFieldAndLink (expectedErrorMessage) {
   await assertFieldErrorAndLinkTextPresentAndCorrect(
-    pages.enterName.getFirstNameErrorFieldId(),
-    pages.enterName.getFirstNameErrorLinkCss(),
+    pages.enterName.firstNameInputField.getInputErrorId(),
+    pages.enterName.firstNameInputField.getInputErrorLinkCss(),
     expectedErrorMessage)
 }
 
 async function assertLastNameErrorFieldAndLink (expectedErrorMessage) {
   await assertFieldErrorAndLinkTextPresentAndCorrect(
-    pages.enterName.getLastNameErrorFieldId(),
-    pages.enterName.getLastNameErrorLinkCss(),
+    pages.enterName.lastNameInputField.getInputErrorId(),
+    pages.enterName.lastNameInputField.getInputErrorLinkCss(),
     expectedErrorMessage)
 }

--- a/src/test/common/steps/enter-nino-steps.js
+++ b/src/test/common/steps/enter-nino-steps.js
@@ -19,13 +19,13 @@ When(/^I do not enter a national insurance number$/, async function () {
 
 Then(/^I am informed that the national insurance number is in the wrong format$/, async function () {
   await assertFieldErrorAndLinkTextPresentAndCorrect(
-    pages.enterNino.getNinoFieldErrorId(),
-    pages.enterNino.getNinoLinkErrorCss(),
+    pages.enterNino.inputField.getInputErrorId(),
+    pages.enterNino.inputField.getInputErrorLinkCss(),
     'Enter a National Insurance number in the correct format')
 })
 
 Then(/^I see the value (.*) in the textbox$/, async function (nino) {
-  const enteredNino = await pages.enterNino.getNinoValue()
+  const enteredNino = await pages.enterNino.inputField.getValue()
   expect(enteredNino).to.be.equal(nino)
 })
 

--- a/src/test/common/steps/phone-number-steps.js
+++ b/src/test/common/steps/phone-number-steps.js
@@ -23,13 +23,13 @@ Then(/^I am informed that I must enter in a valid phone number$/, async function
 })
 
 Then(/^I see the value (.*) in the phone number textbox$/, async function (phoneNumber) {
-  const enteredPhoneNumber = await pages.phoneNumber.getPhoneNumberValue()
+  const enteredPhoneNumber = await pages.phoneNumber.inputField.getValue()
   expect(enteredPhoneNumber).to.be.equal(phoneNumber)
 })
 
 async function assertPhoneNumberErrorFieldAndLink (expectedErrorMessage) {
   await assertFieldErrorAndLinkTextPresentAndCorrect(
-    pages.phoneNumber.getPhoneNumberFieldErrorId(),
-    pages.phoneNumber.getPhoneNumberLinkErrorCss(),
+    pages.phoneNumber.inputField.getInputErrorId(),
+    pages.phoneNumber.inputField.getInputErrorLinkCss(),
     expectedErrorMessage)
 }


### PR DESCRIPTION
- All Page objects for a page which contains an input field have been refactored to use the InputField component.
- All InputFields objects are created on construction of the page object for reuse, the only exception where this is the Enter Child DOB page where the dynamic nature of the input fields means they need to be created each time before use.
- A TODO has been added to the Enter Child DOB Page object for when we fix the naming inconsistency within `htbhf-date-input.njk`, we'll also have to fix the name of the error CSS to match there.