### PR TITLE
Feature/address content summary

### DIFF
--- a/src/web/routes/application/address/content-summary.js
+++ b/src/web/routes/application/address/content-summary.js
@@ -1,0 +1,21 @@
+const { join, filter, compose } = require('ramda')
+
+const { notIsNilOrEmpty } = require('../../../../common/predicates')
+
+const newLineChar = '\n'
+const toMultiLineString = compose(join(newLineChar), filter(notIsNilOrEmpty))
+
+const addressContentSummary = (req) => ({
+  key: req.t('address.summaryKey'),
+  value: toMultiLineString([
+    req.session.claim.addressLine1,
+    req.session.claim.addressLine2,
+    req.session.claim.townOrCity,
+    req.session.claim.county,
+    req.session.claim.postcode
+  ])
+})
+
+module.exports = {
+  addressContentSummary
+}

--- a/src/web/routes/application/address/manual-address/manual-address.js
+++ b/src/web/routes/application/address/manual-address/manual-address.js
@@ -1,7 +1,7 @@
-const { join, filter, compose, isNil, path } = require('ramda')
+const { addressContentSummary } = require('../content-summary')
+const { compose, isNil, path } = require('ramda')
 const { validate } = require('./validate')
 const { sanitize } = require('./sanitize')
-const { notIsNilOrEmpty } = require('../../../../../common/predicates')
 
 const pageContent = ({ translate }) => ({
   title: translate('address.title'),
@@ -18,19 +18,11 @@ const pageContent = ({ translate }) => ({
   hint: translate('address.hint')
 })
 
-const newLineChar = '\n'
-const toMultiLineString = compose(join(newLineChar), filter(notIsNilOrEmpty))
-
-const contentSummary = (req) => ({
-  key: req.t('address.summaryKey'),
-  value: toMultiLineString([
-    req.session.claim.addressLine1,
-    req.session.claim.addressLine2,
-    req.session.claim.townOrCity,
-    req.session.claim.county,
-    req.session.claim.postcode
-  ])
-})
+const contentSummary = (req) => {
+  if (isNavigable(req.session)) {
+    return addressContentSummary(req)
+  }
+}
 
 const isNavigable = compose(isNil, path(['claim', 'selectedAddress']))
 

--- a/src/web/routes/application/address/manual-address/maunal-address.test.js
+++ b/src/web/routes/application/address/manual-address/maunal-address.test.js
@@ -62,6 +62,15 @@ test('Address contentSummary() should return content summary in correct format w
   t.end()
 })
 
+test('Address contentSummary() is undefined when there is a selected address on the session', (t) => {
+  const testReq = assocPath(['session', 'claim', 'selectedAddress'], 'test address', req)
+
+  const result = contentSummary(testReq)
+
+  t.equal(result, undefined, 'should return null when there is a selected address on the session')
+  t.end()
+})
+
 test('Address contentSummary() should return content summary in correct format with county undefined', (t) => {
   const testReq = assocPath(['session', 'claim', 'county'], undefined, req)
   const result = contentSummary(testReq)

--- a/src/web/routes/application/address/select-address/select-address.js
+++ b/src/web/routes/application/address/select-address/select-address.js
@@ -1,4 +1,7 @@
+const { path } = require('ramda')
 const { transformAddress } = require('./adapters')
+
+const { addressContentSummary } = require('../content-summary')
 
 const pageContent = ({ translate }) => ({
   title: translate('address.title'),
@@ -55,18 +58,26 @@ const behaviourForPost = () => (req, res, next) => {
   next()
 }
 
+const contentSummary = (req) => {
+  if (path(['session', 'claim', 'selectedAddress'], req)) {
+    return addressContentSummary(req)
+  }
+}
+
 const selectAddress = {
   path: '/select-address',
   template: 'select-address',
   pageContent,
   toggle: 'ADDRESS_LOOKUP_ENABLED',
   behaviourForGet,
-  behaviourForPost
+  behaviourForPost,
+  contentSummary
 }
 
 module.exports = {
   behaviourForGet,
   selectAddress,
   behaviourForPost,
-  findAddress
+  findAddress,
+  contentSummary
 }

--- a/src/web/routes/application/address/select-address/select-address.test.js
+++ b/src/web/routes/application/address/select-address/select-address.test.js
@@ -1,6 +1,6 @@
 const test = require('tape')
 const sinon = require('sinon')
-const { behaviourForGet, behaviourForPost, findAddress } = require('./select-address')
+const { behaviourForGet, behaviourForPost, findAddress, contentSummary } = require('./select-address')
 
 const POSTCODE_LOOKUP_RESULTS = [
   {
@@ -206,5 +206,42 @@ test('findAddress throws an error when the address is not found', (t) => {
     /Unable to find selected address in list of postcode lookup results/,
     'Should throw an error when no address is found'
   )
+  t.end()
+})
+
+test('Address contentSummary() should return content summary in correct format when there is a selected address on the session', (t) => {
+  const req = {
+    t: string => string,
+    session: {
+      claim: {
+        addressLine1: 'Flat b',
+        addressLine2: '221 Baker street',
+        townOrCity: 'London',
+        county: 'Devon',
+        postcode: 'aa1 1ab',
+        selectedAddress: 'Flat b, 221 Baker Street, London, Devon, aa1 1ab'
+      }
+    }
+  }
+
+  const result = contentSummary(req)
+
+  const expected = {
+    key: 'address.summaryKey',
+    value: 'Flat b\n221 Baker street\nLondon\nDevon\naa1 1ab'
+  }
+
+  t.deepEqual(result, expected, 'should return content summary in correct format when there is a selected address on the session')
+  t.end()
+})
+
+test('Address contentSummary() should return undefined when there is no selected address on the session', (t) => {
+  const req = {
+    claim: {}
+  }
+
+  const result = contentSummary(req)
+
+  t.deepEqual(result, undefined, 'should return undefined when there is no selected address on the session')
   t.end()
 })


### PR DESCRIPTION
- Updated the address content function for select address and manual address so that only one of them is visible on the check details page.
- The change address link on the check details page will now go to select address or manual address, depending on how the user entered an address.