### PR TITLE
Guidance page translations

### DIFF
--- a/src/web/routes/guidance/get-page-meta-data.js
+++ b/src/web/routes/guidance/get-page-meta-data.js
@@ -1,7 +1,5 @@
 const { compose, equals, prop } = require('ramda')
 
-const getPageForPath = (pages, path) => pages.find(hasMatchingPath(path))
-
 const hasMatchingPath = (path) => compose(equals(path), prop('path'))
 
 const getPreviousPage = (pages, index) => pages[index - 1]
@@ -10,18 +8,15 @@ const getNextPage = (pages, index) => pages[index + 1]
 
 const getPageMetadata = (pages, path) => {
   const pageIndexForPath = pages.findIndex(hasMatchingPath(path))
-  const page = getPageForPath(pages, path)
 
   return {
     activePath: path,
     previousPage: getPreviousPage(pages, pageIndexForPath),
-    nextPage: getNextPage(pages, pageIndexForPath),
-    title: page.title
+    nextPage: getNextPage(pages, pageIndexForPath)
   }
 }
 
 module.exports = {
-  getPageForPath,
   getNextPage,
   getPreviousPage,
   getPageMetadata

--- a/src/web/routes/guidance/get-page-meta-data.js
+++ b/src/web/routes/guidance/get-page-meta-data.js
@@ -14,8 +14,8 @@ const getPageMetadata = (pages, path) => {
 
   return {
     activePath: path,
-    previous: getPreviousPage(pages, pageIndexForPath),
-    next: getNextPage(pages, pageIndexForPath),
+    previousPage: getPreviousPage(pages, pageIndexForPath),
+    nextPage: getNextPage(pages, pageIndexForPath),
     title: page.title
   }
 }

--- a/src/web/routes/guidance/get-page-meta-data.test.js
+++ b/src/web/routes/guidance/get-page-meta-data.test.js
@@ -1,6 +1,6 @@
 const test = require('tape')
 
-const { getPageForPath, getNextPage, getPreviousPage, getPageMetadata } = require('./get-page-meta-data')
+const { getNextPage, getPreviousPage, getPageMetadata } = require('./get-page-meta-data')
 
 const page1 = {
   title: 'How it works',
@@ -15,14 +15,6 @@ const page3 = {
   path: '/what-you-can-buy'
 }
 const pages = [page1, page2, page3]
-
-test('getPageForPath() should return the correct page object', (t) => {
-  t.deepEqual(getPageForPath(pages, '/how-it-works'), page1, 'should return correct page object')
-  t.deepEqual(getPageForPath(pages, '/eligibility'), page2, 'should return correct page object')
-  t.deepEqual(getPageForPath(pages, '/what-you-can-buy'), page3, 'should return correct page object')
-  t.equal(getPageForPath(pages, '/unknown'), undefined, 'should return undefined for unknown page')
-  t.end()
-})
 
 test('getNextPage() should return the next page for the given index', (t) => {
   t.deepEqual(getNextPage(pages, 0), page2, 'should return correct next page object')
@@ -45,9 +37,8 @@ test('getPreviousPage() should return the previous page for the given index', (t
 test('getPageMetadata() should return the correct metadata when has both next and previous', (t) => {
   const expected = {
     activePath: '/eligibility',
-    previous: page1,
-    next: page3,
-    title: 'Eligibility'
+    previousPage: page1,
+    nextPage: page3
   }
   t.deepEqual(getPageMetadata(pages, '/eligibility'), expected, 'should return correct metadata')
   t.end()
@@ -56,9 +47,8 @@ test('getPageMetadata() should return the correct metadata when has both next an
 test('getPageMetadata() should return the correct metadata when has only next is available', (t) => {
   const expected = {
     activePath: '/how-it-works',
-    previous: undefined,
-    next: page2,
-    title: 'How it works'
+    previousPage: undefined,
+    nextPage: page2
   }
   t.deepEqual(getPageMetadata(pages, '/how-it-works'), expected, 'should return correct metadata')
   t.end()
@@ -67,9 +57,8 @@ test('getPageMetadata() should return the correct metadata when has only next is
 test('getPageMetadata() should return the correct metadata when has only previous', (t) => {
   const expected = {
     activePath: '/what-you-can-buy',
-    previous: page2,
-    next: undefined,
-    title: 'What you can buy'
+    previousPage: page2,
+    nextPage: undefined
   }
   t.deepEqual(getPageMetadata(pages, '/what-you-can-buy'), expected, 'should return correct metadata')
   t.end()

--- a/src/web/routes/guidance/guidance.js
+++ b/src/web/routes/guidance/guidance.js
@@ -4,10 +4,18 @@ const { getLanguageBase } = require('../language')
 const { getPageMetadata } = require('./get-page-meta-data')
 const { PAGES } = require('./pages')
 
+const internationalisation = (translateFn) => ({
+  title: translateFn('guidance.title'),
+  navigationHeading: translateFn('guidance.navigationHeading'),
+  previousLabel: translateFn('previous'),
+  nextLabel: translateFn('next')
+})
+
 const renderGuidanceRoute = (pages, path) => (req, res) =>
   res.render(`guidance/${getLanguageBase(req.language)}/${path}`, {
     pages,
-    ...getPageMetadata(pages, path)
+    ...getPageMetadata(pages, path),
+    ...internationalisation(req.t)
   })
 
 const registerGuidanceRoute = (router) => (page, index, pages) => router.get(page.path, renderGuidanceRoute(pages, page.path))

--- a/src/web/server/locales/cy/common.json
+++ b/src/web/server/locales/cy/common.json
@@ -154,9 +154,15 @@
     "title": "Sed do eiusmod tempor incididunt ut labore et dolore",
     "heading": "Sed do eiusmod tempor incididunt ut labore et dolore"
   },
+  "guidance": {
+    "title": "Ex monetaria mooeo, vitus et grub (Healthy Start)",
+    "navigationHeading": "Contentus"
+  },
   "yes": "Diam",
   "no": "Sed",
   "back": "Kcab",
   "text": "Occaecat",
-  "email": "Lobortis"
+  "email": "Lobortis",
+  "previous": "Preveo",
+  "next": "Sequentur"
 }

--- a/src/web/server/locales/en/common.json
+++ b/src/web/server/locales/en/common.json
@@ -155,10 +155,16 @@
     "title": "You cannot apply if you live in Scotland",
     "heading": "You cannot apply if you live in Scotland"
   },
+  "guidance": {
+    "title": "Get money off milk, food and vitamins (Healthy Start)",
+    "navigationHeading": "Contents"
+  },
   "yes": "Yes",
   "no": "No",
   "back": "Back",
   "whyDoWeNeedThis": "Why do we need this?",
   "text": "Text",
-  "email": "Email"
+  "email": "Email",
+  "previous": "Previous",
+  "next": "Next"
 }

--- a/src/web/views/macros/htbhf-pagination.njk
+++ b/src/web/views/macros/htbhf-pagination.njk
@@ -3,31 +3,31 @@
   Next and previous pagination links for pages in a sequence
 
   params:
-  next: {
+  nextPage: {
     title: string,
     path: string
   }
-  previous: {
+  previousPage: {
     title: string,
     path: string
   }
 #}
 {% macro htbhfPagination(params) %}
   <div class ="c-htbhf-pagination">
-    {% if params.previous %}
+    {% if params.previousPage %}
       {{ htbhfPaginationLink({
         direction: 'previous',
         directionLabel: 'Previous',
-        title: params.previous.title,
-        path: params.previous.path
+        title: params.previousPage.title,
+        path: params.previousPage.path
       }) }}
     {% endif %}
-    {% if params.next %}
+    {% if params.nextPage %}
       {{ htbhfPaginationLink({
         direction: 'next',
         directionLabel: 'Next',
-        title: params.next.title,
-        path: params.next.path
+        title: params.nextPage.title,
+        path: params.nextPage.path
       }) }}
     {% endif %}
   </div>

--- a/src/web/views/macros/htbhf-pagination.njk
+++ b/src/web/views/macros/htbhf-pagination.njk
@@ -3,6 +3,8 @@
   Next and previous pagination links for pages in a sequence
 
   params:
+  previousLabel: string
+  nextLabel: string
   nextPage: {
     title: string,
     path: string
@@ -17,7 +19,7 @@
     {% if params.previousPage %}
       {{ htbhfPaginationLink({
         direction: 'previous',
-        directionLabel: 'Previous',
+        directionLabel: params.previousLabel,
         title: params.previousPage.title,
         path: params.previousPage.path
       }) }}
@@ -25,7 +27,7 @@
     {% if params.nextPage %}
       {{ htbhfPaginationLink({
         direction: 'next',
-        directionLabel: 'Next',
+        directionLabel: params.nextLabel,
         title: params.nextPage.title,
         path: params.nextPage.path
       }) }}

--- a/src/web/views/templates/guidance.njk
+++ b/src/web/views/templates/guidance.njk
@@ -17,7 +17,7 @@
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-7">
 
   {{ htbhfPagination({
-    previous: previous,
-    next: next
+    previousPage: previousPage,
+    nextPage: nextPage
   }) }}
 {% endblock %}

--- a/src/web/views/templates/guidance.njk
+++ b/src/web/views/templates/guidance.njk
@@ -2,9 +2,9 @@
 {% from "macros/htbhf-pagination.njk" import htbhfPagination %}
 
 {% block pageContent %}
-  <h1 class="govuk-heading-xl">Get money off milk, food and vitamins (Healthy Start)</h1>
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
 
-  <p class="govuk-body">Contents</p>
+  <p class="govuk-body">{{ navigationHeading }}</p>
 
   <ul class="govuk-list">
     {% for page in pages %}
@@ -18,6 +18,8 @@
 
   {{ htbhfPagination({
     previousPage: previousPage,
-    nextPage: nextPage
+    nextPage: nextPage,
+    previousLabel: previousLabel,
+    nextLabel: nextLabel
   }) }}
 {% endblock %}


### PR DESCRIPTION
- Rename previous and next parameters to differentiate between pages and labels
- Add translations for guidance pages
- Remove `title` from page meta as it’s not used in the template - this removes `getPageForPath` function and tests as no longer required