### PR TITLE
Display children’s dates of birth on “check details page”

### DIFF
--- a/src/test/common/page/check.js
+++ b/src/test/common/page/check.js
@@ -2,7 +2,7 @@
 
 const SubmittablePage = require('./submittable-page')
 const CHECK_PAGE_TITLE = 'GOV.UK - Check your answers'
-const GOV_LIST_ROW_CLASSNAME = 'govuk-summary-list__row'
+const GOV_LIST_ROW_SELECTOR = '#claim-summary .govuk-summary-list__row'
 const GOV_LIST_HEADER_CLASSNAME = 'govuk-summary-list__key'
 const GOV_LIST_VALUE_CLASSNAME = 'govuk-summary-list__value'
 const GOV_LIST_ACTION_CLASSNAME = 'govuk-summary-list__actions'
@@ -26,7 +26,7 @@ class Check extends SubmittablePage {
   }
 
   async getCheckDetailsTableContents () {
-    const tableRows = await this.findAllByClassName(GOV_LIST_ROW_CLASSNAME)
+    const tableRows = await this.findAllByCSS(GOV_LIST_ROW_SELECTOR)
     const getDataForRows = tableRows.map(async (tableRow) => this.getDataForRow(tableRow))
     return Promise.all(getDataForRows)
   }

--- a/src/web/assets/sass/all.scss
+++ b/src/web/assets/sass/all.scss
@@ -12,6 +12,7 @@
 // HTBHF components
 @import './components/buttons';
 @import './components/child-dob-input';
+@import './components/children-summary-list';
 
 // HTBHF utilities
 @import './utilities/focus';

--- a/src/web/assets/sass/components/_children-summary-list.scss
+++ b/src/web/assets/sass/components/_children-summary-list.scss
@@ -1,0 +1,54 @@
+/**
+  * Wraps the GOV.UK summary list component to provide a single action for multiple
+  * summary list rows
+  *
+  * 1. Allow space for action on desktop
+  * 2. Visually group rows for each child
+  * 3. Position action on desktop
+  */
+.c-htbhf-children-summary-list {
+  position: relative;  /* 3 */
+
+  .govuk-summary-list {
+    border-bottom: 1px solid $govuk-border-colour;
+  }
+
+  .govuk-summary-list__value {
+    @media (min-width: map-get($govuk-breakpoints, tablet)) {
+      padding-right: 30%; /* 1 */
+    }
+  }
+
+  /**
+   * Using overly specific selectors (instead of modifiers) to avoid rewriting HTML
+   * for GOV.UK summary list
+   */
+  .govuk-summary-list__row:nth-child(odd) {
+    .govuk-summary-list__key,
+    .govuk-summary-list__value {
+      @media (min-width: map-get($govuk-breakpoints, tablet)) {
+        padding-bottom: 0; /* 2 */
+      }
+    }
+  }
+
+  .govuk-summary-list__row:nth-child(even) {
+    .govuk-summary-list__key,
+    .govuk-summary-list__value {
+      @media (min-width: map-get($govuk-breakpoints, tablet)) {
+        padding-top: 0; /* 2 */
+      }
+    }
+  }
+}
+
+.c-htbhf-children-summary-list__action {
+  @extend .govuk-body;
+  padding-top: govuk-spacing(2);
+
+  @media (min-width: map-get($govuk-breakpoints, tablet)) {
+    position: absolute; /* 3 */
+    top: 0; /* 3 */
+    right: 0; /* 3 */
+  }
+}

--- a/src/web/assets/sass/settings/_colors.scss
+++ b/src/web/assets/sass/settings/_colors.scss
@@ -6,3 +6,4 @@ $govuk-link-colour: #005ea5 !default;
 $govuk-link-hover-colour: #2b8cc4 !default;
 $govuk-link-active-colour:	#2b8cc4 !default;
 $govuk-focus-colour: #ffbf47 !default;
+$govuk-border-colour: #bfc1c3 !default;

--- a/src/web/routes/application/check/get.js
+++ b/src/web/routes/application/check/get.js
@@ -12,7 +12,8 @@ const pageContent = ({ translate }) => ({
   summaryListHeadings: {
     aboutYou: translate('check.aboutYou'),
     aboutYourChildren: translate('check.aboutYourChildren')
-  }
+  },
+  childrensDobHiddenText: translate('childrenDob.summaryKey')
 })
 
 // a step is navigable if it hasn't defined an isNavigable function.
@@ -32,7 +33,7 @@ const getCheck = (steps) => (req, res) => {
   req.session.nextAllowedStep = stateMachine.dispatch(actions.GET_NEXT_PATH, req, steps)
 
   res.render('check', {
-    claim: req.session.claim,
+    children: req.session.children,
     ...pageContent({ translate: req.t }),
     checkRowData: getGroupedRowData(req, steps),
     previous: getLastNavigablePath(steps, req)

--- a/src/web/server/locales/en/common.json
+++ b/src/web/server/locales/en/common.json
@@ -39,7 +39,7 @@
     "monthLabel": "Month",
     "yearLabel": "Year",
     "hint": "For example, {{exampleDate}}",
-    "summaryKey": "Child date of birth",
+    "summaryKey": "Children’s date of birth",
     "explanation": "Children’s names will not be stored or shared. We need their dates of birth to confirm your identity and to prevent fraud.",
     "nameLabel": "First name",
     "dateOfBirth": "Date of birth",

--- a/src/web/views/check.njk
+++ b/src/web/views/check.njk
@@ -6,32 +6,35 @@
 
   <h1 class="govuk-heading-xl">{{ heading }}</h1>
 
-  {% for list, listRows in checkRowData %}
-    {% set classes %}
-      {% if loop.last and children %} govuk-!-margin-bottom-1 {% else %} govuk-!-margin-bottom-9 {% endif %}
-    {% endset %}
+  <div id="claim-summary">
+    {% for list, listRows in checkRowData %}
+      {% set classes %}
+        {% if loop.last and children %} govuk-!-margin-bottom-1 {% else %} govuk-!-margin-bottom-9 {% endif %}
+      {% endset %}
 
-    {{ htbhfSummaryList({
-      classes: classes,
-      listRows: listRows,
-      text: {
-        heading: summaryListHeadings[list],
-        change: changeText
-      }
-    }) }}
-  {% endfor %}
-
-  {% if children %}
-    {{ htbhfChildrenSummaryList({
-      classes: 'govuk-!-margin-bottom-9',
-      children: children,
-      action: {
-        href: "/children-dob",
-        text: changeText,
-        visuallyHiddenText: childrensDobHiddenText
-      }
-    }) }}
-  {% endif %}
+      {{ htbhfSummaryList({
+        classes: classes,
+        listRows: listRows,
+        text: {
+          heading: summaryListHeadings[list],
+          change: changeText
+        }
+      }) }}
+    {% endfor %}
+  </div>
+  <div id="children-summary">
+    {% if children %}
+      {{ htbhfChildrenSummaryList({
+        classes: 'govuk-!-margin-bottom-9',
+        children: children,
+        action: {
+          href: "/children-dob",
+          text: changeText,
+          visuallyHiddenText: childrensDobHiddenText
+        }
+      }) }}
+    {% endif %}
+  </div>
 
   {{ govukButton({
       text: buttonText,

--- a/src/web/views/check.njk
+++ b/src/web/views/check.njk
@@ -1,13 +1,18 @@
 {% extends "templates/page.njk" %}
 {% from "macros/htbhf-summary-list.njk" import htbhfSummaryList %}
+{% from "macros/htbhf-children-summary-list.njk" import htbhfChildrenSummaryList %}
 
 {% block pageContent %}
 
   <h1 class="govuk-heading-xl">{{ heading }}</h1>
 
   {% for list, listRows in checkRowData %}
+    {% set classes %}
+      {% if loop.last and children %} govuk-!-margin-bottom-1 {% else %} govuk-!-margin-bottom-9 {% endif %}
+    {% endset %}
+
     {{ htbhfSummaryList({
-      classes: 'govuk-!-margin-bottom-9',
+      classes: classes,
       listRows: listRows,
       text: {
         heading: summaryListHeadings[list],
@@ -15,6 +20,18 @@
       }
     }) }}
   {% endfor %}
+
+  {% if children %}
+    {{ htbhfChildrenSummaryList({
+      classes: 'govuk-!-margin-bottom-9',
+      children: children,
+      action: {
+        href: "/children-dob",
+        text: changeText,
+        visuallyHiddenText: childrensDobHiddenText
+      }
+    }) }}
+  {% endif %}
 
   {{ govukButton({
       text: buttonText,

--- a/src/web/views/macros/htbhf-children-summary-list.njk
+++ b/src/web/views/macros/htbhf-children-summary-list.njk
@@ -1,0 +1,47 @@
+{% from "summary-list/macro.njk" import govukSummaryList %}
+
+{#
+  htbhfChildDobInput() Wraps the GOV.UK summary list component to provide a single action for multiple
+  summary list rows
+#}
+{% macro htbhfChildrenSummaryList(params) %}
+  {% set childRows = [] %}
+
+  {% for i in range(0, params.children.childCount) %}
+    {% set index = i + 1 %}
+    {% set actions = [] %}
+
+    {% set name = {
+      key : {
+        text: 'Name'
+      },
+      value: {
+        text: params.children['childDobName-' + index]
+      }
+    } %}
+
+    {% set dateOfBirth = {
+      key : {
+        text: 'Date of birth'
+      },
+      value: {
+        text: params.children['childDob-' + index]
+      }
+    } %}
+
+    {% set childRowsLength = childRows.push(name) %}
+    {% set childRowsLength = childRows.push(dateOfBirth) %}
+  {% endfor %}
+
+  <div class="c-htbhf-children-summary-list">
+    {{ govukSummaryList({
+      classes: 'govuk-summary-list--no-border ' + params.classes,
+      rows: childRows
+    }) }}
+    <div class="c-htbhf-children-summary-list__action">
+      <a href="{{ params.action.href }}" class="govuk-link">
+        {{ params.action.text }}<span class="govuk-visually-hidden"> {{ params.action.visuallyHiddenText }}</span>
+      </a>
+    </div>
+  </div>
+{% endmacro %}

--- a/src/web/views/macros/htbhf-children-summary-list.njk
+++ b/src/web/views/macros/htbhf-children-summary-list.njk
@@ -9,7 +9,6 @@
 
   {% for i in range(0, params.children.childCount) %}
     {% set index = i + 1 %}
-    {% set actions = [] %}
 
     {% set name = {
       key : {


### PR DESCRIPTION
- Wrap GOV.UK summary list macro to create a custom summary list for children’s dates of birth
- Display children’s dates of birth on “check details page”
- Update HTML structure and acceptance tests for “check details” page to allow the children’s dates of birth summary list to be tested independently (as it’s HTML structure will differ from the main summary list)

Adding acceptance tests for this update is quite involved so leaving for a separate (subsequent) PR.

