### PR TITLE
HTBHF-2045 refactor register steps

### DIFF
--- a/src/web/routes/register-steps/register-steps.test.js
+++ b/src/web/routes/register-steps/register-steps.test.js
@@ -50,7 +50,7 @@ test('registerSteps() throws an error if toggle is not boolean', (t) => {
   const steps = [step2]
   const config = { STEP_2_ENABLED: 'elephant' }
   const result = () => registerSteps(config, steps)
-  t.throws(result, /Invalid toggle config value for step {"path":"\/second","toggle":"STEP_2_ENABLED"}. Config values for toggles must be boolean/, 'throws an error if toggle is not boolean')
+  t.throws(result, /Invalid toggle config value \[STEP_2_ENABLED:elephant\] for step {"path":"\/second","toggle":"STEP_2_ENABLED"}. Error: Can’t coerce elephant to boolean/, 'throws an error if toggle is not boolean')
   t.end()
 })
 

--- a/src/web/routes/register-steps/to-boolean-strict.js
+++ b/src/web/routes/register-steps/to-boolean-strict.js
@@ -1,0 +1,21 @@
+const { isUndefined } = require('./predicates')
+
+const toBooleanStrict = value => {
+  if (isUndefined(value)) {
+    return undefined
+  }
+
+  if (value === 'true' || value === true) {
+    return true
+  }
+
+  if (value === 'false' || value === false) {
+    return false
+  }
+
+  throw new Error(`Can’t coerce ${value} to boolean`)
+}
+
+module.exports = {
+  toBooleanStrict
+}

--- a/src/web/routes/register-steps/to-boolean-strict.test.js
+++ b/src/web/routes/register-steps/to-boolean-strict.test.js
@@ -1,0 +1,16 @@
+const test = require('tape')
+const { toBooleanStrict } = require('./to-boolean-strict')
+
+test('toBooleanStrict() returns correct values', (t) => {
+  t.equal(toBooleanStrict('true'), true, 'coerces string “true” to boolean “true”')
+  t.equal(toBooleanStrict(true), true, 'returns “true” for “true”')
+  t.equal(toBooleanStrict('false'), false, 'coerces string “false” to boolean “false”')
+  t.equal(toBooleanStrict(false), false, 'returns “false” for “false”')
+  t.equal(toBooleanStrict(undefined), undefined, 'returns “undefined” for “undefined”')
+
+  t.throws(() => toBooleanStrict(44), /Can’t coerce 44 to boolean/, 'throws error for integer')
+  t.throws(() => toBooleanStrict('this is not a boolean string'), /Can’t coerce this is not a boolean string to boolean/, 'throws error for a string other than “true” or “false”')
+  t.throws(() => toBooleanStrict(null), /Can’t coerce null to boolean/, 'throws error for null')
+
+  t.end()
+})


### PR DESCRIPTION
- coerce string representations for true and false to boolean (as assumed to be from environment variables)
- remove type checks in `registerSteps` handled by boolean coercion
- add description to functions