### PR TITLE
HTBHF-1755 Disable language detection so that English is the only supported language.

### DIFF
--- a/src/test/acceptance/features/internationalisation.feature
+++ b/src/test/acceptance/features/internationalisation.feature
@@ -1,3 +1,5 @@
+# TODO - Currently all translations are disabled and English is the default, remove @ignore when reinstated
+@ignore
 Feature: Translations
   In order to apply for the Apply for Healthy Start programme
   As a potential claimant

--- a/src/test/common/steps/overview-steps.js
+++ b/src/test/common/steps/overview-steps.js
@@ -33,8 +33,10 @@ Then(/^my session has been destroyed$/, async function () {
 
 Then(/^my session has not been destroyed$/, async function () {
   const pageSessionId = pages.overview.sessionId
-  const langCookie = await pages.overview.getLangCookie()
-  expect(langCookie).not.to.be.equal(undefined)
+  // TODO - Enable this assertion when language support has been reinstated, the language cookie is not currently
+  //  set so this assertion cannot be made until it is reinstated.
+  // const langCookie = await pages.overview.getLangCookie()
+  // expect(langCookie).not.to.be.equal(undefined)
   await pages.overview.openDirect(pages.url)
   const currentSessionId = await pages.overview.getCurrentSessionId()
   expect(pageSessionId).to.be.equal(currentSessionId)

--- a/src/web/server/internationalisation.js
+++ b/src/web/server/internationalisation.js
@@ -25,7 +25,8 @@ const refreshCookieExpirationDate = (req, res, next) => {
 const internationalisation = (config, app) => {
   i18next
     .use(Backend)
-    .use(middleware.LanguageDetector)
+    // TODO - To reinstate language detection and translations, simply uncomment the line below
+    // .use(middleware.LanguageDetector)
     .init({
       ns: ['common', 'validation', 'buttons', 'errors'],
       defaultNS: 'common',


### PR DESCRIPTION
All language based tests have been disabled and TODOs added next to each so we can find them all again when translations are reinstated.