### PR TITLE
Add template prop to guidance pages

### DIFF
--- a/src/web/routes/guidance/guidance.js
+++ b/src/web/routes/guidance/guidance.js
@@ -11,14 +11,14 @@ const internationalisation = (translateFn) => ({
   nextLabel: translateFn('next')
 })
 
-const renderGuidanceRoute = (pages, path) => (req, res) =>
-  res.render(`guidance/${getLanguageBase(req.language)}/${path}`, {
+const renderGuidanceRoute = (pages, page) => (req, res) =>
+  res.render(`guidance/${getLanguageBase(req.language)}/${page.template}`, {
     pages,
-    ...getPageMetadata(pages, path),
+    ...getPageMetadata(pages, page.path),
     ...internationalisation(req.t)
   })
 
-const registerGuidanceRoute = (router) => (page, index, pages) => router.get(page.path, renderGuidanceRoute(pages, page.path))
+const registerGuidanceRoute = (router) => (page, index, pages) => router.get(page.path, renderGuidanceRoute(pages, page))
 
 /**
  * handleRequestForPath() checks the state machine before rendering the page to see if the session

--- a/src/web/routes/guidance/pages.js
+++ b/src/web/routes/guidance/pages.js
@@ -1,30 +1,37 @@
 module.exports.PAGES = [
   {
     title: 'How it works',
-    path: '/how-it-works'
+    path: '/how-it-works',
+    template: 'how-it-works'
   },
   {
     title: 'Eligibility',
-    path: '/eligibility'
+    path: '/eligibility',
+    template: 'eligibility'
   },
   {
     title: 'What you’ll get',
-    path: '/what-you-get'
+    path: '/what-you-get',
+    template: 'what-you-get'
   },
   {
     title: 'What you can buy',
-    path: '/buy'
+    path: '/buy',
+    template: 'buy'
   },
   {
     title: 'Using your card',
-    path: '/using-your-card'
+    path: '/using-your-card',
+    template: 'using-your-card'
   },
   {
     title: 'Apply for Healthy Start',
-    path: '/apply'
+    path: '/apply',
+    template: 'apply'
   },
   {
     title: 'Report a change',
-    path: '/report-a-change'
+    path: '/report-a-change',
+    template: 'report-a-change'
   }
 ]

--- a/src/web/views/guidance/en/what-you-get.njk
+++ b/src/web/views/guidance/en/what-you-get.njk
@@ -45,9 +45,9 @@
 <p class="govuk-body">Vitamins are not part of the card service yet. You’ll be sent vouchers for those separately which you can exchange for vitamin supplements.</p>
 <p class="govuk-body">Find out where you can exchange your vouchers at:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li><a href="https://www.nhs.uk/Service-Search/Healthy-start-vitamins/LocationSearch/348">NHS Choices</a> if you live in England (or ask your midwife or health visitor)</li>
+  <li><a class="govuk-link" href="https://www.nhs.uk/Service-Search/Healthy-start-vitamins/LocationSearch/348">NHS Choices</a> if you live in England (or ask your midwife or health visitor)</li>
   <li>from your midwife or health visitor if you live in Wales</li>
-  <li><a href="https://www.healthystart.nhs.uk/for-health-professionals/vitamins/vitamins-in-northern-ireland">NHS Healthy Start</a>  if you live in Northern Ireland</li>
+  <li><a class="govuk-link" href="https://www.healthystart.nhs.uk/for-health-professionals/vitamins/vitamins-in-northern-ireland">NHS Healthy Start</a>  if you live in Northern Ireland</li>
 </ul>
 
 {% endblock %}


### PR DESCRIPTION
Preparation for replacing current page on base URL with the guidance pages:

- Add missing classes to links
- Add template to pages object