### PR TITLE
Create basic guidance pages structure

### DIFF
--- a/src/web/routes/guidance.js
+++ b/src/web/routes/guidance.js
@@ -1,0 +1,71 @@
+const { compose, equals, prop } = require('ramda')
+const { handleRequestForPath } = require('./application/middleware')
+
+const pages = [
+  {
+    title: 'How it works',
+    path: '/how-it-works'
+  },
+  {
+    title: 'Eligibility',
+    path: '/eligibility'
+  },
+  {
+    title: 'What you can buy',
+    path: '/what-you-can-buy'
+  },
+  {
+    title: 'Using your card',
+    path: '/using-your-card'
+  },
+  {
+    title: 'Apply for Healthy Start',
+    path: '/apply-for-healthy-start'
+  },
+  {
+    title: 'Report a change',
+    path: '/report-a-change'
+  }
+]
+
+const hasMatchingPath = (path) => compose(equals(path), prop('path'))
+
+const getPreviousPage = (pages, index) => pages[index - 1]
+
+const getNextPage = (pages, index) => pages[index + 1]
+
+const getPageMetadata = (pages, path) => {
+  const pageIndexForPath = pages.findIndex(hasMatchingPath(path))
+  const page = getPageForPath(pages, path)
+
+  return {
+    activePath: path,
+    previous: getPreviousPage(pages, pageIndexForPath),
+    next: getNextPage(pages, pageIndexForPath),
+    title: page.title
+  }
+}
+
+const getPageForPath = (pages, path) => pages.find(hasMatchingPath(path))
+
+const getHowItWorks = (req, res) => {
+  res.render('guidance/how-it-works', {
+    ...getPageMetadata(pages, '/how-it-works')
+  })
+}
+
+/**
+ * handleRequestForPath() checks the state machine before rendering the page to see if the session
+ * needs to be cleared.
+ */
+const registerGuidanceRoutes = (config, steps, app) => {
+  app.get('/how-it-works', handleRequestForPath(config, steps), getHowItWorks)
+}
+
+module.exports = {
+  registerGuidanceRoutes,
+  getPageForPath,
+  getNextPage,
+  getPreviousPage,
+  getPageMetadata
+}

--- a/src/web/routes/guidance.test.js
+++ b/src/web/routes/guidance.test.js
@@ -1,0 +1,76 @@
+const test = require('tape')
+
+const { getPageForPath, getNextPage, getPreviousPage, getPageMetadata } = require('./guidance')
+
+const page1 = {
+  title: 'How it works',
+  path: '/how-it-works'
+}
+const page2 = {
+  title: 'Eligibility',
+  path: '/eligibility'
+}
+const page3 = {
+  title: 'What you can buy',
+  path: '/what-you-can-buy'
+}
+const pages = [page1, page2, page3]
+
+test('getPageForPath() should return the correct page object', (t) => {
+  t.deepEqual(getPageForPath(pages, '/how-it-works'), page1, 'should return correct page object')
+  t.deepEqual(getPageForPath(pages, '/eligibility'), page2, 'should return correct page object')
+  t.deepEqual(getPageForPath(pages, '/what-you-can-buy'), page3, 'should return correct page object')
+  t.equal(getPageForPath(pages, '/unknown'), undefined, 'should return undefined for unknown page')
+  t.end()
+})
+
+test('getNextPage() should return the next page for the given index', (t) => {
+  t.deepEqual(getNextPage(pages, 0), page2, 'should return correct next page object')
+  t.deepEqual(getNextPage(pages, 1), page3, 'should return correct next page object')
+  t.deepEqual(getNextPage(pages, 2), undefined, 'should return undefined for last page index')
+  t.equal(getNextPage(pages, 7), undefined, 'should return undefined for index too high')
+  t.equal(getNextPage(pages, -5), undefined, 'should return undefined for index too low')
+  t.end()
+})
+
+test('getPreviousPage() should return the previous page for the given index', (t) => {
+  t.deepEqual(getPreviousPage(pages, 0), undefined, 'should return undefined for first path in list')
+  t.deepEqual(getPreviousPage(pages, 1), page1, 'should return correct previous page object')
+  t.deepEqual(getPreviousPage(pages, 2), page2, 'should return correct previous page object')
+  t.equal(getPreviousPage(pages, 7), undefined, 'should return undefined for index too high')
+  t.equal(getPreviousPage(pages, -5), undefined, 'should return undefined for index too low')
+  t.end()
+})
+
+test('getPageMetadata() should return the correct metadata when has both next and previous', (t) => {
+  const expected = {
+    activePath: '/eligibility',
+    previous: page1,
+    next: page3,
+    title: 'Eligibility'
+  }
+  t.deepEqual(getPageMetadata(pages, '/eligibility'), expected, 'should return correct metadata')
+  t.end()
+})
+
+test('getPageMetadata() should return the correct metadata when has only next is available', (t) => {
+  const expected = {
+    activePath: '/how-it-works',
+    previous: undefined,
+    next: page2,
+    title: 'How it works'
+  }
+  t.deepEqual(getPageMetadata(pages, '/how-it-works'), expected, 'should return correct metadata')
+  t.end()
+})
+
+test('getPageMetadata() should return the correct metadata when has only previous', (t) => {
+  const expected = {
+    activePath: '/what-you-can-buy',
+    previous: page2,
+    next: undefined,
+    title: 'What you can buy'
+  }
+  t.deepEqual(getPageMetadata(pages, '/what-you-can-buy'), expected, 'should return correct metadata')
+  t.end()
+})

--- a/src/web/routes/register-routes.js
+++ b/src/web/routes/register-routes.js
@@ -8,6 +8,7 @@ const { registerPrivacyNoticeRoute } = require('./privacy-notice')
 const { getLanguageBase } = require('./language')
 const { registerHoldingRoute } = require('./application/holding')
 const { registerPageNotFoundRoute } = require('./application/page-not-found')
+const { registerGuidanceRoutes } = require('./guidance')
 
 const { steps } = require('./application/steps')
 const { registerFormRoutes } = require('./application/register-form-routes')
@@ -35,6 +36,7 @@ const registerRoutes = (config, app) => {
     registerConfirmRoute(config, steps, app)
     registerCookiesRoute(app)
     registerPrivacyNoticeRoute(app)
+    registerGuidanceRoutes(config, steps, app)
 
     // Page not found route should always be registered last as it is a catch all route
     registerPageNotFoundRoute(app)

--- a/src/web/views/guidance/how-it-works.njk
+++ b/src/web/views/guidance/how-it-works.njk
@@ -1,0 +1,6 @@
+{% extends "../templates/guidance.njk" %}
+
+{% block guidanceContent %}
+  <h2 class="govuk-heading-xl">{{ title }}</h2>
+This is how it works...
+{% endblock %}

--- a/src/web/views/templates/guidance.njk
+++ b/src/web/views/templates/guidance.njk
@@ -1,0 +1,20 @@
+{% extends "./page.njk" %}
+
+{% block pageContent %}
+  <h1 class="govuk-heading-xl">Get money off milk, food and vitamins (Healthy Start)</h1>
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+  {% block guidanceContent %}{% endblock %}
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+  {% if previous %}
+  <div>
+    <a class="govuk-link govuk-body" href="{{ previous.path }}"><strong>Previous</strong><br />{{ previous.title }}</a>
+  </div>
+  {% endif %}
+  {% if next %}
+  <div>
+    <a class="govuk-link govuk-body" href="{{ next.path }}"><strong>Next</strong><br />{{ next.title }}</a>
+  </div>
+  {% endif %}
+
+{% endblock %}


### PR DESCRIPTION
- Created base Nunjucks template for guidance pages to extend from
- Registered route for first guidance page. This route will eventually change but is indicative of how all the guidance page routes will be registered
- Pass navigation meta data to the view

Future PRs to story branch will:
- Register other guidance page routes
- Deal with translations
- Display page content
- Display contents navigation