### PR TITLE
HTBHF-2047 Renamed enterAddressAndSubmit to enterManualAddressAndSubmit

### DIFF
--- a/src/test/common/steps/check-details.js
+++ b/src/test/common/steps/check-details.js
@@ -26,7 +26,7 @@ const {
   enterNameAndSubmit,
   enterNinoAndSubmit,
   enterDateOfBirthAndSubmit,
-  enterAddressAndSubmit,
+  enterManualAddressAndSubmit,
   enterPhoneNumberAndSubmit,
   enterDoYouLiveInScotlandNoAndSubmit,
   enterEmailAddressAndSubmit,
@@ -44,7 +44,7 @@ When(/^I complete the application with valid details that contains malicious inp
   await selectNoOnPregnancyPage()
   await enterNameAndSubmit('<script>window.alert(\'Boo\')</script>', LAST_NAME)
   await enterNinoAndSubmit()
-  await enterAddressAndSubmit()
+  await enterManualAddressAndSubmit()
   await enterPhoneNumberAndSubmit()
   await enterEmailAddressAndSubmit()
   await selectTextOnSendCode()
@@ -165,7 +165,7 @@ async function completeApplicationWithAddressDetails (addressLine1, addressLine2
   await selectNoOnPregnancyPage()
   await enterNameAndSubmit()
   await enterNinoAndSubmit()
-  await enterAddressAndSubmit(addressLine1, addressLine2, townOrCity, county, postcode)
+  await enterManualAddressAndSubmit(addressLine1, addressLine2, townOrCity, county, postcode)
   await enterPhoneNumberAndSubmit()
   await enterEmailAddressAndSubmit()
   await selectTextOnSendCode()

--- a/src/test/common/steps/common-steps.js
+++ b/src/test/common/steps/common-steps.js
@@ -88,7 +88,7 @@ async function selectNoOnPregnancyPage () {
   }
 }
 
-async function enterAddressAndSubmit (addressLine1 = ADDRESS_LINE_1, addressLine2 = ADDRESS_LINE_2, townOrCity = TOWN, county = COUNTY, postcode = POSTCODE) {
+async function enterManualAddressAndSubmit (addressLine1 = ADDRESS_LINE_1, addressLine2 = ADDRESS_LINE_2, townOrCity = TOWN, county = COUNTY, postcode = POSTCODE) {
   try {
     await pages.manualAddress.line1InputField.enterValue(addressLine1)
     await pages.manualAddress.line2InputField.enterValue(addressLine2)
@@ -242,7 +242,7 @@ module.exports = {
   enterNinoAndSubmit,
   selectNoOnPregnancyPage,
   selectYesOnPregnancyPage,
-  enterAddressAndSubmit,
+  enterManualAddressAndSubmit,
   enterPhoneNumberAndSubmit,
   setupWiremockMappingsWithStatus,
   setupWiremockUpdatedClaimMapping,

--- a/src/test/common/steps/confirmation-code-navigation-steps.js
+++ b/src/test/common/steps/confirmation-code-navigation-steps.js
@@ -8,7 +8,7 @@ const {
   enterNameAndSubmit,
   enterNinoAndSubmit,
   enterDateOfBirthAndSubmit,
-  enterAddressAndSubmit,
+  enterManualAddressAndSubmit,
   enterPhoneNumberAndSubmit,
   enterDoYouLiveInScotlandNoAndSubmit,
   enterEmailAddressAndSubmit,
@@ -61,7 +61,7 @@ async function completeProcessUpToSendCode () {
   await selectNoOnPregnancyPage()
   await enterNameAndSubmit()
   await enterNinoAndSubmit()
-  await enterAddressAndSubmit()
+  await enterManualAddressAndSubmit()
   await enterPhoneNumberAndSubmit()
   await enterEmailAddressAndSubmit()
 }

--- a/src/test/common/steps/manual-address-steps.js
+++ b/src/test/common/steps/manual-address-steps.js
@@ -1,7 +1,7 @@
 const { When, Then } = require('cucumber')
 
 const pages = require('./pages')
-const { enterAddressAndSubmit } = require('./common-steps')
+const { enterManualAddressAndSubmit } = require('./common-steps')
 const { assertFieldErrorAndLinkTextPresentAndCorrect, assertErrorHeaderTextPresent } = require('./common-assertions')
 const { LONG_STRING, BLANK_STRING } = require('./constants')
 
@@ -12,43 +12,43 @@ const VALID_COUNTY = 'Greater London'
 const VALID_POSTCODE = 'AA1 1AA'
 
 When(/^I enter an address with postcode (.*)$/, async function (postcode) {
-  await enterAddressAndSubmit(VALID_ADDRESS_LINE_1, VALID_ADDRESS_LINE_2, VALID_TOWN_OR_CITY, VALID_COUNTY, postcode)
+  await enterManualAddressAndSubmit(VALID_ADDRESS_LINE_1, VALID_ADDRESS_LINE_2, VALID_TOWN_OR_CITY, VALID_COUNTY, postcode)
 })
 
 When(/^I do not enter the first line of an address$/, async function () {
-  await enterAddressAndSubmit(BLANK_STRING, VALID_ADDRESS_LINE_2, VALID_TOWN_OR_CITY, VALID_COUNTY, VALID_POSTCODE)
+  await enterManualAddressAndSubmit(BLANK_STRING, VALID_ADDRESS_LINE_2, VALID_TOWN_OR_CITY, VALID_COUNTY, VALID_POSTCODE)
 })
 
 When(/I do not enter the 'town or city' of an address$/, async function () {
-  await enterAddressAndSubmit(VALID_ADDRESS_LINE_1, VALID_ADDRESS_LINE_2, BLANK_STRING, VALID_COUNTY, VALID_POSTCODE)
+  await enterManualAddressAndSubmit(VALID_ADDRESS_LINE_1, VALID_ADDRESS_LINE_2, BLANK_STRING, VALID_COUNTY, VALID_POSTCODE)
 })
 
 When(/I do not enter the 'county' of an address$/, async function () {
-  await enterAddressAndSubmit(VALID_ADDRESS_LINE_1, VALID_ADDRESS_LINE_2, VALID_TOWN_OR_CITY, BLANK_STRING, VALID_POSTCODE)
+  await enterManualAddressAndSubmit(VALID_ADDRESS_LINE_1, VALID_ADDRESS_LINE_2, VALID_TOWN_OR_CITY, BLANK_STRING, VALID_POSTCODE)
 })
 
 When(/^I enter in an address where the first line is too long$/, async function () {
-  await enterAddressAndSubmit(LONG_STRING, VALID_ADDRESS_LINE_2, VALID_TOWN_OR_CITY, VALID_COUNTY, VALID_POSTCODE)
+  await enterManualAddressAndSubmit(LONG_STRING, VALID_ADDRESS_LINE_2, VALID_TOWN_OR_CITY, VALID_COUNTY, VALID_POSTCODE)
 })
 
 When(/^I enter in an address where the second line is too long$/, async function () {
-  await enterAddressAndSubmit(VALID_ADDRESS_LINE_1, LONG_STRING, VALID_TOWN_OR_CITY, VALID_COUNTY, VALID_POSTCODE)
+  await enterManualAddressAndSubmit(VALID_ADDRESS_LINE_1, LONG_STRING, VALID_TOWN_OR_CITY, VALID_COUNTY, VALID_POSTCODE)
 })
 
 When(/^I enter in an address where the 'town or city' is too long$/, async function () {
-  await enterAddressAndSubmit(VALID_ADDRESS_LINE_1, VALID_ADDRESS_LINE_2, LONG_STRING, VALID_COUNTY, VALID_POSTCODE)
+  await enterManualAddressAndSubmit(VALID_ADDRESS_LINE_1, VALID_ADDRESS_LINE_2, LONG_STRING, VALID_COUNTY, VALID_POSTCODE)
 })
 
 When(/^I enter in an address where the 'county' is too long$/, async function () {
-  await enterAddressAndSubmit(VALID_ADDRESS_LINE_1, VALID_ADDRESS_LINE_2, LONG_STRING, LONG_STRING, VALID_POSTCODE)
+  await enterManualAddressAndSubmit(VALID_ADDRESS_LINE_1, VALID_ADDRESS_LINE_2, LONG_STRING, LONG_STRING, VALID_POSTCODE)
 })
 
 When(/^I do not enter the second line of an address$/, async function () {
-  await enterAddressAndSubmit(VALID_ADDRESS_LINE_1, BLANK_STRING, VALID_TOWN_OR_CITY, VALID_COUNTY, VALID_POSTCODE)
+  await enterManualAddressAndSubmit(VALID_ADDRESS_LINE_1, BLANK_STRING, VALID_TOWN_OR_CITY, VALID_COUNTY, VALID_POSTCODE)
 })
 
 When(/^I do not enter in any address fields$/, async function () {
-  await enterAddressAndSubmit(BLANK_STRING, BLANK_STRING, BLANK_STRING, BLANK_STRING, BLANK_STRING)
+  await enterManualAddressAndSubmit(BLANK_STRING, BLANK_STRING, BLANK_STRING, BLANK_STRING, BLANK_STRING)
 })
 
 Then(/^I am shown the address page$/, async function () {

--- a/src/test/common/steps/navigation/step-page-actions.js
+++ b/src/test/common/steps/navigation/step-page-actions.js
@@ -4,7 +4,7 @@ const {
   enterDateOfBirthAndSubmit,
   selectNoOnPregnancyPage,
   selectYesOnPregnancyPage,
-  enterAddressAndSubmit,
+  enterManualAddressAndSubmit,
   enterPhoneNumberAndSubmit,
   enterDoYouLiveInScotlandNoAndSubmit,
   enterEmailAddressAndSubmit,
@@ -48,7 +48,7 @@ const STEP_PAGE_ACTIONS = [
   },
   {
     page: (pages) => pages.manualAddress,
-    actions: async () => enterAddressAndSubmit()
+    actions: async () => enterManualAddressAndSubmit()
   },
   {
     page: (pages) => pages.phoneNumber,


### PR DESCRIPTION
The new address pages will make the current function name confusing, as such it should be renamed from address to manualAddress.