### PR TITLE
Feature/update manual address page name

### DIFF
--- a/src/test/acceptance/features/address-lookup.feature
+++ b/src/test/acceptance/features/address-lookup.feature
@@ -35,4 +35,4 @@ Feature: Select address
   Scenario: Clicking the address not listed link shows the manual address page
     Given I have entered my details up to the select address page
     When I click the address not listed link
-    Then I am shown the address page
+    Then I am shown the manual-address page

--- a/src/test/acceptance/features/address-lookup.feature
+++ b/src/test/acceptance/features/address-lookup.feature
@@ -3,22 +3,36 @@ Feature: Select address
   As a potential claimant
   I want to lookup my address
 
-  Background:
+  # TODO DW HTBHF-2037 include test once address lookup is enabled
+  @ignore
+  Scenario: Entering a postcode with no search results shows that no addresses were found
     Given I have entered my details up to the postcode page
+    When I enter a postcode with no search results
+    Then I am shown the select address page
+    And I am informed that no addresses were found for my postcode
+    And I am shown a button to enter my address manually
 
-    # TODO DW HTBHF-2037 include test once address lookup is enabled
-    @ignore
-    Scenario: Entering a postcode with no search results shows that no addresses were found
-      When I enter a postcode with no search results
-      Then I am shown the select address page
-      And I am informed that no addresses were found for my postcode
-      And I am shown a button to enter my address manually
+  # TODO DW HTBHF-2037 include test once address lookup is enabled
+  @ignore
+  Scenario: Entering a postcode shows a list of matching addresses
+    Given I have entered my details up to the postcode page
+    When I enter a postcode
+    Then I am shown the select address page
+    And I am shown a list of addresses
+    And I am shown an address not listed link
+    And I am shown a continue button
 
-    # TODO DW HTBHF-2037 include test once address lookup is enabled
-    @ignore
-    Scenario: Entering a postcode shows a list of matching addresses
-      When I enter a postcode
-      Then I am shown the select address page
-      And I am shown a list of addresses
-      And I am shown an address not listed link
-      And I am shown a continue button
+  # TODO DW HTBHF-2037 include test once address lookup is enabled
+  @ignore
+  Scenario: Selecting an address skips the manual address page
+    Given I have entered my details up to the select address page
+    When I select an address
+    And I click continue
+    Then I am shown the phone number page
+
+  # TODO DW HTBHF-2037 include test once address lookup is enabled
+  @ignore
+  Scenario: Clicking the address not listed link shows the manual address page
+    Given I have entered my details up to the select address page
+    When I click the address not listed link
+    Then I am shown the address page

--- a/src/test/acceptance/features/enter-nino.feature
+++ b/src/test/acceptance/features/enter-nino.feature
@@ -8,7 +8,7 @@ Feature: Enter National Insurance number
 
   Scenario: Enter in a valid national insurance number
     When I enter a valid national insurance number
-    Then I am shown the address page
+    Then I am shown the manual-address page
 
   Scenario: Do not enter in a "national insurance number"
     When I do not enter a national insurance number

--- a/src/test/acceptance/features/manual-address.feature
+++ b/src/test/acceptance/features/manual-address.feature
@@ -4,7 +4,7 @@ Feature: Address
   I want to enter my address manually
 
   Background:
-    Given I have entered my details up to the address page
+    Given I have entered my details up to the manual-address page
 
   Scenario Outline: Enter a valid address with all fields entered
     When I enter an address with postcode <postcode>

--- a/src/test/acceptance/features/navigation.feature
+++ b/src/test/acceptance/features/navigation.feature
@@ -36,7 +36,7 @@ Feature: Application process navigation is controlled
     Then I am shown the <application page> page
     Examples:
       | application page    | navigation page |
-      | enter name          | address         |
+      | enter name          | manual-address         |
       | enter date of birth | check answers   |
       | are you pregnant    | confirmation    |
 

--- a/src/test/common/page/manual-address.js
+++ b/src/test/common/page/manual-address.js
@@ -25,7 +25,7 @@ class ManualAddress extends SubmittablePage {
   }
 
   getPageName () {
-    return 'address'
+    return 'manual-address'
   }
 
   async waitForPageLoad (lang = 'en') {

--- a/src/test/common/steps/address-lookup-steps.js
+++ b/src/test/common/steps/address-lookup-steps.js
@@ -20,6 +20,16 @@ When(/^I enter a postcode$/, async function () {
   await enterPostcodeAndSubmit(POSTCODE)
 })
 
+When(/^I select an address$/, async function () {
+  const addressOptions = await pages.selectAddress.getAddressOptions()
+  const option = addressOptions[0]
+  await option.click()
+})
+
+When(/^I click the address not listed link$/, async function () {
+  await pages.selectAddress.clickAddressNotListedLink()
+})
+
 Then(/^I am shown the select address page$/, async function () {
   await pages.selectAddress.waitForPageLoad()
 })

--- a/src/test/common/steps/manual-address-steps.js
+++ b/src/test/common/steps/manual-address-steps.js
@@ -51,7 +51,7 @@ When(/^I do not enter in any address fields$/, async function () {
   await enterManualAddressAndSubmit(BLANK_STRING, BLANK_STRING, BLANK_STRING, BLANK_STRING, BLANK_STRING)
 })
 
-Then(/^I am shown the address page$/, async function () {
+Then(/^I am shown the manual-address page$/, async function () {
   await pages.manualAddress.waitForPageLoad()
 })
 


### PR DESCRIPTION
Updating the manual address test page name from 'address' to 'manual-address' as it was causing confusion now there are multiple address pages.