### PR TITLE
HTBHF-2007 Logging when the accessibility tests finish.

### DIFF
--- a/src/test/a11y/test-suite.js
+++ b/src/test/a11y/test-suite.js
@@ -190,6 +190,7 @@ const runAllTests = async () => {
     await runILiveInScotlandTest(results)
     await runGuidancePageTest(results)
     handleTestResults(results)
+    console.log(`Finished running accessibility tests against ${BASE_URL}`)
   } catch (error) {
     console.error(error)
     process.exit(1)


### PR DESCRIPTION
Logging when the accessibility tests finish as this makes the logs in the build easier to follow.