### PR TITLE
Add acceptance tests for children’s dates of birth on “check details” page

### DIFF
--- a/src/test/common/page/check.js
+++ b/src/test/common/page/check.js
@@ -1,13 +1,16 @@
 'use strict'
 
+const { isNil } = require('ramda')
 const SubmittablePage = require('./submittable-page')
 const CHECK_PAGE_TITLE = 'GOV.UK - Check your answers'
-const GOV_LIST_ROW_SELECTOR = '#claim-summary .govuk-summary-list__row'
+const GOV_LIST_ROW_CLASSNAME = '.govuk-summary-list__row'
 const GOV_LIST_HEADER_CLASSNAME = 'govuk-summary-list__key'
 const GOV_LIST_VALUE_CLASSNAME = 'govuk-summary-list__value'
 const GOV_LIST_ACTION_CLASSNAME = 'govuk-summary-list__actions'
 const GOV_LINK_CLASSNAME = 'govuk-link'
 const GOV_HIDDEN_CLASSNAME = 'govuk-visually-hidden'
+const CLAIM_SUMMARY_PARENT_ID = '#claim-summary'
+const CHILDREN_SUMMARY_PARENT_ID = '#children-summary'
 
 /**
  * Page object for the page where the customer can check their details before submitting.
@@ -25,10 +28,42 @@ class Check extends SubmittablePage {
     return super.waitForPageWithTitle(CHECK_PAGE_TITLE)
   }
 
-  async getCheckDetailsTableContents () {
-    const tableRows = await this.findAllByCSS(GOV_LIST_ROW_SELECTOR)
+  async getContentsOfSummaryListsByParentId (parentId) {
+    const tableRows = await this.findAllByCSS(`${parentId} ${GOV_LIST_ROW_CLASSNAME}`)
     const getDataForRows = tableRows.map(async (tableRow) => this.getDataForRow(tableRow))
     return Promise.all(getDataForRows)
+  }
+
+  async getClaimSummaryListContents () {
+    return this.getContentsOfSummaryListsByParentId(CLAIM_SUMMARY_PARENT_ID)
+  }
+
+  async getChildrenSummaryListContents () {
+    return this.getContentsOfSummaryListsByParentId(CHILDREN_SUMMARY_PARENT_ID)
+  }
+
+  async getActionFromElement (element) {
+    const changeLink = await this.findByClassName(GOV_LINK_CLASSNAME, element)
+    const changeUrl = await changeLink.getAttribute('href')
+    const changeText = await changeLink.getText()
+    const hiddenSpan = await this.findByClassName(GOV_HIDDEN_CLASSNAME, changeLink)
+    const hiddenText = await hiddenSpan.getText()
+
+    return {
+      url: changeUrl,
+      text: changeText.replace(hiddenText, '').trim(),
+      hiddenText: hiddenText
+    }
+  }
+
+  async getActionForRow (row) {
+    try {
+      const actions = await this.findAllByClassName(GOV_LIST_ACTION_CLASSNAME, row)
+      return actions.length === 0 ? null : this.getActionFromElement(actions[0])
+    } catch (error) {
+      console.log(error)
+      throw new Error(error)
+    }
   }
 
   async getDataForRow (tableRow) {
@@ -37,17 +72,12 @@ class Check extends SubmittablePage {
       const headerText = await header.getText()
       const value = await this.findByClassName(GOV_LIST_VALUE_CLASSNAME, tableRow)
       const valueText = await value.getText()
-      const change = await this.findByClassName(GOV_LIST_ACTION_CLASSNAME, tableRow)
-      const changeLink = await this.findByClassName(GOV_LINK_CLASSNAME, change)
-      const changeUrl = await changeLink.getAttribute('href')
-      const changeText = await changeLink.getText()
-      const hiddenSpan = await this.findByClassName(GOV_HIDDEN_CLASSNAME, changeLink)
-      const hiddenText = await hiddenSpan.getText()
+      const action = await this.getActionForRow(tableRow)
 
       return {
         header: headerText,
         value: valueText,
-        action: { url: changeUrl, text: changeText.replace(hiddenText, '').trim(), hiddenText: hiddenText }
+        action: isNil(action) ? undefined : action
       }
     } catch (error) {
       console.log(error)
@@ -55,9 +85,18 @@ class Check extends SubmittablePage {
     }
   }
 
+  async getChangeLinksFor (headerText) {
+    return this.findAllByXPath(`//a[contains(@class, 'govuk-link') and contains(.//span, '${headerText}')]`)
+  }
+
   async clickChangeLinkFor (headerText) {
-    const link = await this.findByXPath(`//a[contains(@class, 'govuk-link') and contains(.//span, '${headerText}')]`)
-    await link.click()
+    const links = await this.getChangeLinksFor(headerText)
+
+    if (!links.length === 1) {
+      throw new Error(links.length, 'change links found for', headerText)
+    }
+
+    await links[0].click()
   }
 }
 

--- a/src/test/common/page/page.js
+++ b/src/test/common/page/page.js
@@ -122,6 +122,15 @@ class Page {
     }
   }
 
+  async findAllByXPath (xpath) {
+    try {
+      return await this.driver.findElements(webdriver.By.xpath(xpath))
+    } catch (error) {
+      console.log(error)
+      throw new Error(error)
+    }
+  }
+
   async findH1 () {
     return this.findByCSS('h1')
   }

--- a/src/test/common/steps/check-details.js
+++ b/src/test/common/steps/check-details.js
@@ -13,7 +13,8 @@ const {
   YES_LABEL,
   NO_LABEL,
   PHONE_NUMBER,
-  EMAIL_ADDRESS
+  EMAIL_ADDRESS,
+  CHILDRENS_DATES_OF_BIRTH
 } = require('./constants')
 
 const pages = require('./pages')
@@ -86,42 +87,47 @@ Then(/^The back link on the check details page links to the email address page$/
 })
 
 Then(/^the check details page contains all data entered for a pregnant woman$/, async function () {
-  const tableContents = await pages.check.getCheckDetailsTableContents()
-  assertNameShown(tableContents)
-  assertNinoShown(tableContents)
-  assertDobShown(tableContents)
-  assertAreYouPregnantValueShown(tableContents, YES_LABEL)
-  assertDueDateShownInSixMonths(tableContents)
-  assertFullAddressShown(tableContents)
-  assertPhoneNumberShown(tableContents)
-  assertEmailAddressShown(tableContents)
-  assertDoYouHaveChildrenIsShown(tableContents, YES_LABEL)
+  const claimContents = await pages.check.getClaimSummaryListContents()
+  const childrenContents = await pages.check.getChildrenSummaryListContents()
+  assertNameShown(claimContents)
+  assertNinoShown(claimContents)
+  assertDobShown(claimContents)
+  assertAreYouPregnantValueShown(claimContents, YES_LABEL)
+  assertDueDateShownInSixMonths(claimContents)
+  assertFullAddressShown(claimContents)
+  assertPhoneNumberShown(claimContents)
+  assertEmailAddressShown(claimContents)
+  assertDoYouHaveChildrenIsShown(claimContents, YES_LABEL)
+  assertChildrensDatesOfBirthIsShown(childrenContents, CHILDRENS_DATES_OF_BIRTH)
 })
 
 Then(/^the check details page contains all data entered for a woman who is not pregnant$/, async function () {
-  const tableContents = await pages.check.getCheckDetailsTableContents()
-  assertNameShown(tableContents)
-  assertNinoShown(tableContents)
-  assertDobShown(tableContents)
-  assertAreYouPregnantValueShown(tableContents, NO_LABEL)
-  assertNoValueForField(tableContents, 'Baby’s due date')
-  assertFullAddressShown(tableContents)
-  assertPhoneNumberShown(tableContents)
-  assertEmailAddressShown(tableContents)
-  assertDoYouHaveChildrenIsShown(tableContents, YES_LABEL)
+  const claimContents = await pages.check.getClaimSummaryListContents()
+  const childrenContents = await pages.check.getChildrenSummaryListContents()
+  assertNameShown(claimContents)
+  assertNinoShown(claimContents)
+  assertDobShown(claimContents)
+  assertAreYouPregnantValueShown(claimContents, NO_LABEL)
+  assertNoValueForField(claimContents, 'Baby’s due date')
+  assertFullAddressShown(claimContents)
+  assertPhoneNumberShown(claimContents)
+  assertEmailAddressShown(claimContents)
+  assertDoYouHaveChildrenIsShown(claimContents, YES_LABEL)
+  assertChildrensDatesOfBirthIsShown(childrenContents, CHILDRENS_DATES_OF_BIRTH)
 })
 
+// TO DO GJ HTBHF-1852 assert childrens dates of birth is not shown
 Then(/^the check details page contains all data entered for an applicant with no second line of address$/, async function () {
-  const tableContents = await pages.check.getCheckDetailsTableContents()
-  assertNameShown(tableContents)
-  assertNinoShown(tableContents)
-  assertDobShown(tableContents)
-  assertAreYouPregnantValueShown(tableContents, NO_LABEL)
-  assertNoValueForField(tableContents, 'Baby’s due date')
-  assertAddressShownWithNoSecondLine(tableContents)
-  assertPhoneNumberShown(tableContents)
-  assertEmailAddressShown(tableContents)
-  assertDoYouHaveChildrenIsShown(tableContents, NO_LABEL)
+  const claimContents = await pages.check.getClaimSummaryListContents()
+  assertNameShown(claimContents)
+  assertNinoShown(claimContents)
+  assertDobShown(claimContents)
+  assertAreYouPregnantValueShown(claimContents, NO_LABEL)
+  assertNoValueForField(claimContents, 'Baby’s due date')
+  assertAddressShownWithNoSecondLine(claimContents)
+  assertPhoneNumberShown(claimContents)
+  assertEmailAddressShown(claimContents)
+  assertDoYouHaveChildrenIsShown(claimContents, NO_LABEL)
 })
 
 Then(/^all page content is present on the check details page$/, async function () {
@@ -144,8 +150,10 @@ async function allPageContentIsCorrectOnCheckPage () {
   expect(h2Text.toString().trim()).to.have.lengthOf.at.least(1, 'expected check page H2 text to not be empty')
   const submitButtonText = await pages.check.getSubmitButtonText()
   expect(submitButtonText.toString().trim()).to.have.lengthOf.at.least(1, 'expected submit button text to not be empty')
-  const tableContents = await pages.check.getCheckDetailsTableContents()
-  assertHeaderAndChangeLinkShownForEachRow(tableContents)
+  const claimContents = await pages.check.getClaimSummaryListContents()
+  assertHeaderAndChangeLinkShownForEachRow(claimContents)
+  const childrenContents = await pages.check.getChildrenSummaryListContents()
+  assertHeaderTextShownForEachRow(childrenContents)
 }
 
 function getValueForField (tableContents, fieldName) {
@@ -166,64 +174,91 @@ function getDateInSixMonths () {
   return formatDateForDisplayFromDate(date)
 }
 
-function assertNameShown (tableContents) {
-  const nameValue = getValueForField(tableContents, 'Your name')
+function assertNameShown (contents) {
+  const nameValue = getValueForField(contents, 'Your name')
   expect(nameValue).to.be.equal(FULL_NAME)
 }
 
-function assertNinoShown (tableContents) {
-  const ninoValue = getValueForField(tableContents, 'National Insurance number')
+function assertNinoShown (contents) {
+  const ninoValue = getValueForField(contents, 'National Insurance number')
   expect(ninoValue).to.be.equal(VALID_ELIGIBLE_NINO)
 }
 
-function assertDobShown (tableContents) {
-  const dobValue = getValueForField(tableContents, 'Date of birth')
+function assertDobShown (contents) {
+  const dobValue = getValueForField(contents, 'Date of birth')
   expect(dobValue).to.be.equal(DATE_OF_BIRTH)
 }
 
-function assertAreYouPregnantValueShown (tableContents, expectedValue) {
-  const areYouPregnantValue = getValueForField(tableContents, 'Are you pregnant?')
+function assertAreYouPregnantValueShown (contents, expectedValue) {
+  const areYouPregnantValue = getValueForField(contents, 'Are you pregnant?')
   expect(areYouPregnantValue).to.be.equal(expectedValue)
 }
 
-function assertDueDateShownInSixMonths (tableContents) {
-  const dueDateValue = getValueForField(tableContents, 'Baby’s due date')
+function assertDueDateShownInSixMonths (contents) {
+  const dueDateValue = getValueForField(contents, 'Baby’s due date')
   expect(dueDateValue).to.be.equal(getDateInSixMonths())
 }
 
-function assertFullAddressShown (tableContents) {
-  assertAddressShown(tableContents, FULL_ADDRESS)
+function assertFullAddressShown (contents) {
+  assertAddressShown(contents, FULL_ADDRESS)
 }
 
-function assertAddressShownWithNoSecondLine (tableContents) {
-  assertAddressShown(tableContents, FULL_ADDRESS_NO_LINE_2)
+function assertAddressShownWithNoSecondLine (contents) {
+  assertAddressShown(contents, FULL_ADDRESS_NO_LINE_2)
 }
 
-function assertAddressShown (tableContents, expectedAddress) {
-  const addressValue = getValueForField(tableContents, 'Address')
+function assertAddressShown (contents, expectedAddress) {
+  const addressValue = getValueForField(contents, 'Address')
   expect(addressValue).to.be.equal(expectedAddress)
 }
 
-function assertPhoneNumberShown (tableContents) {
-  const phoneNumberValue = getValueForField(tableContents, 'Mobile telephone number')
+function assertPhoneNumberShown (contents) {
+  const phoneNumberValue = getValueForField(contents, 'Mobile telephone number')
   expect(phoneNumberValue).to.be.equal(PHONE_NUMBER)
 }
 
-function assertEmailAddressShown (tableContents) {
-  const emailAddressValue = getValueForField(tableContents, 'Email address')
+function assertEmailAddressShown (contents) {
+  const emailAddressValue = getValueForField(contents, 'Email address')
   expect(emailAddressValue).to.be.equal(EMAIL_ADDRESS)
 }
 
-function assertDoYouHaveChildrenIsShown (tableContents, expectedValue) {
-  const doYouHaveChildrenValue = getValueForField(tableContents, 'Children under 4 years old?')
+function assertDoYouHaveChildrenIsShown (contents, expectedValue) {
+  const doYouHaveChildrenValue = getValueForField(contents, 'Children under 4 years old?')
   expect(doYouHaveChildrenValue).to.be.equal(expectedValue)
 }
 
-function hasChangeLinkAndHeaderText (row) {
-  return row.action.text === 'Change' && row.header.trim().length > 0
+async function assertChildrensDatesOfBirthChangeLinkIsShown () {
+  const changeLinks = await pages.check.getChangeLinksFor('Children’s date of birth')
+  expect(changeLinks.length).to.be.equal(1)
 }
 
-function assertHeaderAndChangeLinkShownForEachRow (tableContents) {
-  const matchingRows = tableContents.filter(hasChangeLinkAndHeaderText)
-  expect(matchingRows.length).to.be.equal(tableContents.length)
+async function assertChildrensDatesOfBirthIsShown (contents, expectedValues) {
+  expectedValues.forEach((expected) => {
+    const value = getValueForField(contents, expected.header)
+    expect(value).to.be.equal(expected.value)
+  })
+
+  await assertChildrensDatesOfBirthChangeLinkIsShown()
+}
+
+function hasChangeLink (row) {
+  return row.action.text === 'Change'
+}
+
+function hasHeaderText (row) {
+  return row.header.trim().length > 0
+}
+
+function hasChangeLinkAndHeaderText (row) {
+  return hasChangeLink(row) && hasHeaderText(row)
+}
+
+function assertHeaderTextShownForEachRow (contents) {
+  const matchingRows = contents.filter(hasHeaderText)
+  expect(matchingRows.length).to.be.equal(contents.length)
+}
+
+function assertHeaderAndChangeLinkShownForEachRow (contents) {
+  const matchingRows = contents.filter(hasChangeLinkAndHeaderText)
+  expect(matchingRows.length).to.be.equal(contents.length)
 }

--- a/src/test/common/steps/constants.js
+++ b/src/test/common/steps/constants.js
@@ -1,3 +1,5 @@
+const { dateLastYear } = require('../../common/dates')
+
 // Create a string 501 characters long
 const LONG_STRING = new Array(502).join('A')
 const BLANK_STRING = ''
@@ -62,6 +64,19 @@ const PHONE_NUMBER_2 = '07111111111'
 const EMAIL_ADDRESS = 'test@email.com'
 const EMAIL_ADDRESS_2 = 'different-email-address@email.com'
 
+// TO DO GJ HTBHF-1852 format date using formatDateForDisplayFromDate() on check details page
+function formatDate (date) {
+  const year = date.getFullYear()
+  const month = date.getMonth() + 1
+  const day = date.getDate()
+  return `${year}-${month.toString().padStart(2, '0')}-${day}`
+}
+
+const CHILDRENS_DATES_OF_BIRTH = [
+  { header: 'Name', value: 'Joe' },
+  { header: 'Date of birth', value: formatDate(dateLastYear()) }
+]
+
 module.exports = {
   LONG_STRING,
   BLANK_STRING,
@@ -88,5 +103,6 @@ module.exports = {
   TEXT_LABEL,
   EMAIL_LABEL,
   TEXT,
-  EMAIL
+  EMAIL,
+  CHILDRENS_DATES_OF_BIRTH
 }


### PR DESCRIPTION
- Allow testing of children’s dates of birth summary list independently from claim summary list
- Assert single change link is shown for children’s dates of birth
- Remove legacy reference to `tableContents` (update to `contents`)

To do in next PR:
- Correctly format date
- Assert children’s dates of birth not shown