### PR TITLE
Group summary lists by list name

### DIFF
--- a/src/web/routes/application/check/constants.js
+++ b/src/web/routes/application/check/constants.js
@@ -1,0 +1,1 @@
+module.exports.DEFAULT_LIST = 'aboutYou'

--- a/src/web/routes/application/check/constants.js
+++ b/src/web/routes/application/check/constants.js
@@ -1,1 +1,2 @@
 module.exports.DEFAULT_LIST = 'aboutYou'
+module.exports.SUMMARY_LIST_KEY = 'list'

--- a/src/web/routes/application/check/get-row-data.js
+++ b/src/web/routes/application/check/get-row-data.js
@@ -1,6 +1,8 @@
 const { pipe, map, filter, flatten, isNil, groupBy, pathOr } = require('ramda')
 const { notIsNil } = require('../../../../common/predicates')
-const { DEFAULT_LIST } = require('./constants')
+const { DEFAULT_LIST, SUMMARY_LIST_KEY } = require('./constants')
+
+const SUMMARY_LIST_PATH = [SUMMARY_LIST_KEY]
 
 const combinePathWithRow = (path) => (row) => ({
   ...row,
@@ -19,7 +21,7 @@ const getRowData = (req) => (step) => {
   return Array.isArray(result) ? result.map(applyPathToRow) : applyPathToRow(result)
 }
 
-const listPath = pathOr(DEFAULT_LIST, ['list'])
+const listPath = pathOr(DEFAULT_LIST, SUMMARY_LIST_PATH)
 
 const groupRowData = groupBy(listPath)
 

--- a/src/web/routes/application/check/get-row-data.js
+++ b/src/web/routes/application/check/get-row-data.js
@@ -1,5 +1,6 @@
-const { pipe, map, filter, flatten, isNil, groupBy, path } = require('ramda')
+const { pipe, map, filter, flatten, isNil, groupBy, pathOr } = require('ramda')
 const { notIsNil } = require('../../../../common/predicates')
+const { DEFAULT_LIST } = require('./constants')
 
 const combinePathWithRow = (path) => (row) => ({
   ...row,
@@ -18,12 +19,18 @@ const getRowData = (req) => (step) => {
   return Array.isArray(result) ? result.map(applyPathToRow) : applyPathToRow(result)
 }
 
-const listPath = path(['list'])
+const listPath = pathOr(DEFAULT_LIST, ['list'])
 
 const groupRowData = groupBy(listPath)
+
+const getGroupedRowData = (req, steps) => {
+  const flattened = getFlattenedRowData(req)(steps)
+  return groupRowData(flattened)
+}
 
 module.exports = {
   getRowData,
   getFlattenedRowData,
-  groupRowData
+  groupRowData,
+  getGroupedRowData
 }

--- a/src/web/routes/application/check/get-row-data.js
+++ b/src/web/routes/application/check/get-row-data.js
@@ -1,4 +1,4 @@
-const { pipe, map, filter, flatten, isNil } = require('ramda')
+const { pipe, map, filter, flatten, isNil, groupBy, path } = require('ramda')
 const { notIsNil } = require('../../../../common/predicates')
 
 const combinePathWithRow = (path) => (row) => ({
@@ -18,7 +18,12 @@ const getRowData = (req) => (step) => {
   return Array.isArray(result) ? result.map(applyPathToRow) : applyPathToRow(result)
 }
 
+const listPath = path(['list'])
+
+const groupRowData = groupBy(listPath)
+
 module.exports = {
   getRowData,
-  getFlattenedRowData
+  getFlattenedRowData,
+  groupRowData
 }

--- a/src/web/routes/application/check/get-row-data.test.js
+++ b/src/web/routes/application/check/get-row-data.test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const { getRowData, getFlattenedRowData } = require('./get-row-data')
+const { getRowData, getFlattenedRowData, groupRowData } = require('./get-row-data')
 
 test('getRowData should return an object combining path with row data', (t) => {
   const step = {
@@ -65,5 +65,52 @@ test('getFlattenedRowData returns flattened row data with step with empty conten
   t.deepEqual(result,
     [{ key1: 'myKey1', value1: 'myValue1', path: 'mypath1' }],
     'should flatten step with content summary and remove step without content summary')
+  t.end()
+})
+
+test.only('groupRowData returns an object with row data grouped by list', (t) => {
+  const rowData = [
+    {
+      list: 'About you',
+      key: 'email address',
+      value: 'my@email.com'
+    },
+    {
+      list: 'About your children',
+      key: 'Do you have children',
+      value: 'yes'
+    },
+    {
+      list: 'About you',
+      key: 'Telephone',
+      value: '111-111-111-111'
+    }
+  ]
+
+  const expected = {
+    'About you': [
+      {
+        list: 'About you',
+        key: 'email address',
+        value: 'my@email.com'
+      },
+      {
+        list: 'About you',
+        key: 'Telephone',
+        value: '111-111-111-111'
+      }
+    ],
+    'About your children': [
+      {
+        list: 'About your children',
+        key: 'Do you have children',
+        value: 'yes'
+      }
+    ]
+  }
+
+  const result = groupRowData(rowData)
+
+  t.deepEqual(result, expected, 'returns an object with row data grouped by list')
   t.end()
 })

--- a/src/web/routes/application/check/get-row-data.test.js
+++ b/src/web/routes/application/check/get-row-data.test.js
@@ -1,5 +1,6 @@
 const test = require('tape')
-const { getRowData, getFlattenedRowData, groupRowData } = require('./get-row-data')
+const { getRowData, getFlattenedRowData, groupRowData, getGroupedRowData } = require('./get-row-data')
+const { DEFAULT_LIST } = require('./constants')
 
 test('getRowData should return an object combining path with row data', (t) => {
   const step = {
@@ -68,7 +69,7 @@ test('getFlattenedRowData returns flattened row data with step with empty conten
   t.end()
 })
 
-test.only('groupRowData returns an object with row data grouped by list', (t) => {
+test('groupRowData returns an object with row data grouped by list', (t) => {
   const rowData = [
     {
       list: 'About you',
@@ -112,5 +113,38 @@ test.only('groupRowData returns an object with row data grouped by list', (t) =>
   const result = groupRowData(rowData)
 
   t.deepEqual(result, expected, 'returns an object with row data grouped by list')
+  t.end()
+})
+
+test('getGroupedRowData returns grouped row data', (t) => {
+  const step1 = {
+    contentSummary: () => ([{ keyA: 'myKeyA', valueA: 'myValueA', list: 'list1' }, { keyB: 'myKeyB', valueB: 'myValueB', list: 'list1' }]),
+    path: 'mypath1'
+  }
+  const step2 = {
+    contentSummary: () => ({ key2: 'myKey2', value: 'myValue2' }),
+    path: 'mypath2'
+  }
+  const step3 = {
+    contentSummary: () => ({ key3: 'myKey3', value: 'myValue3', list: 'list1' }),
+    path: 'mypath3'
+  }
+  const req = {}
+  const steps = [step1, step2, step3]
+
+  const expected = {
+    list1: [
+      { keyA: 'myKeyA', valueA: 'myValueA', list: 'list1', path: 'mypath1' },
+      { keyB: 'myKeyB', valueB: 'myValueB', list: 'list1', path: 'mypath1' },
+      { key3: 'myKey3', value: 'myValue3', list: 'list1', path: 'mypath3' }
+    ],
+    [DEFAULT_LIST]: [
+      { key2: 'myKey2', value: 'myValue2', path: 'mypath2' }
+    ]
+  }
+
+  const result = getGroupedRowData(req, steps)
+
+  t.deepEqual(result, expected, 'should flatten step content summary')
   t.end()
 })

--- a/src/web/routes/application/check/get-row-data.test.js
+++ b/src/web/routes/application/check/get-row-data.test.js
@@ -116,13 +116,13 @@ test('groupRowData returns an object with row data grouped by list', (t) => {
   t.end()
 })
 
-test('getGroupedRowData returns grouped row data', (t) => {
+test('getGroupedRowData returns row data grouped by list', (t) => {
   const step1 = {
     contentSummary: () => ([{ keyA: 'myKeyA', valueA: 'myValueA', list: 'list1' }, { keyB: 'myKeyB', valueB: 'myValueB', list: 'list1' }]),
     path: 'mypath1'
   }
   const step2 = {
-    contentSummary: () => ({ key2: 'myKey2', value: 'myValue2' }),
+    contentSummary: () => ({ key2: 'myKey2', value: 'myValue2', list: 'list2' }),
     path: 'mypath2'
   }
   const step3 = {
@@ -138,13 +138,36 @@ test('getGroupedRowData returns grouped row data', (t) => {
       { keyB: 'myKeyB', valueB: 'myValueB', list: 'list1', path: 'mypath1' },
       { key3: 'myKey3', value: 'myValue3', list: 'list1', path: 'mypath3' }
     ],
-    [DEFAULT_LIST]: [
-      { key2: 'myKey2', value: 'myValue2', path: 'mypath2' }
+    list2: [
+      { key2: 'myKey2', value: 'myValue2', path: 'mypath2', list: 'list2' }
     ]
   }
 
   const result = getGroupedRowData(req, steps)
 
-  t.deepEqual(result, expected, 'should flatten step content summary')
+  t.deepEqual(result, expected, 'returns row data grouped by list')
+  t.end()
+})
+
+test('getGroupedRowData sets a default list if no list is defined', (t) => {
+  const step1 = {
+    contentSummary: () => ({ key1: 'myKey1', value: 'myValue1' }),
+    path: 'mypath1'
+  }
+  const step2 = {
+    contentSummary: () => ({ key2: 'myKey2', value: 'myValue2', list: 'list2' }),
+    path: 'mypath2'
+  }
+  const req = {}
+  const steps = [step1, step2]
+
+  const expected = {
+    [DEFAULT_LIST]: [{ key1: 'myKey1', value: 'myValue1', path: 'mypath1' }],
+    list2: [{ key2: 'myKey2', value: 'myValue2', list: 'list2', path: 'mypath2' }]
+  }
+
+  const result = getGroupedRowData(req, steps)
+
+  t.deepEqual(result, expected, 'sets a default list if no list is defined')
   t.end()
 })

--- a/src/web/routes/application/check/get.js
+++ b/src/web/routes/application/check/get.js
@@ -1,6 +1,6 @@
 const { stateMachine, states, actions } = require('../common/state-machine')
 const { getPreviousPath } = require('../common/get-previous-path')
-const { getFlattenedRowData } = require('./get-row-data')
+const { getGroupedRowData } = require('./get-row-data')
 
 const pageContent = ({ translate }) => ({
   title: translate('check.title'),
@@ -9,8 +9,10 @@ const pageContent = ({ translate }) => ({
   sendApplicationText: translate('check.sendApplicationText'),
   buttonText: translate('buttons:continue'),
   changeText: translate('check.change'),
-  aboutYou: translate('check.aboutYou'),
-  aboutYourChildren: translate('check.aboutYourChildren')
+  summaryListHeadings: {
+    aboutYou: translate('check.aboutYou'),
+    aboutYourChildren: translate('check.aboutYourChildren')
+  }
 })
 
 // a step is navigable if it hasn't defined an isNavigable function.
@@ -32,7 +34,7 @@ const getCheck = (steps) => (req, res) => {
   res.render('check', {
     claim: req.session.claim,
     ...pageContent({ translate: req.t }),
-    checkRowData: getFlattenedRowData(req)(steps),
+    checkRowData: getGroupedRowData(req, steps),
     previous: getLastNavigablePath(steps, req)
   })
 }

--- a/src/web/views/check.njk
+++ b/src/web/views/check.njk
@@ -1,36 +1,19 @@
 {% extends "templates/page.njk" %}
-{% from "input/macro.njk" import govukInput %}
-{% from "summary-list/macro.njk" import govukSummaryList %}
-{% from "fieldset/macro.njk" import govukFieldset %}
-
-{% set safeRows = [] %}
-{% for rowData in checkRowData %}
-  {% set row = {
-   key : {
-    text: rowData.key
-   },
-   value: {
-    text: rowData.value | escape | nl2br | safe
-   },
-   actions: {
-    items: [ {
-        href: rowData.path,
-        text: changeText,
-        visuallyHiddenText: rowData.key
-    } ]
-   }
-  } %}
-  {{ safeRows.push(row) }}
-{% endfor %}
+{% from "macros/htbhf-summary-list.njk" import htbhfSummaryList %}
 
 {% block pageContent %}
 
   <h1 class="govuk-heading-xl">{{ heading }}</h1>
-  <h2 class="govuk-heading-m">{{ aboutYou }}</h2>
 
-  {{ govukSummaryList({
-      rows: safeRows
-  }) }}
+  {% for list, listRows in checkRowData %}
+    {{ htbhfSummaryList({
+      listRows: listRows,
+      text: {
+        heading: summaryListHeadings[list],
+        change: changeText
+      }
+    }) }}
+  {% endfor %}
 
   {{ govukButton({
       text: buttonText,

--- a/src/web/views/macros/htbhf-summary-list.njk
+++ b/src/web/views/macros/htbhf-summary-list.njk
@@ -1,0 +1,38 @@
+{% from "summary-list/macro.njk" import govukSummaryList %}
+
+{#
+  htbhfSummaryList() wraps govukSummaryList() mapping list data to the correct parameters and adding a heading
+
+  params:
+  listRows: array of rows for summary list
+  text: object { heading: text, change: text }
+#}
+{% macro htbhfSummaryList(params) %}
+  <h2 class="govuk-heading-m">{{ params.text.heading }}</h2>
+
+  {% set safeRows = [] %}
+
+  {% for rowData in params.listRows %}
+    {% set row = {
+      key : {
+        text: rowData.key
+      },
+      value: {
+        text: rowData.value | escape | nl2br | safe
+      },
+      actions: {
+        items: [ {
+            href: rowData.path,
+            text: params.text.change,
+            visuallyHiddenText: rowData.key
+        } ]
+      }
+    } %}
+
+    {% set safeRowsLength = safeRows.push(row) %}
+  {% endfor %}
+
+  {{ govukSummaryList({
+      rows: safeRows
+  }) }}
+{% endmacro %}


### PR DESCRIPTION
Update the structure of the data consumed by the “check details” page to allow rendering multiple summary lists:

- Group the data passed to the view by list
- Refactor the summary list into a macro
- Refactor the page content structure to allow for easy translation of the summary list headings 