### PR TITLE
HTBHF-2037 Renamed incorrect page parameter to pageName.

### DIFF
--- a/src/test/common/steps/check-answers.js
+++ b/src/test/common/steps/check-answers.js
@@ -27,7 +27,7 @@ const { assertBackLinkPointsToPage } = require('./common-assertions')
 
 When(/^I complete the application with valid details that contains malicious input$/, async function () {
   const actionOptions = { ...DEFAULT_ACTION_OPTIONS, firstName: '<script>window.alert(\'Boo\')</script>' }
-  await enterDetailsUpToPage({ page: pages.checkAnswers.getPageName(), actionOptions })
+  await enterDetailsUpToPage({ pageName: pages.checkAnswers.getPageName(), actionOptions })
 })
 
 When(/^I complete the application with valid details for an applicant with no second line of address$/, async function () {
@@ -123,7 +123,7 @@ Then(/^there are no children displayed$/, async function () {
 
 async function completeApplicationWithAddressDetails (addressLine1, addressLine2, townOrCity, county, postcode) {
   const actionOptions = { ...DEFAULT_ACTION_OPTIONS, addressLine1, addressLine2, townOrCity, county, postcode }
-  await enterDetailsUpToPage({ page: pages.checkAnswers.getPageName(), actionOptions })
+  await enterDetailsUpToPage({ pageName: pages.checkAnswers.getPageName(), actionOptions })
 }
 
 async function assertCheckAnswersWithAddressForClaimantWithChildrenAndNotPregnant (fullAddress) {

--- a/src/test/common/steps/confirmation-code-navigation-steps.js
+++ b/src/test/common/steps/confirmation-code-navigation-steps.js
@@ -13,13 +13,13 @@ const {
 } = require('./common-steps')
 
 When(/^I complete the application with valid details, selecting to receive my confirmation code via text$/, async function () {
-  await enterDetailsUpToPage({ page: pages.sendCode.getPageName() })
+  await enterDetailsUpToPage({ pageName: pages.sendCode.getPageName() })
   await selectTextOnSendCode()
   await enterConfirmationCodeAndSubmit()
 })
 
 When(/^I complete the application with valid details, selecting to receive my confirmation code via email$/, async function () {
-  await enterDetailsUpToPage({ page: pages.sendCode.getPageName() })
+  await enterDetailsUpToPage({ pageName: pages.sendCode.getPageName() })
   await selectEmailOnSendCode()
   await enterConfirmationCodeAndSubmit()
 })

--- a/src/test/common/steps/navigation/navigation.js
+++ b/src/test/common/steps/navigation/navigation.js
@@ -11,10 +11,10 @@ const getPageIndex = (stepActions, pageName, pages) => stepActions.findIndex(pag
 
 // Uses isStepEnabled to enable / disable page navigation by the toggle specified
 // To be concise “features” is referenced directly rather than being an argument
-const getStepsUpToPage = (page, stepActions) => {
-  const pageIndex = getPageIndex(stepActions, page, pages)
+const getStepsUpToPage = (pageName, stepActions) => {
+  const pageIndex = getPageIndex(stepActions, pageName, pages)
   if (pageIndex === -1) {
-    throw new Error(`Unable to find page ${page}`)
+    throw new Error(`Unable to find page ${pageName}`)
   }
   return stepActions.slice(0, pageIndex + 1).filter(isStepEnabled(features))
 }
@@ -28,19 +28,19 @@ const runPageActions = (actionOptions) => async (step, index, arrayLength) => {
   }
 }
 
-const enterDetailsUpToPage = async ({ page, stepActions = STEP_PAGE_ACTIONS, actionOptions = DEFAULT_ACTION_OPTIONS }) => {
+const enterDetailsUpToPage = async ({ pageName, stepActions = STEP_PAGE_ACTIONS, actionOptions = DEFAULT_ACTION_OPTIONS }) => {
   try {
     await pages.guidance.openApplyPage(pages.url)
     await pages.guidance.clickStartButton()
-    await Promise.each(getStepsUpToPage(page, stepActions), runPageActions(actionOptions))
+    await Promise.each(getStepsUpToPage(pageName, stepActions), runPageActions(actionOptions))
   } catch (error) {
-    assert.fail(`Unexpected error caught trying to enter details up to page ${page} - ${error}`)
+    assert.fail(`Unexpected error caught trying to enter details up to page ${pageName} - ${error}`)
     throw new Error(error)
   }
 }
 
 const enterDetailsUpToCheckAnswersPage = async (actionOptions) => {
-  await enterDetailsUpToPage({ page: pages.checkAnswers.getPageName(), actionOptions })
+  await enterDetailsUpToPage({ pageName: pages.checkAnswers.getPageName(), actionOptions })
 }
 
 const enterDetailsUpToCheckAnswersPageForAPregnantWoman = async () => {

--- a/src/test/common/steps/navigation/steps.js
+++ b/src/test/common/steps/navigation/steps.js
@@ -4,11 +4,11 @@ const { assert } = require('chai')
 const pages = require('../pages')
 const { enterDetailsUpToPage } = require('./navigation')
 
-Given(/^I have entered my details up to the (.*) page$/, async function (page) {
+Given(/^I have entered my details up to the (.*) page$/, async function (pageName) {
   try {
-    await enterDetailsUpToPage({ page })
+    await enterDetailsUpToPage({ pageName })
   } catch (error) {
-    assert.fail(`Unexpected error caught trying to enter details up to page ${page} - ${error}`)
+    assert.fail(`Unexpected error caught trying to enter details up to page ${pageName} - ${error}`)
     throw new Error(error)
   }
 })
@@ -17,9 +17,9 @@ Given(/^I am starting a new application$/, async function () {
   await pages.guidance.openApplyPage(pages.url)
 })
 
-When(/^I navigate to the (.*) page$/, async function (page) {
+When(/^I navigate to the (.*) page$/, async function (pageName) {
   try {
-    await pages.openPageDirect(page)
+    await pages.openPageDirect(pageName)
   } catch (error) {
     throw new Error('Unexpected error caught navigating to page: ' + error)
   }


### PR DESCRIPTION
A few functions were using `page` as a parameter name where they were actually expecting a page name. These parameters have been renamed to `pageName` to prevent confusion in the future.