### PR TITLE
Format date for children’s dates of birth summary

### DIFF
--- a/src/test/common/steps/constants.js
+++ b/src/test/common/steps/constants.js
@@ -1,4 +1,5 @@
 const { dateLastYear } = require('../../common/dates')
+const { formatDateForDisplayFromDate } = require('../../../web/routes/application/common/formatters')
 
 // Create a string 501 characters long
 const LONG_STRING = new Array(502).join('A')
@@ -64,17 +65,9 @@ const PHONE_NUMBER_2 = '07111111111'
 const EMAIL_ADDRESS = 'test@email.com'
 const EMAIL_ADDRESS_2 = 'different-email-address@email.com'
 
-// TO DO GJ HTBHF-1852 format date using formatDateForDisplayFromDate() on check details page
-function formatDate (date) {
-  const year = date.getFullYear()
-  const month = date.getMonth() + 1
-  const day = date.getDate()
-  return `${year}-${month.toString().padStart(2, '0')}-${day}`
-}
-
 const CHILDRENS_DATES_OF_BIRTH = [
   { header: 'Name', value: 'Joe' },
-  { header: 'Date of birth', value: formatDate(dateLastYear()) }
+  { header: 'Date of birth', value: formatDateForDisplayFromDate(dateLastYear()) }
 ]
 
 module.exports = {

--- a/src/web/routes/application/check/constants.js
+++ b/src/web/routes/application/check/constants.js
@@ -1,4 +1,2 @@
 module.exports.DEFAULT_LIST = 'aboutYou'
 module.exports.SUMMARY_LIST_KEY = 'list'
-module.exports.NAME_KEY = 'Name'
-module.exports.DATE_OF_BIRTH_KEY = 'Date of birth'

--- a/src/web/routes/application/check/constants.js
+++ b/src/web/routes/application/check/constants.js
@@ -1,2 +1,4 @@
 module.exports.DEFAULT_LIST = 'aboutYou'
 module.exports.SUMMARY_LIST_KEY = 'list'
+module.exports.NAME_KEY = 'Name'
+module.exports.DATE_OF_BIRTH_KEY = 'Date of birth'

--- a/src/web/routes/application/check/get-childrens-dates-of-birth-rows.js
+++ b/src/web/routes/application/check/get-childrens-dates-of-birth-rows.js
@@ -1,5 +1,4 @@
 const { formatDateForDisplay } = require('../common/formatters')
-const { NAME_KEY, DATE_OF_BIRTH_KEY } = require('./constants')
 
 const buildRow = (keyText, valueText) => ({
   key: {
@@ -17,13 +16,13 @@ const getFormattedDateForChild = (children, index) =>
     children[`childDob-${index}-year`]
   )
 
-const getChildrensDatesOfBirthRows = (children) => {
+const getChildrensDatesOfBirthRows = (localisation) => (children) => {
   const rows = []
 
   for (let i = 0; i < children.childCount; i++) {
     const index = i + 1
-    const nameRow = buildRow(NAME_KEY, children[`childDobName-${index}`])
-    const dateOfBirthRow = buildRow(DATE_OF_BIRTH_KEY, getFormattedDateForChild(children, index))
+    const nameRow = buildRow(localisation['name'], children[`childDobName-${index}`])
+    const dateOfBirthRow = buildRow(localisation['dateOfBirth'], getFormattedDateForChild(children, index))
     rows.push(nameRow, dateOfBirthRow)
   }
 

--- a/src/web/routes/application/check/get-childrens-dates-of-birth-rows.js
+++ b/src/web/routes/application/check/get-childrens-dates-of-birth-rows.js
@@ -1,0 +1,35 @@
+const { formatDateForDisplay } = require('../common/formatters')
+const { NAME_KEY, DATE_OF_BIRTH_KEY } = require('./constants')
+
+const buildRow = (keyText, valueText) => ({
+  key: {
+    text: keyText
+  },
+  value: {
+    text: valueText
+  }
+})
+
+const getFormattedDateForChild = (children, index) =>
+  formatDateForDisplay(
+    children[`childDob-${index}-day`],
+    children[`childDob-${index}-month`],
+    children[`childDob-${index}-year`]
+  )
+
+const getChildrensDatesOfBirthRows = (children) => {
+  const rows = []
+
+  for (let i = 0; i < children.childCount; i++) {
+    const index = i + 1
+    const nameRow = buildRow(NAME_KEY, children[`childDobName-${index}`])
+    const dateOfBirthRow = buildRow(DATE_OF_BIRTH_KEY, getFormattedDateForChild(children, index))
+    rows.push(nameRow, dateOfBirthRow)
+  }
+
+  return rows
+}
+
+module.exports = {
+  getChildrensDatesOfBirthRows
+}

--- a/src/web/routes/application/check/get-childrens-dates-of-birth-rows.test.js
+++ b/src/web/routes/application/check/get-childrens-dates-of-birth-rows.test.js
@@ -1,0 +1,40 @@
+const test = require('tape')
+const { getChildrensDatesOfBirthRows } = require('./get-childrens-dates-of-birth-rows')
+const { NAME_KEY, DATE_OF_BIRTH_KEY } = require('./constants')
+
+test('getChildrensDatesOfBirthRows() builds rows in correct format', (t) => {
+  const children = {
+    'childDobName-1': 'Lisa',
+    'childDob-1-day': '14',
+    'childDob-1-month': '11',
+    'childDob-1-year': '1990',
+    'childDobName-2': 'Bart',
+    'childDob-2-day': '2',
+    'childDob-2-month': '3',
+    'childDob-2-year': '1999',
+    'childCount': 2
+  }
+
+  const expected = [
+    {
+      key: { text: NAME_KEY },
+      value: { text: 'Lisa' }
+    },
+    {
+      key: { text: DATE_OF_BIRTH_KEY },
+      value: { text: '14 November 1990' }
+    },
+    {
+      key: { text: NAME_KEY },
+      value: { text: 'Bart' } },
+    {
+      key: { text: DATE_OF_BIRTH_KEY },
+      value: { text: '2 March 1999' }
+    }
+  ]
+
+  const result = getChildrensDatesOfBirthRows(children)
+
+  t.deepEqual(result, expected, 'builds rows in correct format')
+  t.end()
+})

--- a/src/web/routes/application/check/get-childrens-dates-of-birth-rows.test.js
+++ b/src/web/routes/application/check/get-childrens-dates-of-birth-rows.test.js
@@ -1,8 +1,12 @@
 const test = require('tape')
 const { getChildrensDatesOfBirthRows } = require('./get-childrens-dates-of-birth-rows')
-const { NAME_KEY, DATE_OF_BIRTH_KEY } = require('./constants')
 
 test('getChildrensDatesOfBirthRows() builds rows in correct format', (t) => {
+  const localisation = {
+    name: 'Name',
+    dateOfBirth: 'Date of birth'
+  }
+
   const children = {
     'childDobName-1': 'Lisa',
     'childDob-1-day': '14',
@@ -17,23 +21,23 @@ test('getChildrensDatesOfBirthRows() builds rows in correct format', (t) => {
 
   const expected = [
     {
-      key: { text: NAME_KEY },
+      key: { text: 'Name' },
       value: { text: 'Lisa' }
     },
     {
-      key: { text: DATE_OF_BIRTH_KEY },
+      key: { text: 'Date of birth' },
       value: { text: '14 November 1990' }
     },
     {
-      key: { text: NAME_KEY },
+      key: { text: 'Name' },
       value: { text: 'Bart' } },
     {
-      key: { text: DATE_OF_BIRTH_KEY },
+      key: { text: 'Date of birth' },
       value: { text: '2 March 1999' }
     }
   ]
 
-  const result = getChildrensDatesOfBirthRows(children)
+  const result = getChildrensDatesOfBirthRows(localisation)(children)
 
   t.deepEqual(result, expected, 'builds rows in correct format')
   t.end()

--- a/src/web/routes/application/check/get.js
+++ b/src/web/routes/application/check/get.js
@@ -14,7 +14,9 @@ const pageContent = ({ translate }) => ({
     aboutYou: translate('check.aboutYou'),
     aboutYourChildren: translate('check.aboutYourChildren')
   },
-  childrensDobHiddenText: translate('childrenDob.summaryKey')
+  childrensDobHiddenText: translate('childrenDob.summaryKey'),
+  name: translate('check.name'),
+  dateOfBirth: translate('check.dateOfBirth')
 })
 
 // a step is navigable if it hasn't defined an isNavigable function.
@@ -30,13 +32,16 @@ const getLastNavigablePath = (steps, req) => {
 
 const getCheck = (steps) => (req, res) => {
   const { children } = req.session
+  const localisation = pageContent({ translate: req.t })
+  const getLocalisedChildrensDatesOfBirthRows = getChildrensDatesOfBirthRows(localisation)
+
   stateMachine.setState(states.IN_REVIEW, req)
   req.session.nextAllowedStep = stateMachine.dispatch(actions.GET_NEXT_PATH, req, steps)
 
   res.render('check', {
-    ...pageContent({ translate: req.t }),
+    ...localisation,
     claimSummaryLists: getGroupedRowData(req, steps),
-    childrensDatesOfBirthRows: children ? getChildrensDatesOfBirthRows(children) : [],
+    childrensDatesOfBirthRows: children ? getLocalisedChildrensDatesOfBirthRows(children) : [],
     previous: getLastNavigablePath(steps, req)
   })
 }

--- a/src/web/routes/application/check/get.js
+++ b/src/web/routes/application/check/get.js
@@ -1,6 +1,7 @@
 const { stateMachine, states, actions } = require('../common/state-machine')
 const { getPreviousPath } = require('../common/get-previous-path')
 const { getGroupedRowData } = require('./get-row-data')
+const { getChildrensDatesOfBirthRows } = require('./get-childrens-dates-of-birth-rows')
 
 const pageContent = ({ translate }) => ({
   title: translate('check.title'),
@@ -28,14 +29,14 @@ const getLastNavigablePath = (steps, req) => {
 }
 
 const getCheck = (steps) => (req, res) => {
+  const { children } = req.session
   stateMachine.setState(states.IN_REVIEW, req)
-
   req.session.nextAllowedStep = stateMachine.dispatch(actions.GET_NEXT_PATH, req, steps)
 
   res.render('check', {
-    children: req.session.children,
     ...pageContent({ translate: req.t }),
-    checkRowData: getGroupedRowData(req, steps),
+    claimSummaryLists: getGroupedRowData(req, steps),
+    childrensDatesOfBirthRows: children ? getChildrensDatesOfBirthRows(children) : [],
     previous: getLastNavigablePath(steps, req)
   })
 }

--- a/src/web/server/locales/cy/common.json
+++ b/src/web/server/locales/cy/common.json
@@ -105,7 +105,9 @@
     "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
     "change": "Consectetur",
     "aboutYou": "Ed vulputate",
-    "aboutYourChildren": "Lorem ipsum dolor"
+    "aboutYourChildren": "Lorem ipsum dolor",
+    "name": "Nom",
+    "dateOfBirth": "Natal eiusmod"
   },
   "terms-and-conditions": {
     "title": "Risus sed vulputate odio ut enim blandit volutpat maecenas volutpat",

--- a/src/web/server/locales/en/common.json
+++ b/src/web/server/locales/en/common.json
@@ -106,7 +106,9 @@
     "heading": "Check your answers",
     "change": "Change",
     "aboutYou": "About you",
-    "aboutYourChildren": "About your children"
+    "aboutYourChildren": "About your children",
+    "name": "Name",
+    "dateOfBirth": "Date of birth"
   },
   "terms-and-conditions": {
     "title": "Terms and conditions",

--- a/src/web/views/check.njk
+++ b/src/web/views/check.njk
@@ -7,7 +7,7 @@
   <h1 class="govuk-heading-xl">{{ heading }}</h1>
 
   <div id="claim-summary">
-    {% for list, listRows in checkRowData %}
+    {% for list, listRows in claimSummaryLists %}
       {% set classes %}
         {% if loop.last and children %} govuk-!-margin-bottom-1 {% else %} govuk-!-margin-bottom-9 {% endif %}
       {% endset %}
@@ -23,10 +23,10 @@
     {% endfor %}
   </div>
   <div id="children-summary">
-    {% if children %}
+    {% if childrensDatesOfBirthRows | length %}
       {{ htbhfChildrenSummaryList({
         classes: 'govuk-!-margin-bottom-9',
-        children: children,
+        rows: childrensDatesOfBirthRows,
         action: {
           href: "/children-dob",
           text: changeText,

--- a/src/web/views/macros/htbhf-children-summary-list.njk
+++ b/src/web/views/macros/htbhf-children-summary-list.njk
@@ -5,37 +5,10 @@
   summary list rows
 #}
 {% macro htbhfChildrenSummaryList(params) %}
-  {% set childRows = [] %}
-
-  {% for i in range(0, params.children.childCount) %}
-    {% set index = i + 1 %}
-
-    {% set name = {
-      key : {
-        text: 'Name'
-      },
-      value: {
-        text: params.children['childDobName-' + index]
-      }
-    } %}
-
-    {% set dateOfBirth = {
-      key : {
-        text: 'Date of birth'
-      },
-      value: {
-        text: params.children['childDob-' + index]
-      }
-    } %}
-
-    {% set childRowsLength = childRows.push(name) %}
-    {% set childRowsLength = childRows.push(dateOfBirth) %}
-  {% endfor %}
-
   <div class="c-htbhf-children-summary-list">
     {{ govukSummaryList({
       classes: 'govuk-summary-list--no-border ' + params.classes,
-      rows: childRows
+      rows: params.rows
     }) }}
     <div class="c-htbhf-children-summary-list__action">
       <a href="{{ params.action.href }}" class="govuk-link">


### PR DESCRIPTION
- Move building of rows for children’s dates of birth summary list out of the view (this means we can reuse date formatters without creating a new Nunjucks filter. It also follows how the rows for the other summary lists are generated)
- Format children’s dates of birth in summary list
- Import correct date formatter in acceptance tests