### PR TITLE
HTBHF-2045 dynamically determine next path

### DIFF
--- a/src/web/routes/application/are-you-pregnant/are-you-pregnant.js
+++ b/src/web/routes/application/are-you-pregnant/are-you-pregnant.js
@@ -35,7 +35,6 @@ const pageContent = ({ translate }) => ({
 
 const areYouPregnant = {
   path: '/are-you-pregnant',
-  next: () => '/enter-name',
   template: 'are-you-pregnant',
   pageContent,
   validate,

--- a/src/web/routes/application/children-dob/children-dob.js
+++ b/src/web/routes/application/children-dob/children-dob.js
@@ -39,7 +39,6 @@ const behaviourForPost = [
 
 const childrenDob = {
   path: PATH,
-  next: () => '/are-you-pregnant',
   template: 'children-dob',
   pageContent,
   isNavigable,

--- a/src/web/routes/application/common/state-machine/get-next-for-step.test.js
+++ b/src/web/routes/application/common/state-machine/get-next-for-step.test.js
@@ -1,10 +1,45 @@
 const test = require('tape')
-const { getNextForStep } = require('./get-next-for-step')
+const { getNextPathFromSteps, getNextForStep } = require('./get-next-for-step')
+const { CHECK_URL } = require('../constants')
+
+const step1 = {
+  path: '/first'
+}
+
+const step2 = {
+  path: '/second'
+}
+
+const step3 = {
+  path: '/third'
+}
+
+const steps = [step1, step2, step3]
+
+test('getNextPathFromSteps() gets the path for the next step in sequence of steps', (t) => {
+  const result = getNextPathFromSteps(steps, step1)
+  t.equal(result, '/second')
+  t.end()
+})
+
+test(`getNextPathFromSteps() returns ${CHECK_URL} for final step`, (t) => {
+  const result = getNextPathFromSteps(steps, step3)
+  t.equal(result, CHECK_URL)
+  t.end()
+})
+
+test('getNextForStep() returns path for next step in sequence if next property is undefined on step', (t) => {
+  const req = {}
+  const result = getNextForStep(req, step2, steps)
+
+  t.equal(result, '/third', 'returns path for next step in sequence if next property is undefined on step')
+  t.end()
+})
 
 test('getNextForStep() throws error if next is not a function', (t) => {
   const step = { next: 'This is not a function' }
   const req = {}
-  const result = () => getNextForStep(req, step)
+  const result = () => getNextForStep(req, step, [...steps, step])
 
   t.throws(result, /Next property for step must be a function/, 'throws error if next is not a function')
   t.end()
@@ -13,25 +48,25 @@ test('getNextForStep() throws error if next is not a function', (t) => {
 test('getNextForStep() throws error if result of calling next is not a string', (t) => {
   const step = { next: () => null }
   const req = {}
-  const result = () => getNextForStep(req, step)
+  const result = () => getNextForStep(req, step, [...steps, step])
 
-  t.throws(result, /Next function must return a string/, 'throws error if result of calling next is not a string')
+  t.throws(result, /Next function must return a string starting with a forward slash/, 'throws error if result of calling next is not a string')
   t.end()
 })
 
 test('getNextForStep() throws error if result of calling next does not start with forward slash', (t) => {
   const step = { next: () => 'path-without-forward-slash' }
   const req = {}
-  const result = () => getNextForStep(req, step)
+  const result = () => getNextForStep(req, step, [...steps, step])
 
-  t.throws(result, /Next path must start with a forward slash/, 'throws error if result of calling next does not start with forward slash')
+  t.throws(result, /Next function must return a string starting with a forward slash/, 'throws error if result of calling next does not start with forward slash')
   t.end()
 })
 
 test('getNextForStep() should return the result of calling next', (t) => {
   const step = { next: () => '/the-next-path' }
   const req = {}
-  const result = getNextForStep(req, step)
+  const result = getNextForStep(req, step, [...steps, step])
 
   t.equals(result, '/the-next-path', 'return the result of calling next')
   t.end()
@@ -42,7 +77,7 @@ test('getNextForStep() passes request as an argument when calling next function'
   const next = (req) => req.session.some
   const step = { next }
 
-  const result = getNextForStep(req, step)
+  const result = getNextForStep(req, step, [...steps, step])
 
   t.equals(result, '/path', 'passes request as an argument when calling next function')
   t.end()

--- a/src/web/routes/application/common/state-machine/state-machine.js
+++ b/src/web/routes/application/common/state-machine/state-machine.js
@@ -32,7 +32,7 @@ const isNextPathNavigable = (nextStep, req) => isNil(nextStep) || isNil(nextStep
  */
 const getNextNavigablePath = (path, req, steps) => {
   const thisStep = getStepForPath(path, steps)
-  const nextPath = getNextForStep(req, thisStep)
+  const nextPath = getNextForStep(req, thisStep, steps)
   const nextStep = getStepForPath(nextPath, steps)
   if (isNextPathNavigable(nextStep, req)) {
     return nextPath

--- a/src/web/routes/application/email-address/email-address.js
+++ b/src/web/routes/application/email-address/email-address.js
@@ -30,7 +30,6 @@ const behaviourForPost = (req, res, next) => {
 
 const emailAddress = {
   path: '/email-address',
-  next: () => '/send-code',
   template: 'email-address',
   validate,
   pageContent,

--- a/src/web/routes/application/enter-code/enter-code.js
+++ b/src/web/routes/application/enter-code/enter-code.js
@@ -43,7 +43,6 @@ const isNavigable = (session) => session[CONFIRMATION_CODE_ENTERED_SESSION_PROPE
 
 const enterCode = {
   path: '/enter-code',
-  next: () => '/check',
   template: 'enter-code',
   pageContent,
   behaviourForGet,

--- a/src/web/routes/application/enter-dob/enter-dob.js
+++ b/src/web/routes/application/enter-dob/enter-dob.js
@@ -23,7 +23,6 @@ const contentSummary = (req) => ({
 
 const enterDob = {
   path: '/enter-dob',
-  next: () => '/do-you-have-children',
   template: 'enter-dob',
   pageContent,
   validate,

--- a/src/web/routes/application/enter-name/enter-name.js
+++ b/src/web/routes/application/enter-name/enter-name.js
@@ -17,7 +17,6 @@ const contentSummary = (req) => ({
 
 const enterName = {
   path: '/enter-name',
-  next: () => '/enter-nino',
   template: 'enter-name',
   validate,
   pageContent,

--- a/src/web/routes/application/enter-nino/enter-nino.js
+++ b/src/web/routes/application/enter-nino/enter-nino.js
@@ -17,7 +17,6 @@ const contentSummary = (req) => ({
 
 const enterNino = {
   path: '/enter-nino',
-  next: () => '/manual-address',
   template: 'enter-nino',
   sanitize,
   validate,

--- a/src/web/routes/application/manual-address/manual-address.js
+++ b/src/web/routes/application/manual-address/manual-address.js
@@ -34,7 +34,6 @@ const contentSummary = (req) => ({
 
 const manualAddress = {
   path: '/manual-address',
-  next: () => '/phone-number',
   template: 'manual-address',
   pageContent,
   validate,

--- a/src/web/routes/application/middleware/handle-post.test.js
+++ b/src/web/routes/application/middleware/handle-post.test.js
@@ -114,45 +114,6 @@ test('handlePost() adds next allowed step to session', (t) => {
   t.end()
 })
 
-test('handlePost() calls next() with error if no next property exists on step', (t) => {
-  const { handlePost } = proxyquire('./handle-post', { ...defaultValidator })
-
-  const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
-  const step = steps[1]
-  const req = {
-    session: {},
-    path: '/second'
-  }
-
-  const res = {}
-  const next = sinon.spy()
-
-  handlePost(steps, step)(req, res, next)
-
-  t.equal(next.calledWith(sinon.match.instanceOf(Error)), true, 'it should throw an error')
-  t.end()
-})
-
-test('handlePost() calls next() with error if next property is blank', (t) => {
-  const { handlePost } = proxyquire('./handle-post', { ...defaultValidator })
-
-  const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
-  const step = steps[1]
-  const req = {
-    session: {},
-    path: '/second',
-    next: ''
-  }
-
-  const res = {}
-  const next = sinon.spy()
-
-  handlePost(steps, step)(req, res, next)
-
-  t.equal(next.calledWith(sinon.match.instanceOf(Error)), true, 'it should throw an error')
-  t.end()
-})
-
 test('handlePost() should invalidate review if required by step', (t) => {
   const dispatch = sinon.spy()
   const INVALIDATE_REVIEW = 'INVALIDATE_REVIEW'

--- a/src/web/routes/application/phone-number/phone-number.js
+++ b/src/web/routes/application/phone-number/phone-number.js
@@ -31,7 +31,6 @@ const behaviourForPost = (req, res, next) => {
 
 const phoneNumber = {
   path: '/phone-number',
-  next: () => '/email-address',
   template: 'phone-number',
   validate,
   sanitize,

--- a/src/web/routes/application/send-code/send-code.js
+++ b/src/web/routes/application/send-code/send-code.js
@@ -35,7 +35,6 @@ const isNavigable = (session) => session[CONFIRMATION_CODE_ENTERED_SESSION_PROPE
 
 const sendCode = {
   path: '/send-code',
-  next: () => '/enter-code',
   template: 'send-code',
   pageContent,
   validate,


### PR DESCRIPTION
- Update `getNextForStep` to dynamically determine the next path in the sequence
- Remove redundant error tests for `handlePost`
- Remove `next` prop on steps that reference the next step in sequence of steps

This does not affect steps that determine the next path based on the session - if a function is used for `next` prop on step it will take precedence over the default dynamic behaviour.