### PR TITLE
HTBHF-1844 Added new form description macro. Updated content for phon…

### DIFF
--- a/src/web/routes/application/phone-number/phone-number.js
+++ b/src/web/routes/application/phone-number/phone-number.js
@@ -6,7 +6,7 @@ const { handleConfirmationCodeReset, getConfirmationCodeChannel } = require('../
 const pageContent = ({ translate }) => ({
   title: translate('phoneNumber.title'),
   heading: translate('phoneNumber.heading'),
-  hint: translate('phoneNumber.hint'),
+  formDescription: translate('phoneNumber.formDescription'),
   phoneNumberLabel: translate('phoneNumber.phoneNumberLabel'),
   buttonText: translate('buttons:continue'),
   explanation: translate('phoneNumber.explanation')

--- a/src/web/server/locales/cy/common.json
+++ b/src/web/server/locales/cy/common.json
@@ -68,7 +68,7 @@
   "phoneNumber": {
     "title": "Urna condimentum mattis?",
     "heading": "Urna condimentum mattis?",
-    "hint": "Ullamcorper malesuada proin libero risus 2 non 2",
+    "formDescription": "Ullamcorper malesuada proin libero risus (DWP ro HMRC).",
     "phoneNumberLabel": "Penatibus",
     "summaryKey": "Risus sed vulputate",
     "explanation": "Consectetur adipiscing elit Sceela"

--- a/src/web/server/locales/en/common.json
+++ b/src/web/server/locales/en/common.json
@@ -68,7 +68,7 @@
   "phoneNumber": {
     "title": "What’s your mobile telephone number?",
     "heading": "What’s your mobile telephone number?",
-    "hint": "This must be the same number you use for any benefits you claim.",
+    "formDescription": "If you claim any benefits you must use the same mobile number registered with the benefits agency (DWP or HMRC).",
     "phoneNumberLabel": "UK mobile number",
     "summaryKey": "Mobile telephone number",
     "explanation": "We need this to prevent fraud and to contact you about your application if necessary."

--- a/src/web/views/macros/htbhf-form-description.njk
+++ b/src/web/views/macros/htbhf-form-description.njk
@@ -1,0 +1,5 @@
+{% macro htbhfFormDescription(formDescription) %}
+
+<p class="govuk-body govuk-!-padding-bottom-4">{{formDescription}}</p>
+
+{% endmacro %}

--- a/src/web/views/phone-number.njk
+++ b/src/web/views/phone-number.njk
@@ -4,6 +4,7 @@
 {% from "details/macro.njk" import govukDetails %}
 {% from "hint/macro.njk" import govukHint %}
 {% from "inset-text/macro.njk" import govukInsetText %}
+{% from "macros/htbhf-form-description.njk" import htbhfFormDescription %}
 
 {% block formContent %}
 
@@ -15,9 +16,7 @@
     }
   }) %}
 
-    {{ govukHint({
-      text: hint
-    }) }}
+    {{ htbhfFormDescription(formDescription) }}
 
     {{ govukInput({
       label: {


### PR DESCRIPTION
- Added new macro for form description. (Black text underneath H1 text)
- Phone number page is now using a form description instead of a hint (grey text).
- Updated content to match prototype.