### PR TITLE
Remove children from session

### DIFF
--- a/src/test/acceptance/features/change-children.feature
+++ b/src/test/acceptance/features/change-children.feature
@@ -11,3 +11,10 @@ Feature: Change answer for Do you have children?
     And I say Yes to the do you have children three or younger question
     And I click continue
     Then I am shown the enter your childrens dates of birth page
+
+  Scenario: I can change my answer to no for 'Do you have children?' from the check details page
+    When I choose to change my answer to Do you have children
+    And I say No to the do you have children three or younger question
+    And I click continue
+    Then I am shown the check details page
+    And there are no children displayed

--- a/src/test/common/steps/check-details.js
+++ b/src/test/common/steps/check-details.js
@@ -143,6 +143,10 @@ Then(/^I am shown the check details page with correct page content$/, async func
   await allPageContentIsCorrectOnCheckPage()
 })
 
+Then(/^there are no children displayed$/, async function () {
+  await assertChildrensDatesOfBirthIsNotShown()
+})
+
 async function allPageContentIsCorrectOnCheckPage () {
   const h1Text = await pages.check.getH1Text()
   expect(h1Text.toString().trim()).to.have.lengthOf.at.least(1, 'expected check page H1 text to not be empty')

--- a/src/web/routes/application/children-dob/set-children-in-session.js
+++ b/src/web/routes/application/children-dob/set-children-in-session.js
@@ -1,10 +1,10 @@
-const { pickBy } = require('ramda')
+const { pickBy, isNil } = require('ramda')
 const { countKeysContainingString } = require('./count-keys')
 const { DAY_FIELD_SUFFIX } = require('./constants')
 const { isChildEntry } = require('./predicates')
 
 const setChildrenInSessionForGet = (req) => {
-  if (!req.session.hasOwnProperty('children')) {
+  if (isNil(req.session.children)) {
     req.session.children = {
       inputCount: 1,
       childCount: 0

--- a/src/web/routes/application/do-you-have-children-three-or-younger/do-you-have-children-three-or-younger.js
+++ b/src/web/routes/application/do-you-have-children-three-or-younger/do-you-have-children-three-or-younger.js
@@ -1,5 +1,5 @@
 const { validate } = require('./validate')
-const { YES } = require('../common/constants')
+const { YES, NO } = require('../common/constants')
 
 const pageContent = ({ translate }) => ({
   title: translate('doYouHaveChildrenThreeOrYounger.title'),
@@ -20,6 +20,14 @@ const contentSummary = (req) => ({
 
 const claimantHasChildren = claim => claim.doYouHaveChildrenThreeOrYounger === YES
 
+const behaviourForPost = (req, res, next) => {
+  if (req.body.doYouHaveChildrenThreeOrYounger === NO) {
+    req.session.children = null
+  }
+
+  next()
+}
+
 const doYouHaveChildrenThreeOrYounger = {
   path: '/do-you-have-children-three-or-younger',
   next,
@@ -27,9 +35,11 @@ const doYouHaveChildrenThreeOrYounger = {
   pageContent,
   validate,
   contentSummary,
-  shouldInvalidateReview: claimantHasChildren
+  shouldInvalidateReview: claimantHasChildren,
+  behaviourForPost
 }
 
 module.exports = {
-  doYouHaveChildrenThreeOrYounger
+  doYouHaveChildrenThreeOrYounger,
+  behaviourForPost
 }

--- a/src/web/routes/application/do-you-have-children-three-or-younger/do-you-have-children-three-or-younger.test.js
+++ b/src/web/routes/application/do-you-have-children-three-or-younger/do-you-have-children-three-or-younger.test.js
@@ -1,0 +1,49 @@
+const test = require('tape')
+const sinon = require('sinon')
+const { behaviourForPost } = require('./do-you-have-children-three-or-younger')
+const { YES, NO } = require('../common/constants')
+
+const children = {
+  'childName-1': 'Lisa',
+  'childDob-1': '2018-02-22'
+}
+
+test('behaviourForPost() removes children from session when answer to “Do you have children” is “no”', (t) => {
+  const req = {
+    session: {
+      children
+    },
+    body: {
+      doYouHaveChildrenThreeOrYounger: NO
+    }
+  }
+
+  const res = {}
+  const next = sinon.spy()
+
+  behaviourForPost(req, res, next)
+
+  t.equal(req.session.children, null, 'removes children from session')
+  t.equal(next.called, true, 'calls next')
+  t.end()
+})
+
+test('behaviourForPost() does not update children when answer to “Do you have children” is “yes”', (t) => {
+  const req = {
+    session: {
+      children
+    },
+    body: {
+      doYouHaveChildrenThreeOrYounger: YES
+    }
+  }
+
+  const res = {}
+  const next = sinon.spy()
+
+  behaviourForPost(req, res, next)
+
+  t.deepEqual(req.session.children, children, 'does not update children')
+  t.equal(next.called, true, 'calls next')
+  t.end()
+})

--- a/src/web/routes/application/terms-and-conditions/create-request-body.js
+++ b/src/web/routes/application/terms-and-conditions/create-request-body.js
@@ -1,3 +1,4 @@
+const { isNil } = require('ramda')
 const { toDateString } = require('../common/formatters')
 const { YES } = require('../common/constants')
 
@@ -13,7 +14,7 @@ const createExpectedDeliveryDate = (claim) => {
 }
 
 const createChildrenDobArray = (children) => {
-  if (typeof children === 'undefined') {
+  if (isNil(children)) {
     return null
   }
 

--- a/src/web/routes/application/terms-and-conditions/create-request-body.test.js
+++ b/src/web/routes/application/terms-and-conditions/create-request-body.test.js
@@ -173,6 +173,13 @@ test('createChildrenDob returns null with undefined children object provided', (
   t.end()
 })
 
+test('createChildrenDob returns null when children argument is null', (t) => {
+  const childrenList = createChildrenDobArray(null)
+
+  t.equals(childrenList, null)
+  t.end()
+})
+
 test('createChildrenDob throws an error when the childCount is 1 and there is no date of birth in the session.children object', (t) => {
   // This object is invalid because it doesn't have the constructed date for the first child under the key childDob-1
   const invalidConstructedChildren = {


### PR DESCRIPTION
Remove children from session when changing answer for “Do you have children?” from “Yes” to “No”.

Checking children's existence on session is now implemented using `isNil` which allows for checking both `null` and `undefined`. An alternative would be to remove `children` using the `delete` operator.