### PR TITLE
Define properties for request body at step level

### DIFF
--- a/src/web/routes/application/address/manual-address/manual-address.js
+++ b/src/web/routes/application/address/manual-address/manual-address.js
@@ -22,6 +22,16 @@ const contentSummary = req => isNavigable(req.session) ? addressContentSummary(r
 
 const isNavigable = compose(isNil, path(['claim', 'selectedAddress']))
 
+const requestBody = (session) => ({
+  address: {
+    addressLine1: session.claim.addressLine1,
+    addressLine2: session.claim.addressLine2,
+    townOrCity: session.claim.townOrCity,
+    county: session.claim.county,
+    postcode: session.claim.postcode
+  }
+})
+
 const manualAddress = {
   path: '/manual-address',
   template: 'manual-address',
@@ -29,11 +39,13 @@ const manualAddress = {
   validate,
   sanitize,
   contentSummary,
-  isNavigable
+  isNavigable,
+  requestBody
 }
 
 module.exports = {
   contentSummary,
   manualAddress,
-  isNavigable
+  isNavigable,
+  requestBody
 }

--- a/src/web/routes/application/address/manual-address/manual-address.js
+++ b/src/web/routes/application/address/manual-address/manual-address.js
@@ -2,6 +2,7 @@ const { addressContentSummary } = require('../content-summary')
 const { compose, isNil, path } = require('ramda')
 const { validate } = require('./validate')
 const { sanitize } = require('../sanitize')
+const { requestBody } = require('../request-body')
 
 const pageContent = ({ translate }) => ({
   title: translate('address.title'),
@@ -22,16 +23,6 @@ const contentSummary = req => isNavigable(req.session) ? addressContentSummary(r
 
 const isNavigable = compose(isNil, path(['claim', 'selectedAddress']))
 
-const requestBody = (session) => ({
-  address: {
-    addressLine1: session.claim.addressLine1,
-    addressLine2: session.claim.addressLine2,
-    townOrCity: session.claim.townOrCity,
-    county: session.claim.county,
-    postcode: session.claim.postcode
-  }
-})
-
 const manualAddress = {
   path: '/manual-address',
   template: 'manual-address',
@@ -46,6 +37,5 @@ const manualAddress = {
 module.exports = {
   contentSummary,
   manualAddress,
-  isNavigable,
-  requestBody
+  isNavigable
 }

--- a/src/web/routes/application/address/manual-address/maunal-address.test.js
+++ b/src/web/routes/application/address/manual-address/maunal-address.test.js
@@ -1,6 +1,6 @@
 const test = require('tape')
 const { assocPath } = require('ramda')
-const { contentSummary, isNavigable, requestBody } = require('./manual-address')
+const { contentSummary, isNavigable } = require('./manual-address')
 
 const req = {
   t: string => string,
@@ -111,22 +111,5 @@ test('isNavigable() returns false when there is a selected address', (t) => {
   const result = isNavigable(session)
 
   t.equal(result, false, 'Should return true when there is no session')
-  t.end()
-})
-
-test('requestBody() returns request body in correct format', (t) => {
-  const result = requestBody(req.session)
-
-  const expected = {
-    address: {
-      addressLine1: 'Flat b',
-      addressLine2: '221 Baker street',
-      townOrCity: 'London',
-      county: 'Devon',
-      postcode: 'aa1 1ab'
-    }
-  }
-
-  t.deepEqual(result, expected, 'returns request body in correct format')
   t.end()
 })

--- a/src/web/routes/application/address/manual-address/maunal-address.test.js
+++ b/src/web/routes/application/address/manual-address/maunal-address.test.js
@@ -1,6 +1,6 @@
 const test = require('tape')
 const { assocPath } = require('ramda')
-const { contentSummary, isNavigable } = require('./manual-address')
+const { contentSummary, isNavigable, requestBody } = require('./manual-address')
 
 const req = {
   t: string => string,
@@ -111,5 +111,22 @@ test('isNavigable() returns false when there is a selected address', (t) => {
   const result = isNavigable(session)
 
   t.equal(result, false, 'Should return true when there is no session')
+  t.end()
+})
+
+test('requestBody() returns request body in correct format', (t) => {
+  const result = requestBody(req.session)
+
+  const expected = {
+    address: {
+      addressLine1: 'Flat b',
+      addressLine2: '221 Baker street',
+      townOrCity: 'London',
+      county: 'Devon',
+      postcode: 'aa1 1ab'
+    }
+  }
+
+  t.deepEqual(result, expected, 'returns request body in correct format')
   t.end()
 })

--- a/src/web/routes/application/address/request-body.js
+++ b/src/web/routes/application/address/request-body.js
@@ -1,0 +1,13 @@
+const requestBody = (session) => ({
+  address: {
+    addressLine1: session.claim.addressLine1,
+    addressLine2: session.claim.addressLine2,
+    townOrCity: session.claim.townOrCity,
+    county: session.claim.county,
+    postcode: session.claim.postcode
+  }
+})
+
+module.exports = {
+  requestBody
+}

--- a/src/web/routes/application/address/request-body.test.js
+++ b/src/web/routes/application/address/request-body.test.js
@@ -1,0 +1,31 @@
+const test = require('tape')
+const { requestBody } = require('./request-body')
+
+const req = {
+  session: {
+    claim: {
+      addressLine1: 'Flat b',
+      addressLine2: '221 Baker street',
+      townOrCity: 'London',
+      county: 'Devon',
+      postcode: 'aa1 1ab'
+    }
+  }
+}
+
+test('requestBody() returns request body in correct format', (t) => {
+  const result = requestBody(req.session)
+
+  const expected = {
+    address: {
+      addressLine1: 'Flat b',
+      addressLine2: '221 Baker street',
+      townOrCity: 'London',
+      county: 'Devon',
+      postcode: 'aa1 1ab'
+    }
+  }
+
+  t.deepEqual(result, expected, 'returns request body in correct format')
+  t.end()
+})

--- a/src/web/routes/application/address/select-address/select-address.js
+++ b/src/web/routes/application/address/select-address/select-address.js
@@ -1,7 +1,7 @@
 const { path } = require('ramda')
 const { transformAddress } = require('./adapters')
-
 const { addressContentSummary } = require('../content-summary')
+const { requestBody } = require('../request-body')
 
 const pageContent = ({ translate }) => ({
   title: translate('address.title'),
@@ -71,7 +71,8 @@ const selectAddress = {
   toggle: 'ADDRESS_LOOKUP_ENABLED',
   behaviourForGet,
   behaviourForPost,
-  contentSummary
+  contentSummary,
+  requestBody
 }
 
 module.exports = {

--- a/src/web/routes/application/are-you-pregnant/are-you-pregnant.js
+++ b/src/web/routes/application/are-you-pregnant/are-you-pregnant.js
@@ -1,6 +1,7 @@
 const { validate } = require('./validate')
 const { YES } = require('../common/constants')
 const { formatDateForDisplay, getExampleDate } = require('../common/formatters')
+const { requestBody } = require('./request-body')
 
 const contentSummary = (req) => {
   const pregnantSummary = {
@@ -38,7 +39,8 @@ const areYouPregnant = {
   template: 'are-you-pregnant',
   pageContent,
   validate,
-  contentSummary
+  contentSummary,
+  requestBody
 }
 
 module.exports = {

--- a/src/web/routes/application/are-you-pregnant/request-body.js
+++ b/src/web/routes/application/are-you-pregnant/request-body.js
@@ -1,0 +1,21 @@
+const { toDateString } = require('../common/formatters')
+const { YES } = require('../common/constants')
+
+const createExpectedDeliveryDate = (claim) => {
+  if (claim.areYouPregnant === YES) {
+    return toDateString(
+      claim['expectedDeliveryDate-day'],
+      claim['expectedDeliveryDate-month'],
+      claim['expectedDeliveryDate-year']
+    )
+  }
+  return null
+}
+
+const requestBody = (session) => ({
+  expectedDeliveryDate: createExpectedDeliveryDate(session.claim)
+})
+
+module.exports = {
+  requestBody
+}

--- a/src/web/routes/application/are-you-pregnant/request-body.test.js
+++ b/src/web/routes/application/are-you-pregnant/request-body.test.js
@@ -1,0 +1,43 @@
+const test = require('tape')
+const { requestBody } = require('./request-body')
+
+const CLAIM_WITH_EXPECTED_DELIVERY_DATE = {
+  areYouPregnant: 'yes',
+  'expectedDeliveryDate-day': '01',
+  'expectedDeliveryDate-month': '03',
+  'expectedDeliveryDate-year': '2019'
+}
+
+const CLAIM_WITHOUT_EXPECTED_DELIVERY_DATE = {
+  areYouPregnant: 'no'
+}
+
+test('requestBody() adds expected delivery date when claimant is pregnant', (t) => {
+  const session = {
+    claim: CLAIM_WITH_EXPECTED_DELIVERY_DATE
+  }
+
+  const expected = {
+    expectedDeliveryDate: '2019-03-01'
+  }
+
+  const result = requestBody(session)
+
+  t.deepEqual(expected, result, 'adds expected delivery date when claimant is pregnant')
+  t.end()
+})
+
+test('requestBody() does not add expected delivery date when claimant is not pregnant', (t) => {
+  const session = {
+    claim: CLAIM_WITHOUT_EXPECTED_DELIVERY_DATE
+  }
+
+  const expected = {
+    expectedDeliveryDate: null
+  }
+
+  const result = requestBody(session)
+
+  t.deepEqual(expected, result, 'does not add expected delivery date when claimant is not pregnant')
+  t.end()
+})

--- a/src/web/routes/application/child-date-of-birth/child-date-of-birth.js
+++ b/src/web/routes/application/child-date-of-birth/child-date-of-birth.js
@@ -6,6 +6,7 @@ const { setChildrenInSessionForGet, setChildrenInSessionForPost } = require('./s
 const { handleRemoveAction } = require('./handle-remove-action')
 const { handleAddAction } = require('./handle-add-action')
 const { PATH } = require('./constants')
+const { requestBody } = require('./request-body')
 
 const pageContent = ({ translate }) => ({
   title: translate('childDateOfBirth.title'),
@@ -44,7 +45,8 @@ const childDateOfBirth = {
   isNavigable,
   behaviourForGet,
   behaviourForPost,
-  validate
+  validate,
+  requestBody
 }
 
 module.exports = {

--- a/src/web/routes/application/child-date-of-birth/request-body.js
+++ b/src/web/routes/application/child-date-of-birth/request-body.js
@@ -1,0 +1,27 @@
+const { isNil } = require('ramda')
+
+const createChildrenDobArray = (children) => {
+  if (isNil(children)) {
+    return null
+  }
+
+  let childrenArray = []
+  for (let i = 1; i <= children.childCount; i++) {
+    const childDobKey = `childDob-${i}`
+    const childDob = children[childDobKey]
+    if (typeof childDob === 'undefined') {
+      throw new Error(`No child date of birth stored in session for ${childDobKey}`)
+    }
+    childrenArray.push(childDob)
+  }
+  return childrenArray
+}
+
+const requestBody = (session) => ({
+  childrenDob: createChildrenDobArray(session.children)
+})
+
+module.exports = {
+  createChildrenDobArray,
+  requestBody
+}

--- a/src/web/routes/application/child-date-of-birth/request-body.test.js
+++ b/src/web/routes/application/child-date-of-birth/request-body.test.js
@@ -1,0 +1,58 @@
+const test = require('tape')
+const { createChildrenDobArray } = require('./request-body')
+
+const CHILDREN = {
+  'childName-1': 'First',
+  'childDob-1-day': '1',
+  'childDob-1-month': '1',
+  'childDob-1-year': '2018',
+  'childName-2': 'Second',
+  'childDob-2-day': '2',
+  'childDob-2-month': '2',
+  'childDob-2-year': '2017',
+  'childDob-1': '2018-01-01',
+  'childDob-2': '2017-02-02',
+  'inputCount': 2,
+  'childCount': 2
+}
+
+test('createChildrenDob extracts childrens dates of birth', (t) => {
+  const expectedChildren = ['2018-01-01', '2017-02-02']
+
+  const childrenList = createChildrenDobArray(CHILDREN)
+
+  t.deepEqual(childrenList, expectedChildren)
+  t.end()
+})
+
+test('createChildrenDob returns null with undefined children object provided', (t) => {
+  let children
+
+  const childrenList = createChildrenDobArray(children)
+
+  t.equals(childrenList, null)
+  t.end()
+})
+
+test('createChildrenDob returns null when children argument is null', (t) => {
+  const childrenList = createChildrenDobArray(null)
+
+  t.equals(childrenList, null)
+  t.end()
+})
+
+test('createChildrenDob throws an error when the childCount is 1 and there is no date of birth in the session.children object', (t) => {
+  // This object is invalid because it doesn't have the constructed date for the first child under the key childDob-1
+  const invalidConstructedChildren = {
+    'childName-1': 'First',
+    'childDob-day': '1',
+    'childDob-month': '1',
+    'childDob-year': '2018',
+    'inputCount': 1,
+    'childCount': 1
+  }
+
+  const childrenList = createChildrenDobArray.bind(null, invalidConstructedChildren)
+  t.throws(childrenList, /No child date of birth stored in session for childDob-1/, 'should throw an error when on dob stored for child')
+  t.end()
+})

--- a/src/web/routes/application/date-of-birth/date-of-birth.js
+++ b/src/web/routes/application/date-of-birth/date-of-birth.js
@@ -21,14 +21,21 @@ const contentSummary = (req) => ({
   )
 })
 
+const requestBody = (session) => ({
+  dateOfBirth: session.claim.dateOfBirth
+})
+
 const dateOfBirth = {
   path: '/date-of-birth',
   template: 'date-of-birth',
   pageContent,
   validate,
-  contentSummary
+  contentSummary,
+  requestBody
 }
 
 module.exports = {
-  dateOfBirth
+  dateOfBirth,
+  contentSummary,
+  requestBody
 }

--- a/src/web/routes/application/date-of-birth/date-of-birth.test.js
+++ b/src/web/routes/application/date-of-birth/date-of-birth.test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const { dateOfBirth } = require('./date-of-birth')
+const { contentSummary, requestBody } = require('./date-of-birth')
 
 const req = {
   t: string => string,
@@ -7,13 +7,14 @@ const req = {
     claim: {
       'dateOfBirth-day': '30',
       'dateOfBirth-month': '05',
-      'dateOfBirth-year': '1920'
+      'dateOfBirth-year': '1920',
+      'dateOfBirth': '1920-05-30'
     }
   }
 }
 
 test('Date of birth contentSummary() should return content summary in correct format', (t) => {
-  const result = dateOfBirth.contentSummary(req)
+  const result = contentSummary(req)
 
   const expected = {
     key: 'dateOfBirth.summaryKey',
@@ -21,5 +22,16 @@ test('Date of birth contentSummary() should return content summary in correct fo
   }
 
   t.deepEqual(result, expected, 'should return content summary in correct format')
+  t.end()
+})
+
+test('Date of birth requestBody() should return request body in correct format', (t) => {
+  const result = requestBody(req.session)
+
+  const expected = {
+    'dateOfBirth': '1920-05-30'
+  }
+
+  t.deepEqual(result, expected, 'should return request body in correct format')
   t.end()
 })

--- a/src/web/routes/application/email-address/email-address.js
+++ b/src/web/routes/application/email-address/email-address.js
@@ -28,17 +28,23 @@ const behaviourForPost = () => (req, res, next) => {
   next()
 }
 
+const requestBody = (session) => ({
+  emailAddress: session.claim.emailAddress
+})
+
 const emailAddress = {
   path: '/email-address',
   template: 'email-address',
   validate,
   pageContent,
   contentSummary,
-  behaviourForPost
+  behaviourForPost,
+  requestBody
 }
 
 module.exports = {
   contentSummary,
   emailAddress,
-  behaviourForPost
+  behaviourForPost,
+  requestBody
 }

--- a/src/web/routes/application/email-address/email-address.test.js
+++ b/src/web/routes/application/email-address/email-address.test.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
-const { contentSummary } = require('./email-address')
+const { contentSummary, requestBody } = require('./email-address')
 
 const { TEXT, EMAIL } = require('../common/constants')
 
@@ -87,5 +87,16 @@ test('behaviourForPost() does not reset confirmation code if the user has not up
 
   t.equal(handleConfirmationCodeReset.called, false)
   handleConfirmationCodeReset.resetHistory()
+  t.end()
+})
+
+test('requestBody() returns request body in correct format', (t) => {
+  const result = requestBody(req.session)
+
+  const expected = {
+    emailAddress: 'test@email.com'
+  }
+
+  t.deepEqual(result, expected, 'returns request body in correct format')
   t.end()
 })

--- a/src/web/routes/application/name/name.js
+++ b/src/web/routes/application/name/name.js
@@ -15,15 +15,22 @@ const contentSummary = (req) => ({
   value: `${req.session.claim.firstName} ${req.session.claim.lastName}`.trim()
 })
 
+const requestBody = (session) => ({
+  firstName: session.claim.firstName,
+  lastName: session.claim.lastName
+})
+
 const name = {
   path: '/name',
   template: 'name',
   validate,
   pageContent,
-  contentSummary
+  contentSummary,
+  requestBody
 }
 
 module.exports = {
   contentSummary,
+  requestBody,
   name
 }

--- a/src/web/routes/application/name/name.test.js
+++ b/src/web/routes/application/name/name.test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const { contentSummary } = require('./name')
+const { contentSummary, requestBody } = require('./name')
 
 const req = {
   t: string => string,
@@ -20,5 +20,17 @@ test('Enter name contentSummary() should return content summary in correct forma
   }
 
   t.deepEqual(result, expected, 'should return content summary in correct format')
+  t.end()
+})
+
+test('requestBody() returns request body in correct format', (t) => {
+  const result = requestBody(req.session)
+
+  const expected = {
+    firstName: 'Lisa',
+    lastName: 'Smith'
+  }
+
+  t.deepEqual(result, expected, 'returns request body in correct format')
   t.end()
 })

--- a/src/web/routes/application/national-insurance-number/national-insurance-number.js
+++ b/src/web/routes/application/national-insurance-number/national-insurance-number.js
@@ -15,15 +15,21 @@ const contentSummary = (req) => ({
   value: req.session.claim.nino
 })
 
+const requestBody = (session) => ({
+  nino: session.claim.nino
+})
+
 const nationalInsuranceNumber = {
   path: '/national-insurance-number',
   template: 'national-insurance-number',
   sanitize,
   validate,
   pageContent,
-  contentSummary
+  contentSummary,
+  requestBody
 }
 
 module.exports = {
-  nationalInsuranceNumber
+  nationalInsuranceNumber,
+  requestBody
 }

--- a/src/web/routes/application/national-insurance-number/national-insurance-number.test.js
+++ b/src/web/routes/application/national-insurance-number/national-insurance-number.test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const { nationalInsuranceNumber } = require('./national-insurance-number')
+const { nationalInsuranceNumber, requestBody } = require('./national-insurance-number')
 
 const req = {
   t: string => string,
@@ -19,5 +19,16 @@ test('National insurance number contentSummary() should return content summary i
   }
 
   t.deepEqual(result, expected, 'should return content summary in correct format')
+  t.end()
+})
+
+test('requestBody() returns request body in correct format', (t) => {
+  const result = requestBody(req.session)
+
+  const expected = {
+    nino: 'QQ123456C'
+  }
+
+  t.deepEqual(result, expected, 'returns request body in correct format')
   t.end()
 })

--- a/src/web/routes/application/phone-number/phone-number.js
+++ b/src/web/routes/application/phone-number/phone-number.js
@@ -29,6 +29,10 @@ const behaviourForPost = () => (req, res, next) => {
   next()
 }
 
+const requestBody = (session) => ({
+  phoneNumber: session.claim.formattedPhoneNumber
+})
+
 const phoneNumber = {
   path: '/phone-number',
   template: 'phone-number',
@@ -36,11 +40,13 @@ const phoneNumber = {
   sanitize,
   pageContent,
   contentSummary,
-  behaviourForPost
+  behaviourForPost,
+  requestBody
 }
 
 module.exports = {
   contentSummary,
   phoneNumber,
-  behaviourForPost
+  behaviourForPost,
+  requestBody
 }

--- a/src/web/routes/application/phone-number/phone-number.test.js
+++ b/src/web/routes/application/phone-number/phone-number.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
 const { TEXT, EMAIL } = require('../common/constants')
-const { contentSummary } = require('./phone-number')
+const { contentSummary, requestBody } = require('./phone-number')
 
 const handleConfirmationCodeReset = sinon.spy()
 
@@ -86,5 +86,25 @@ test('behaviourForPost() does not reset confirmation code if the user has not up
 
   t.equal(handleConfirmationCodeReset.called, false)
   handleConfirmationCodeReset.resetHistory()
+  t.end()
+})
+
+test('requestBody() returns request body in correct format', (t) => {
+  const req = {
+    session: {
+      claim: {
+        phoneNumber: '07700 900645',
+        formattedPhoneNumber: '+447700900645'
+      }
+    }
+  }
+
+  const result = requestBody(req.session)
+
+  const expected = {
+    phoneNumber: '+447700900645'
+  }
+
+  t.deepEqual(result, expected, 'returns request body in correct format')
   t.end()
 })

--- a/src/web/routes/application/terms-and-conditions/create-request-body.js
+++ b/src/web/routes/application/terms-and-conditions/create-request-body.js
@@ -1,52 +1,9 @@
-const { isNil } = require('ramda')
-const { toDateString } = require('../common/formatters')
-const { YES } = require('../common/constants')
+const { isUndefined } = require('../../../../common/predicates')
 
-const createExpectedDeliveryDate = (claim) => {
-  if (claim.areYouPregnant === YES) {
-    return toDateString(
-      claim['expectedDeliveryDate-day'],
-      claim['expectedDeliveryDate-month'],
-      claim['expectedDeliveryDate-year']
-    )
-  }
-  return null
-}
+const buildRequestBodyForStep = (session) => (claimant, step) =>
+  isUndefined(step.requestBody) ? claimant : { ...claimant, ...step.requestBody(session) }
 
-const createChildrenDobArray = (children) => {
-  if (isNil(children)) {
-    return null
-  }
-
-  let childrenArray = []
-  for (let i = 1; i <= children.childCount; i++) {
-    const childDobKey = `childDob-${i}`
-    const childDob = children[childDobKey]
-    if (typeof childDob === 'undefined') {
-      throw new Error(`No child date of birth stored in session for ${childDobKey}`)
-    }
-    childrenArray.push(childDob)
-  }
-  return childrenArray
-}
-
-const createClaim = (claim, children) => ({
-  firstName: claim.firstName,
-  lastName: claim.lastName,
-  nino: claim.nino,
-  dateOfBirth: claim.dateOfBirth,
-  address: {
-    addressLine1: claim.addressLine1,
-    addressLine2: claim.addressLine2,
-    townOrCity: claim.townOrCity,
-    county: claim.county,
-    postcode: claim.postcode
-  },
-  expectedDeliveryDate: createExpectedDeliveryDate(claim),
-  phoneNumber: claim.formattedPhoneNumber,
-  emailAddress: claim.emailAddress,
-  childrenDob: createChildrenDobArray(children)
-})
+const createClaim = (steps, session) => steps.reduce(buildRequestBodyForStep(session), {})
 
 const createDeviceFingerprint = (headers) => ({
   'user-agent': headers['user-agent'],
@@ -56,13 +13,13 @@ const createDeviceFingerprint = (headers) => ({
   'accept-language': headers['accept-language']
 })
 
-const createRequestBody = (config, req) => ({
-  claimant: createClaim(req.session.claim, req.session.children),
+const createRequestBody = (config, steps, req) => ({
+  claimant: createClaim(steps, req.session),
   deviceFingerprint: createDeviceFingerprint(req.headers),
   webUIVersion: config.environment.APP_VERSION
 })
 
 module.exports = {
   createRequestBody,
-  createChildrenDobArray
+  createClaim
 }

--- a/src/web/routes/application/terms-and-conditions/create-request-body.test.js
+++ b/src/web/routes/application/terms-and-conditions/create-request-body.test.js
@@ -1,12 +1,40 @@
 const test = require('tape')
-const { createRequestBody, createChildrenDobArray } = require('./create-request-body')
-const APP_VERSION = 'myAppVersion'
+const { createRequestBody, createClaim } = require('./create-request-body')
 
-const config = {
-  environment: {
-    APP_VERSION
+test('createClaim() creates a claim in the correct format', (t) => {
+  const steps = [
+    {
+      requestBody: (session) => ({
+        bodyValueOne: session['valueOne']
+      })
+    }, {
+      requestBody: (session) => ({
+        nestedValues: {
+          nestedBodyValueOne: session['valueOne'],
+          nestedBodyValueTwo: session['valueTwo']
+        }
+      })
+    }
+  ]
+
+  const session = {
+    valueOne: 'one',
+    valueTwo: 'two'
   }
-}
+
+  const result = createClaim(steps, session)
+
+  const expected = {
+    bodyValueOne: 'one',
+    nestedValues: {
+      nestedBodyValueOne: 'one',
+      nestedBodyValueTwo: 'two'
+    }
+  }
+
+  t.deepEqual(result, expected, 'creates the claim in the correct format')
+  t.end()
+})
 
 const requestHeaders = {
   'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.80 Safari/537.36',
@@ -25,177 +53,49 @@ const expectedFingerprint = {
   'accept-language': 'en-GB,en-US;q=0.9,en;q=0.8'
 }
 
-const CLAIM_WITHOUT_EXPECTED_DELIVERY_DATE = {
-  _csrf: 'cmm9LYCZ-NU6gvQlx6BVmzJ16i0Q0rutqHXE',
-  firstName: 'James',
-  lastName: 'The third',
-  nino: 'qq123456c',
-  'dateOfBirth-day': '01',
-  'dateOfBirth-month': '01',
-  'dateOfBirth-year': '1920',
-  dateOfBirth: '1920-01-01',
-  areYouPregnant: 'no',
-  addressLine1: 'Flat b',
-  addressLine2: '221 Baker street',
-  townOrCity: 'London',
-  county: 'Greater London',
-  postcode: 'aa1 1ab',
-  phoneNumber: '07700 900645',
-  formattedPhoneNumber: '+447700900645',
-  emailAddress: 'test@email.com'
-}
+test('createRequestBody() adds claim, device fingerprint and web UI version to request body', (t) => {
+  const APP_VERSION = 'myAppVersion'
 
-const CLAIM_WITH_EXPECTED_DELIVERY_DATE = {
-  _csrf: 'cmm9LYCZ-NU6gvQlx6BVmzJ16i0Q0rutqHXE',
-  firstName: 'James',
-  lastName: 'The third',
-  nino: 'qq123456c',
-  'dateOfBirth-day': '01',
-  'dateOfBirth-month': '01',
-  'dateOfBirth-year': '1920',
-  dateOfBirth: '1920-01-01',
-  areYouPregnant: 'yes',
-  'expectedDeliveryDate-day': '01',
-  'expectedDeliveryDate-month': '03',
-  'expectedDeliveryDate-year': '2019',
-  addressLine1: 'Flat b',
-  addressLine2: '221 Baker street',
-  townOrCity: 'London',
-  county: 'Greater London',
-  postcode: 'aa1 1ab',
-  phoneNumber: '07700 900645',
-  formattedPhoneNumber: '+447700900645',
-  emailAddress: 'test@email.com'
-}
+  const config = {
+    environment: {
+      APP_VERSION
+    }
+  }
 
-const CHILDREN = {
-  'childName-1': 'First',
-  'childDob-1-day': '1',
-  'childDob-1-month': '1',
-  'childDob-1-year': '2018',
-  'childName-2': 'Second',
-  'childDob-2-day': '2',
-  'childDob-2-month': '2',
-  'childDob-2-year': '2017',
-  'childDob-1': '2018-01-01',
-  'childDob-2': '2017-02-02',
-  'inputCount': 2,
-  'childCount': 2
-}
+  const steps = [
+    {
+      requestBody: (session) => ({
+        bodyValueOne: session.claim['valueOne']
+      })
+    },
+    {
+      requestBody: (session) => ({
+        bodyValueTwo: session.claim['valueTwo']
+      })
+    }
+  ]
 
-test('create claim body', (t) => {
   const request = {
     session: {
-      claim: CLAIM_WITH_EXPECTED_DELIVERY_DATE,
-      children: CHILDREN
+      claim: {
+        valueOne: 'one',
+        valueTwo: 'two'
+      }
     },
     headers: requestHeaders
   }
 
   const expectedBody = {
     claimant: {
-      firstName: 'James',
-      lastName: 'The third',
-      nino: 'qq123456c',
-      dateOfBirth: '1920-01-01',
-      address: {
-        addressLine1: 'Flat b',
-        addressLine2: '221 Baker street',
-        townOrCity: 'London',
-        county: 'Greater London',
-        postcode: 'aa1 1ab'
-      },
-      expectedDeliveryDate: '2019-03-01',
-      phoneNumber: '+447700900645', // assert that the phone number posted is the formatted version
-      emailAddress: 'test@email.com',
-      childrenDob: [
-        '2018-01-01',
-        '2017-02-02'
-      ]
+      bodyValueOne: 'one',
+      bodyValueTwo: 'two'
     },
     deviceFingerprint: expectedFingerprint,
     webUIVersion: APP_VERSION
   }
 
-  const bodyToPost = createRequestBody(config, request)
+  const bodyToPost = createRequestBody(config, steps, request)
 
   t.deepEqual(bodyToPost, expectedBody)
-  t.end()
-})
-
-test('create claim body without expectedDeliveryDate when not pregnant', (t) => {
-  const request = {
-    session: {
-      claim: CLAIM_WITHOUT_EXPECTED_DELIVERY_DATE
-    },
-    headers: requestHeaders
-  }
-
-  const expectedBody = {
-    claimant: {
-      firstName: 'James',
-      lastName: 'The third',
-      nino: 'qq123456c',
-      dateOfBirth: '1920-01-01',
-      address: {
-        addressLine1: 'Flat b',
-        addressLine2: '221 Baker street',
-        townOrCity: 'London',
-        county: 'Greater London',
-        postcode: 'aa1 1ab'
-      },
-      expectedDeliveryDate: null,
-      phoneNumber: '+447700900645', // assert that the phone number posted is the formatted version
-      emailAddress: 'test@email.com',
-      childrenDob: null
-    },
-    deviceFingerprint: expectedFingerprint,
-    webUIVersion: APP_VERSION
-  }
-
-  const bodyToPost = createRequestBody(config, request)
-
-  t.deepEqual(bodyToPost, expectedBody)
-  t.end()
-})
-
-test('createChildrenDob extracts childrens dates of birth', (t) => {
-  const expectedChildren = ['2018-01-01', '2017-02-02']
-
-  const childrenList = createChildrenDobArray(CHILDREN)
-
-  t.deepEqual(childrenList, expectedChildren)
-  t.end()
-})
-
-test('createChildrenDob returns null with undefined children object provided', (t) => {
-  let children
-
-  const childrenList = createChildrenDobArray(children)
-
-  t.equals(childrenList, null)
-  t.end()
-})
-
-test('createChildrenDob returns null when children argument is null', (t) => {
-  const childrenList = createChildrenDobArray(null)
-
-  t.equals(childrenList, null)
-  t.end()
-})
-
-test('createChildrenDob throws an error when the childCount is 1 and there is no date of birth in the session.children object', (t) => {
-  // This object is invalid because it doesn't have the constructed date for the first child under the key childDob-1
-  const invalidConstructedChildren = {
-    'childName-1': 'First',
-    'childDob-day': '1',
-    'childDob-month': '1',
-    'childDob-year': '2018',
-    'inputCount': 1,
-    'childCount': 1
-  }
-
-  const childrenList = createChildrenDobArray.bind(null, invalidConstructedChildren)
-  t.throws(childrenList, /No child date of birth stored in session for childDob-1/, 'should throw an error when on dob stored for child')
   t.end()
 })

--- a/src/web/routes/application/terms-and-conditions/post.js
+++ b/src/web/routes/application/terms-and-conditions/post.js
@@ -38,7 +38,7 @@ const postTermsAndConditions = (steps, config) => (req, res, next) => {
       'X-Request-ID': req.headers[REQUEST_ID_HEADER],
       'X-Session-ID': req.sessionID
     },
-    body: createRequestBody(config, req),
+    body: createRequestBody(config, steps, req),
     simple: false,
     transform: handleErrorResponse
   })


### PR DESCRIPTION
The general rule of the application is to define logic and  data transformations at the step level. It therefore makes sense that the properties for the request body should also be defined at the step level. The benefits of this approach are:

1. Related code is all in one place in the application architecture
2. Toggling a step will mean the relevant part of the request body is also toggled
3. Easier to unit test individual parts of the request body

The acceptance test that checks the request body being sent to the server should give us confidence to make this update. A lot of the PR is moving code from `create-request-body.js` to the relevant steps:

- Create a function that iterates over each step to generate the request body that is sent to the server
- Move definition of request body properties to the relevant steps
- Move testing of request body properties to the relevant steps
- Create a common request body function for manual address / select address