### PR TITLE
HTBHF-1964 Add acceptance tests for guidance pages.

### DIFF
--- a/src/test/acceptance/features/guidance-pages.feature
+++ b/src/test/acceptance/features/guidance-pages.feature
@@ -10,7 +10,7 @@ Feature: Guidance pages
       | page                    |
       | How it works            |
       | Eligibility             |
-      | What you get            |
+      | What you’ll get         |
       | What you can buy        |
       | Using your card         |
       | Apply for Healthy Start |

--- a/src/test/acceptance/features/guidance-pages.feature
+++ b/src/test/acceptance/features/guidance-pages.feature
@@ -1,0 +1,17 @@
+Feature: Guidance pages
+  Before applying for the  Apply for Healthy Start programme
+  As a potential claimant
+  I want to see the guidance pages before I start the application process
+
+  Scenario Outline: The guidance pages are present and navigable
+    Given I open the <page> guidance page
+    Then all the <page> guidance page content is present
+    Examples:
+      | page                    |
+      | How it works            |
+      | Eligibility             |
+      | What you get            |
+      | What you can buy        |
+      | Using your card         |
+      | Apply for Healthy Start |
+      | Report a change         |

--- a/src/test/common/page/guidance.js
+++ b/src/test/common/page/guidance.js
@@ -1,5 +1,5 @@
 'use strict'
-
+const { head, last } = require('ramda')
 const Page = require('./page')
 
 const { PAGES, getPageMetadata } = require('../../../web/routes/guidance')
@@ -20,7 +20,7 @@ class Guidance extends Page {
   }
 
   getPageTitle (pageName) {
-    return 'GOV.UK - ' + pageName
+    return `GOV.UK - ${pageName}`
   }
 
   getPageWithTitle (pages, pageName) {
@@ -28,11 +28,11 @@ class Guidance extends Page {
   }
 
   hasPreviousLink (pageName) {
-    return pageName !== 'How it works'
+    return pageName !== head(PAGES).title
   }
 
   hasNextLink (pageName) {
-    return pageName !== 'Report a change'
+    return pageName !== last(PAGES).title
   }
 
   getNextLink (pageName) {
@@ -59,9 +59,9 @@ class Guidance extends Page {
 
   // Find links in the contents section, which should be for all the pages except the current page
   async getContentsLinks (pageName) {
-    const allPageExceptCurrent = PAGES.filter(page => page.title !== pageName)
-    const pagePath = allPageExceptCurrent.map(async (page) => this.findLinkForHref(this.getPageMetadataForPage(page.title).activePath))
-    return Promise.all(pagePath)
+    const allPagesExceptCurrent = PAGES.filter(page => page.title !== pageName)
+    const pagePaths = allPagesExceptCurrent.map(async (page) => this.findLinkForHref(this.getPageMetadataForPage(page.title).activePath))
+    return Promise.all(pagePaths)
   }
 
   async findLinkForHref (href) {

--- a/src/test/common/page/guidance.js
+++ b/src/test/common/page/guidance.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const Page = require('./page')
+
+const { PAGES, getPageMetadata } = require('../../../web/routes/guidance')
+
+/**
+ * Page object for all the guidance pages. This may extend Page, but as it represent multiple static page, it must
+ * implement its own methods for navigation, but can use all the find methods from Page when required.
+ */
+class Guidance extends Page {
+  async openGuidancePage (baseURL, pageName, lang = 'en') {
+    try {
+      await this.openPage(`${baseURL}${this.getPageWithTitle(PAGES, pageName).path}`, lang)
+      return super.waitForPageWithTitle(this.getPageTitle(pageName))
+    } catch (error) {
+      console.error(`Error caught trying to open guidance page at: ${baseURL}`, error)
+      throw new Error(error)
+    }
+  }
+
+  getPageTitle (pageName) {
+    return 'GOV.UK - ' + pageName
+  }
+
+  getPageWithTitle (pages, pageName) {
+    return pages.find(page => page.title === pageName)
+  }
+
+  hasPreviousLink (pageName) {
+    return pageName !== 'How it works'
+  }
+
+  hasNextLink (pageName) {
+    return pageName !== 'Report a change'
+  }
+
+  getNextLink (pageName) {
+    return this.getPageMetadataForPage(pageName).next
+  }
+
+  getPreviousLink (pageName) {
+    return this.getPageMetadataForPage(pageName).previous
+  }
+
+  getPageMetadataForPage (pageName) {
+    return getPageMetadata(PAGES, this.getPageWithTitle(PAGES, pageName).path)
+  }
+
+  async findNextLinkForPage (pageName) {
+    const nextLinkHref = this.getNextLink(pageName).path
+    return this.findLinkForHref(nextLinkHref)
+  }
+
+  async findPreviousLinkForPage (pageName) {
+    const previousLinkHref = this.getPreviousLink(pageName).path
+    return this.findLinkForHref(previousLinkHref)
+  }
+
+  // Find links in the contents section, which should be for all the pages except the current page
+  async getContentsLinks (pageName) {
+    const allPageExceptCurrent = PAGES.filter(page => page.title !== pageName)
+    const pagePath = allPageExceptCurrent.map(async (page) => this.findLinkForHref(this.getPageMetadataForPage(page.title).activePath))
+    return Promise.all(pagePath)
+  }
+
+  async findLinkForHref (href) {
+    const linkCss = `a[href="${href}"]`
+    return this.findByCSS(linkCss)
+  }
+}
+
+module.exports = Guidance

--- a/src/test/common/page/guidance.js
+++ b/src/test/common/page/guidance.js
@@ -36,11 +36,11 @@ class Guidance extends Page {
   }
 
   getNextLink (pageName) {
-    return this.getPageMetadataForPage(pageName).next
+    return this.getPageMetadataForPage(pageName).nextPage
   }
 
   getPreviousLink (pageName) {
-    return this.getPageMetadataForPage(pageName).previous
+    return this.getPageMetadataForPage(pageName).previousPage
   }
 
   getPageMetadataForPage (pageName) {

--- a/src/test/common/page/page.js
+++ b/src/test/common/page/page.js
@@ -102,8 +102,8 @@ class Page {
     return this.findAllBy(CLASSNAME_TYPE, className)
   }
 
-  async findByCSS (className, scope) {
-    return this.findBy(CSS_TYPE, className, scope)
+  async findByCSS (selector, scope) {
+    return this.findBy(CSS_TYPE, selector, scope)
   }
 
   async findAllByCSS (selector) {

--- a/src/test/common/page/submittable-page-with-radio-buttons.js
+++ b/src/test/common/page/submittable-page-with-radio-buttons.js
@@ -33,11 +33,11 @@ class SubmittablePageWithRadioButtons extends SubmittablePage {
     return this.driver.findElements(webdriver.By.className('govuk-radios__item'))
   }
 
-  async getAllRadioLabels (option) {
+  async getAllRadioLabels () {
     try {
       return this.driver.findElements(webdriver.By.className('govuk-label govuk-radios__label'))
     } catch (error) {
-      console.log(`Error getting radio button with option ${option}`)
+      console.log(`Error getting all radio button labels`)
       throw new Error(error)
     }
   }

--- a/src/test/common/steps/guidance-steps.js
+++ b/src/test/common/steps/guidance-steps.js
@@ -1,0 +1,46 @@
+const { When, Then } = require('cucumber')
+const { expect } = require('chai')
+
+const pages = require('./pages')
+
+When(/^I open the (.*) guidance page$/, async function (pageName) {
+  await pages.guidance.openGuidancePage(pages.url, pageName)
+})
+
+Then(/^all the (.*) guidance page content is present$/, async function (pageName) {
+  await assertGuidancePageHeadersCorrect(pageName)
+  await assertGuidancePageContentsCorrect(pageName)
+  await assertGuidancePageNavigationLinksCorrect(pageName)
+})
+
+async function assertGuidancePageHeadersCorrect (pageName) {
+  const h1Text = await pages.cookies.getH1Text()
+  expect(h1Text.toString().trim()).to.be.equal('Get money off milk, food and vitamins (Healthy Start)',
+    'expected guidance page H1 text to be correct')
+  const h2Text = await pages.cookies.getH2Text()
+  let expectedH2PageName = pageName
+  if (pageName === 'What you get') {
+    // Page title from pages doesn't match what's in the title of the What you get page
+    expectedH2PageName = 'What you’ll get'
+  }
+  expect(h2Text.toString().trim()).to.be.equal(expectedH2PageName, 'expected guidance page H2 text to be correct')
+}
+
+// Make sure that the links in the table of contents are correct on the page
+async function assertGuidancePageContentsCorrect (pageName) {
+  const contentLinks = await pages.guidance.getContentsLinks(pageName)
+  expect(contentLinks).to.be.lengthOf(6, 'must have correct number of contents links')
+}
+
+// Make sure there is the correct previous / next links on the page
+async function assertGuidancePageNavigationLinksCorrect (pageName) {
+  if (pages.guidance.hasPreviousLink(pageName)) {
+    const previousLink = await pages.guidance.findPreviousLinkForPage(pageName)
+    expect(previousLink.toString().trim()).not.to.be.equal(undefined)
+  }
+
+  if (pages.guidance.hasNextLink(pageName)) {
+    const nextLink = await pages.guidance.findNextLinkForPage(pageName)
+    expect(nextLink.toString().trim()).not.to.be.equal(undefined)
+  }
+}

--- a/src/test/common/steps/guidance-steps.js
+++ b/src/test/common/steps/guidance-steps.js
@@ -18,12 +18,7 @@ async function assertGuidancePageHeadersCorrect (pageName) {
   expect(h1Text.toString().trim()).to.be.equal('Get money off milk, food and vitamins (Healthy Start)',
     'expected guidance page H1 text to be correct')
   const h2Text = await pages.cookies.getH2Text()
-  let expectedH2PageName = pageName
-  if (pageName === 'What you get') {
-    // Page title from pages doesn't match what's in the title of the What you get page
-    expectedH2PageName = 'What you’ll get'
-  }
-  expect(h2Text.toString().trim()).to.be.equal(expectedH2PageName, 'expected guidance page H2 text to be correct')
+  expect(h2Text.toString().trim()).to.be.equal(pageName, 'expected guidance page H2 text to be correct')
 }
 
 // Make sure that the links in the table of contents are correct on the page

--- a/src/test/common/steps/pages.js
+++ b/src/test/common/steps/pages.js
@@ -22,6 +22,7 @@ const DoYouHaveChildren = require('../page/do-you-have-children')
 const SendCode = require('../page/send-code')
 const EnterChildrenDOB = require('../page/enter-children-dob')
 const EnterCode = require('../page/enter-code')
+const Guidance = require('../page/guidance')
 const { URL, DRIVER_MANAGER } = require('./test-startup-config')
 
 /**
@@ -66,6 +67,7 @@ class Pages {
     this.enterCode = null
     this.url = URL
     this.allPages = null
+    this.guidance = null
   }
 
   /**
@@ -97,6 +99,8 @@ class Pages {
     this.sendCode = new SendCode(this.driver)
     this.enterChildrenDOB = new EnterChildrenDOB(this.driver)
     this.enterCode = new EnterCode(this.driver)
+    // NOTE: The guidance page is not added to the list of allPages as it has its own navigation methods
+    this.guidance = new Guidance(this.driver)
     // NOTE: This map should contain all page objects, and not the Generic Page as this doesn't itself represent a page
     this.allPages = [this.overview, this.enterName, this.enterNino, this.enterDOB, this.areYouPregnant, this.manualAddress, this.phoneNumber,
       this.check, this.confirm, this.cookies, this.privacyNotice, this.confirmUpdated, this.doYouLiveInScotland, this.iLiveInScotland, this.emailAddress,

--- a/src/web/routes/guidance/get-page-meta-data.js
+++ b/src/web/routes/guidance/get-page-meta-data.js
@@ -1,5 +1,7 @@
 const { compose, equals, prop } = require('ramda')
 
+const getPageForPath = (pages, path) => pages.find(hasMatchingPath(path))
+
 const hasMatchingPath = (path) => compose(equals(path), prop('path'))
 
 const getPreviousPage = (pages, index) => pages[index - 1]
@@ -8,15 +10,18 @@ const getNextPage = (pages, index) => pages[index + 1]
 
 const getPageMetadata = (pages, path) => {
   const pageIndexForPath = pages.findIndex(hasMatchingPath(path))
+  const page = getPageForPath(pages, path)
 
   return {
     activePath: path,
     previousPage: getPreviousPage(pages, pageIndexForPath),
-    nextPage: getNextPage(pages, pageIndexForPath)
+    nextPage: getNextPage(pages, pageIndexForPath),
+    title: page.title
   }
 }
 
 module.exports = {
+  getPageForPath,
   getNextPage,
   getPreviousPage,
   getPageMetadata

--- a/src/web/routes/guidance/get-page-meta-data.test.js
+++ b/src/web/routes/guidance/get-page-meta-data.test.js
@@ -1,6 +1,6 @@
 const test = require('tape')
 
-const { getNextPage, getPreviousPage, getPageMetadata } = require('./get-page-meta-data')
+const { getPageForPath, getNextPage, getPreviousPage, getPageMetadata } = require('./get-page-meta-data')
 
 const page1 = {
   title: 'How it works',
@@ -15,6 +15,14 @@ const page3 = {
   path: '/what-you-can-buy'
 }
 const pages = [page1, page2, page3]
+
+test('getPageForPath() should return the correct page object', (t) => {
+  t.deepEqual(getPageForPath(pages, '/how-it-works'), page1, 'should return correct page object')
+  t.deepEqual(getPageForPath(pages, '/eligibility'), page2, 'should return correct page object')
+  t.deepEqual(getPageForPath(pages, '/what-you-can-buy'), page3, 'should return correct page object')
+  t.equal(getPageForPath(pages, '/unknown'), undefined, 'should return undefined for unknown page')
+  t.end()
+})
 
 test('getNextPage() should return the next page for the given index', (t) => {
   t.deepEqual(getNextPage(pages, 0), page2, 'should return correct next page object')
@@ -38,7 +46,8 @@ test('getPageMetadata() should return the correct metadata when has both next an
   const expected = {
     activePath: '/eligibility',
     previousPage: page1,
-    nextPage: page3
+    nextPage: page3,
+    title: 'Eligibility'
   }
   t.deepEqual(getPageMetadata(pages, '/eligibility'), expected, 'should return correct metadata')
   t.end()
@@ -48,7 +57,8 @@ test('getPageMetadata() should return the correct metadata when has only next is
   const expected = {
     activePath: '/how-it-works',
     previousPage: undefined,
-    nextPage: page2
+    nextPage: page2,
+    title: 'How it works'
   }
   t.deepEqual(getPageMetadata(pages, '/how-it-works'), expected, 'should return correct metadata')
   t.end()
@@ -58,7 +68,8 @@ test('getPageMetadata() should return the correct metadata when has only previou
   const expected = {
     activePath: '/what-you-can-buy',
     previousPage: page2,
-    nextPage: undefined
+    nextPage: undefined,
+    title: 'What you can buy'
   }
   t.deepEqual(getPageMetadata(pages, '/what-you-can-buy'), expected, 'should return correct metadata')
   t.end()

--- a/src/web/routes/guidance/guidance.js
+++ b/src/web/routes/guidance/guidance.js
@@ -5,7 +5,7 @@ const { getPageMetadata } = require('./get-page-meta-data')
 const { PAGES } = require('./pages')
 
 const internationalisation = (translateFn) => ({
-  title: translateFn('guidance.title'),
+  heading: translateFn('guidance.heading'),
   navigationHeading: translateFn('guidance.navigationHeading'),
   previousLabel: translateFn('previous'),
   nextLabel: translateFn('next')

--- a/src/web/routes/guidance/index.js
+++ b/src/web/routes/guidance/index.js
@@ -1,3 +1,7 @@
+const { getPageMetadata } = require('./get-page-meta-data')
+
 module.exports = {
-  ...require('./guidance')
+  ...require('./guidance'),
+  ...require('./pages'),
+  getPageMetadata
 }

--- a/src/web/routes/guidance/pages.js
+++ b/src/web/routes/guidance/pages.js
@@ -8,7 +8,7 @@ module.exports.PAGES = [
     path: '/eligibility'
   },
   {
-    title: 'What you get',
+    title: 'What you’ll get',
     path: '/what-you-get'
   },
   {

--- a/src/web/server/locales/en/common.json
+++ b/src/web/server/locales/en/common.json
@@ -156,7 +156,7 @@
     "heading": "You cannot apply if you live in Scotland"
   },
   "guidance": {
-    "title": "Get money off milk, food and vitamins (Healthy Start)",
+    "heading": "Get money off milk, food and vitamins (Healthy Start)",
     "navigationHeading": "Contents"
   },
   "yes": "Yes",

--- a/src/web/views/templates/guidance.njk
+++ b/src/web/views/templates/guidance.njk
@@ -2,7 +2,7 @@
 {% from "macros/htbhf-pagination.njk" import htbhfPagination %}
 
 {% block pageContent %}
-  <h1 class="govuk-heading-xl">{{ title }}</h1>
+  <h1 class="govuk-heading-xl">{{ heading }}</h1>
 
   <p class="govuk-body">{{ navigationHeading }}</p>
 


### PR DESCRIPTION
 - The page object for guidance pages is a bit different because it encapsulates all the guidance pages so has its own navigation step and function.
 - The tests themselves assert that the headers are correct, that there a links for all pages (table of contents) apart from the page itself, plus there are previous and next links if applicable. There are no assertions for actual content.

This was my best stab at getting the feature file correct, please feel free to suggest alternatives, I found it quite hard to get them right so they might not be perfect yet.