### PR TITLE
NO-JIRA setting OPTIMISE_MEMORY to true to prevent OOM errors, logging the number of cores available

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,6 +9,7 @@ applications:
     NODE_ENV: production
     APP_VERSION: ((app-version))
     GOOGLE_ANALYTICS_URI: https://www.google-analytics.com/collect
+    OPTIMIZE_MEMORY: true
   buildpacks:
     - nodejs_buildpack
   services:

--- a/src/web/server/server.js
+++ b/src/web/server/server.js
@@ -11,6 +11,7 @@ const { registerErrorHandlers } = require('./error-handlers')
 const { setViewEngine } = require('./view-engine')
 const { internationalisation } = require('./internationalisation')
 const { requestID } = require('./headers')
+const numCores = require('os').cpus().length
 
 const configureStaticPaths = (app) => {
   /**
@@ -26,6 +27,7 @@ const configureStaticPaths = (app) => {
 const listen = (config, app) =>
   app.listen(config.server.PORT, () => {
     logger.info(`App listening on port ${config.server.PORT}`)
+    logger.info(`Number of cores available: ${numCores} (node uses only a single core)`)
   })
 
 const start = (config, app) => () => {


### PR DESCRIPTION
See https://docs.cloudfoundry.org/buildpacks/node/node-tips.html#memory