### PR TITLE
HTBHF-1853 move row data transformations to separate file

### DIFF
--- a/src/web/routes/application/check/get-row-data.js
+++ b/src/web/routes/application/check/get-row-data.js
@@ -1,0 +1,24 @@
+const { pipe, map, filter, flatten, isNil } = require('ramda')
+const { notIsNil } = require('../../../../common/predicates')
+
+const combinePathWithRow = (path) => (row) => ({
+  ...row,
+  path
+})
+
+const getFlattenedRowData = (req) => pipe(map(getRowData(req)), filter(notIsNil), flatten)
+
+const getRowData = (req) => (step) => {
+  if (isNil(step.contentSummary)) {
+    return null
+  }
+  const result = step.contentSummary(req)
+  const applyPathToRow = combinePathWithRow(step.path)
+
+  return Array.isArray(result) ? result.map(applyPathToRow) : applyPathToRow(result)
+}
+
+module.exports = {
+  getRowData,
+  getFlattenedRowData
+}

--- a/src/web/routes/application/check/get-row-data.test.js
+++ b/src/web/routes/application/check/get-row-data.test.js
@@ -1,0 +1,69 @@
+const test = require('tape')
+const { getRowData, getFlattenedRowData } = require('./get-row-data')
+
+test('getRowData should return an object combining path with row data', (t) => {
+  const step = {
+    contentSummary: () => ({ key: 'myKey', value: 'myValue' }),
+    path: 'mypath'
+  }
+  const req = {}
+  t.deepEqual(
+    getRowData(req)(step),
+    { key: 'myKey', value: 'myValue', path: 'mypath' },
+    'should match expected row content'
+  )
+  t.end()
+})
+
+test('getRowData should return an array of objects combining path with row data', (t) => {
+  const step = {
+    contentSummary: () => ([{ key: 'myKey', value: 'myValue' }, { key: 'myKey2', value: 'myValue2' }]),
+    path: 'mypath'
+  }
+  const req = {}
+  t.deepEqual(
+    getRowData(req)(step),
+    [{ key: 'myKey', value: 'myValue', path: 'mypath' }, { key: 'myKey2', value: 'myValue2', path: 'mypath' }],
+    'should match expected content for multiple rows'
+  )
+  t.end()
+})
+
+test('getFlattenedRowData returns flattened row data', (t) => {
+  const step1 = {
+    contentSummary: () => ([{ keyA: 'myKey1', valueA: 'myValue1' }, { keyB: 'myKey3', valueB: 'myValue3' }]),
+    path: 'mypath1'
+  }
+  const step2 = {
+    contentSummary: () => ({ key2: 'myKey2', value: 'myValue2' }),
+    path: 'mypath2'
+  }
+  const req = {}
+  const steps = [step1, step2]
+
+  const result = getFlattenedRowData(req)(steps)
+
+  t.deepEqual(result,
+    [{ keyA: 'myKey1', valueA: 'myValue1', path: 'mypath1' }, { keyB: 'myKey3', valueB: 'myValue3', path: 'mypath1' }, { key2: 'myKey2', value: 'myValue2', path: 'mypath2' }],
+    'should flatten step content summary')
+  t.end()
+})
+
+test('getFlattenedRowData returns flattened row data with step with empty content removed', (t) => {
+  const step1 = {
+    contentSummary: () => ({ key1: 'myKey1', value1: 'myValue1' }),
+    path: 'mypath1'
+  }
+  const step2 = {
+    path: 'mypath2'
+  }
+  const req = {}
+  const steps = [step1, step2]
+
+  const result = getFlattenedRowData(req)(steps)
+
+  t.deepEqual(result,
+    [{ key1: 'myKey1', value1: 'myValue1', path: 'mypath1' }],
+    'should flatten step with content summary and remove step without content summary')
+  t.end()
+})

--- a/src/web/routes/application/check/get.js
+++ b/src/web/routes/application/check/get.js
@@ -1,7 +1,6 @@
-const { pipe, map, filter, flatten, isNil } = require('ramda')
-const { notIsNil } = require('../../../../common/predicates')
 const { stateMachine, states, actions } = require('../common/state-machine')
 const { getPreviousPath } = require('../common/get-previous-path')
+const { getFlattenedRowData } = require('./get-row-data')
 
 const pageContent = ({ translate }) => ({
   title: translate('check.title'),
@@ -13,23 +12,6 @@ const pageContent = ({ translate }) => ({
   aboutYou: translate('check.aboutYou'),
   aboutYourChildren: translate('check.aboutYourChildren')
 })
-
-const combinePathWithRow = (path) => (row) => ({
-  ...row,
-  path
-})
-
-const getFlattenedRowData = (req) => pipe(map(getRowData(req)), filter(notIsNil), flatten)
-
-const getRowData = (req) => (step) => {
-  if (isNil(step.contentSummary)) {
-    return null
-  }
-  const result = step.contentSummary(req)
-  const applyPathToRow = combinePathWithRow(step.path)
-
-  return Array.isArray(result) ? result.map(applyPathToRow) : applyPathToRow(result)
-}
 
 // a step is navigable if it hasn't defined an isNavigable function.
 const stepIsNavigable = (step, session) => !step.hasOwnProperty('isNavigable') || step.isNavigable(session)
@@ -57,7 +39,5 @@ const getCheck = (steps) => (req, res) => {
 
 module.exports = {
   getCheck,
-  getRowData,
-  getFlattenedRowData,
   getLastNavigablePath
 }

--- a/src/web/routes/application/check/get.test.js
+++ b/src/web/routes/application/check/get.test.js
@@ -2,8 +2,6 @@ const test = require('tape')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
-const { getRowData, getFlattenedRowData } = require('./get')
-
 const getPreviousPath = sinon.spy()
 const { getLastNavigablePath } = proxyquire('./get', { '../common/get-previous-path': { getPreviousPath } })
 
@@ -34,72 +32,5 @@ test('getLastNavigablePath calls getPreviousPath if last step isNavigable return
   getLastNavigablePath(steps, session)
 
   t.equal(getPreviousPath.called, true)
-  t.end()
-})
-
-test('getRowData should return an object combining path with row data', (t) => {
-  const step = {
-    contentSummary: () => ({ key: 'myKey', value: 'myValue' }),
-    path: 'mypath'
-  }
-  const req = {}
-  t.deepEqual(
-    getRowData(req)(step),
-    { key: 'myKey', value: 'myValue', path: 'mypath' },
-    'should match expected row content'
-  )
-  t.end()
-})
-
-test('getRowData should return an array of objects combining path with row data', (t) => {
-  const step = {
-    contentSummary: () => ([{ key: 'myKey', value: 'myValue' }, { key: 'myKey2', value: 'myValue2' }]),
-    path: 'mypath'
-  }
-  const req = {}
-  t.deepEqual(
-    getRowData(req)(step),
-    [{ key: 'myKey', value: 'myValue', path: 'mypath' }, { key: 'myKey2', value: 'myValue2', path: 'mypath' }],
-    'should match expected content for multiple rows'
-  )
-  t.end()
-})
-
-test('getFlattenedRowData returns flattened row data', (t) => {
-  const step1 = {
-    contentSummary: () => ([{ keyA: 'myKey1', valueA: 'myValue1' }, { keyB: 'myKey3', valueB: 'myValue3' }]),
-    path: 'mypath1'
-  }
-  const step2 = {
-    contentSummary: () => ({ key2: 'myKey2', value: 'myValue2' }),
-    path: 'mypath2'
-  }
-  const req = {}
-  const steps = [step1, step2]
-
-  const result = getFlattenedRowData(req)(steps)
-
-  t.deepEqual(result,
-    [{ keyA: 'myKey1', valueA: 'myValue1', path: 'mypath1' }, { keyB: 'myKey3', valueB: 'myValue3', path: 'mypath1' }, { key2: 'myKey2', value: 'myValue2', path: 'mypath2' }],
-    'should flatten step content summary')
-  t.end()
-})
-
-test('getFlattenedRowData returns flattened row data with step with empty content removed', (t) => {
-  const step1 = {
-    contentSummary: () => ({ key1: 'myKey1', value1: 'myValue1' }),
-    path: 'mypath1'
-  }
-  const step2 = {
-    path: 'mypath2'
-  }
-  const req = {}
-  const steps = [step1, step2]
-
-  const result = getFlattenedRowData(req)(steps)
-
-  t.deepEqual(result,
-    [{ key1: 'myKey1', value1: 'myValue1', path: 'mypath1' }],
-    'should flatten step with content summary and remove step without content summary')
   t.end()
 })


### PR DESCRIPTION
Displaying check details for “About your children” will extend the functions for generating row data on the “check details” page. This PR moves these data transformation functions into a separate file in preparation for extending / refactoring.