### PR TITLE
HTBHF-2037 fix select address options acceptance test

### DIFF
--- a/src/test/common/wiremock/postcode-lookup/index.js
+++ b/src/test/common/wiremock/postcode-lookup/index.js
@@ -1,1 +1,4 @@
-module.exports = require('./postcode-lookup')
+module.exports = {
+  ...require('./postcode-lookup'),
+  ...require('./mappings')
+}


### PR DESCRIPTION
Previously the acceptance tests asserted that every `option` in the `select` for address lookup contained the correct postcode. This no longer works as the postcode has been removed from each option.

It’s important to assert that each `option` contains text (instead of just asserting that the correct number of `option` elements exist). So we need to:

- Get the results returned by the API response (from the Wiremock mapping)
- Iterate over each `option` web element returned by Selenium
- Check that the text matches the corresponding result in the API response