### PR TITLE
HTBHF-1972 changed travis linux version to trusty (downgrade from bionic)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   directories:
     - bin/
 
-dist: bionic
+dist: trusty
 
 services:
 - redis-server


### PR DESCRIPTION
Chrome has been crashing much more than previously - this is in case the new linux version was to blame.