### PR TITLE
HTBHF-2297 minimise redundant address transforms

### DIFF
--- a/src/web/routes/application/address/formats.js
+++ b/src/web/routes/application/address/formats.js
@@ -1,0 +1,15 @@
+const { isString } = require('../../../../common/predicates')
+
+const SINGLE_WORD_REGEX = /\b\w+/g
+
+const toTitleCase = (str) => {
+  return !isString(str) ? str : str.replace(
+    SINGLE_WORD_REGEX,
+    function (txt) { return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase() }
+  )
+}
+
+module.exports = {
+  SINGLE_WORD_REGEX,
+  toTitleCase
+}

--- a/src/web/routes/application/address/formats.test.js
+++ b/src/web/routes/application/address/formats.test.js
@@ -1,0 +1,17 @@
+const test = require('tape')
+const { toTitleCase, SINGLE_WORD_REGEX } = require('./formats')
+const safeRegex = require('safe-regex')
+
+test('toTitleCase() should uppercase the first letter of every word', (t) => {
+  const result = toTitleCase('10A, MY STREET, WESTON-SUPER-MARE')
+
+  const expected = '10a, My Street, Weston-Super-Mare'
+
+  t.equals(result, expected, 'transforms string to title case correctly')
+  t.end()
+})
+
+test('single word regex is safe()', (t) => {
+  t.equal(safeRegex(SINGLE_WORD_REGEX), true)
+  t.end()
+})

--- a/src/web/routes/application/address/postcode/adapters.js
+++ b/src/web/routes/application/address/postcode/adapters.js
@@ -1,33 +1,20 @@
 const { compose, map, pick, prop, propOr } = require('ramda')
-const { isString } = require('../../../../../common/predicates')
 const { OS_PLACES_ADDRESS_KEYS } = require('../constants')
+const { toTitleCase } = require('../formats')
 
 const RESULTS_PROP = 'results'
 const DELIVERY_POINT_ADDRESS_PROP = 'DPA'
-const SINGLE_WORD_REGEX = /\b\w+/g
 
-const toTitleCase = (str) => {
-  return !isString(str) ? str : str.replace(
-    SINGLE_WORD_REGEX,
-    function (txt) { return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase() }
-  )
-}
+const transformAddressField = (address) => ({
+  ...address,
+  ADDRESS: toTitleCase(address.ADDRESS.replace(`, ${address.POSTCODE}`, ''))
+})
 
-const convertCase = (address) => {
-  const titleCase = map(toTitleCase, address)
-  titleCase.ADDRESS = toTitleCase(address.ADDRESS.replace(`, ${address.POSTCODE}`, ''))
-  titleCase.POSTCODE = address.POSTCODE
-  return titleCase
-}
-
-const transformAddress = compose(convertCase, pick(OS_PLACES_ADDRESS_KEYS), prop(DELIVERY_POINT_ADDRESS_PROP))
+const transformAddress = compose(transformAddressField, pick(OS_PLACES_ADDRESS_KEYS), prop(DELIVERY_POINT_ADDRESS_PROP))
 
 const transformOsPlacesApiResponse = compose(map(transformAddress), propOr([], RESULTS_PROP))
 
 module.exports = {
-  SINGLE_WORD_REGEX,
-  toTitleCase,
-  convertCase,
   transformAddress,
   transformOsPlacesApiResponse
 }

--- a/src/web/routes/application/address/postcode/adapters.js
+++ b/src/web/routes/application/address/postcode/adapters.js
@@ -5,6 +5,9 @@ const { toTitleCase } = require('../formats')
 const RESULTS_PROP = 'results'
 const DELIVERY_POINT_ADDRESS_PROP = 'DPA'
 
+// Transform single line address field (ADDRESS) for use in UI:
+// - Convert to title case
+// - Remove postcode
 const transformAddressField = (address) => ({
   ...address,
   ADDRESS: toTitleCase(address.ADDRESS.replace(`, ${address.POSTCODE}`, ''))

--- a/src/web/routes/application/address/postcode/adapters.test.js
+++ b/src/web/routes/application/address/postcode/adapters.test.js
@@ -1,53 +1,19 @@
 const test = require('tape')
-const { transformAddress, transformOsPlacesApiResponse, toTitleCase, convertCase, SINGLE_WORD_REGEX } = require('./adapters')
+const { transformAddress, transformOsPlacesApiResponse } = require('./adapters')
 const TEST_FIXTURES = require('./test-fixtures.json')
-const safeRegex = require('safe-regex')
-
-test('toTitleCase() should uppercase the first letter of every word', (t) => {
-  const result = toTitleCase('10A, MY STREET, WESTON-SUPER-MARE')
-
-  const expected = '10a, My Street, Weston-Super-Mare'
-
-  t.equals(result, expected, 'transforms string to title case correctly')
-  t.end()
-})
-
-test('convertCase() should convert the case of the address to title case', (t) => {
-  const original = {
-    ADDRESS: '10A, MAYFIELD AVENUE, WESTON-SUPER-MARE, BS22 6AA',
-    BUILDING_NAME: '10A',
-    THOROUGHFARE_NAME: 'MAYFIELD AVENUE',
-    POST_TOWN: 'WESTON-SUPER-MARE',
-    POSTCODE: 'BS22 6AA',
-    LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'NORTH SOMERSET'
-  }
-  const result = convertCase(original)
-
-  const expected = {
-    ADDRESS: '10a, Mayfield Avenue, Weston-Super-Mare',
-    BUILDING_NAME: '10a',
-    THOROUGHFARE_NAME: 'Mayfield Avenue',
-    POST_TOWN: 'Weston-Super-Mare',
-    POSTCODE: 'BS22 6AA',
-    LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'North Somerset'
-  }
-
-  t.deepEqual(result, expected, 'converts case of an address correctly')
-  t.end()
-})
 
 test('transformAddress() transforms address correctly', (t) => {
   const result = transformAddress(TEST_FIXTURES.results[0])
 
   const expected = {
     ADDRESS: 'Alan Jeffery Engineering, 1, Valley Road, Plymouth',
-    ORGANISATION_NAME: 'Alan Jeffery Engineering',
+    ORGANISATION_NAME: 'ALAN JEFFERY ENGINEERING',
     BUILDING_NUMBER: '1',
-    THOROUGHFARE_NAME: 'Valley Road',
-    DEPENDENT_THOROUGHFARE_NAME: 'Upper Valley Road',
-    POST_TOWN: 'Plymouth',
+    DEPENDENT_THOROUGHFARE_NAME: 'UPPER VALLEY ROAD',
+    THOROUGHFARE_NAME: 'VALLEY ROAD',
+    POST_TOWN: 'PLYMOUTH',
     POSTCODE: 'PL7 1RF',
-    LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'City Of Plymouth'
+    LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'CITY OF PLYMOUTH'
   }
 
   t.deepEqual(result, expected, 'transforms address correctly')
@@ -60,49 +26,53 @@ test('transformOsPlacesApiResponse() transforms OS Places API response correctly
   const expected = [
     {
       ADDRESS: 'Alan Jeffery Engineering, 1, Valley Road, Plymouth',
-      ORGANISATION_NAME: 'Alan Jeffery Engineering',
+      ORGANISATION_NAME: 'ALAN JEFFERY ENGINEERING',
       BUILDING_NUMBER: '1',
-      THOROUGHFARE_NAME: 'Valley Road',
-      DEPENDENT_THOROUGHFARE_NAME: 'Upper Valley Road',
-      POST_TOWN: 'Plymouth',
+      DEPENDENT_THOROUGHFARE_NAME: 'UPPER VALLEY ROAD',
+      THOROUGHFARE_NAME: 'VALLEY ROAD',
+      POST_TOWN: 'PLYMOUTH',
       POSTCODE: 'PL7 1RF',
-      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'City Of Plymouth'
-    }, {
+      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'CITY OF PLYMOUTH'
+    },
+    {
       ADDRESS: 'Dulux Decorator Centre, 2, Valley Road, Plymouth',
-      ORGANISATION_NAME: 'Dulux Decorator Centre',
+      ORGANISATION_NAME: 'DULUX DECORATOR CENTRE',
       BUILDING_NUMBER: '2',
-      THOROUGHFARE_NAME: 'Valley Road',
-      DEPENDENT_THOROUGHFARE_NAME: 'Upper Valley Road',
-      POST_TOWN: 'Plymouth',
+      DEPENDENT_THOROUGHFARE_NAME: 'UPPER VALLEY ROAD',
+      THOROUGHFARE_NAME: 'VALLEY ROAD',
+      POST_TOWN: 'PLYMOUTH',
       POSTCODE: 'PL7 1RF',
-      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'City Of Plymouth'
-    }, {
+      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'CITY OF PLYMOUTH'
+    },
+    {
       ADDRESS: 'Mill Autos, 3, Valley Road, Plymouth',
-      ORGANISATION_NAME: 'Mill Autos',
+      ORGANISATION_NAME: 'MILL AUTOS',
       BUILDING_NUMBER: '3',
-      THOROUGHFARE_NAME: 'Valley Road',
-      DEPENDENT_THOROUGHFARE_NAME: 'Upper Valley Road',
-      POST_TOWN: 'Plymouth',
+      DEPENDENT_THOROUGHFARE_NAME: 'UPPER VALLEY ROAD',
+      THOROUGHFARE_NAME: 'VALLEY ROAD',
+      POST_TOWN: 'PLYMOUTH',
       POSTCODE: 'PL7 1RF',
-      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'City Of Plymouth'
-    }, {
+      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'CITY OF PLYMOUTH'
+    },
+    {
       ADDRESS: 'Goat Hill Farm, 2, Troll Bridge, Goat Hill, Slaithwaite, Slaith, Huddersfield',
-      ORGANISATION_NAME: 'Goat Hill Farm',
+      ORGANISATION_NAME: 'GOAT HILL FARM',
       BUILDING_NUMBER: '2',
-      THOROUGHFARE_NAME: 'Goat Hill',
-      DEPENDENT_THOROUGHFARE_NAME: 'Troll Bridge',
-      DOUBLE_DEPENDENT_LOCALITY: 'Slaithwaite',
-      DEPENDENT_LOCALITY: 'Slaith',
-      POST_TOWN: 'Huddersfield',
+      DEPENDENT_THOROUGHFARE_NAME: 'TROLL BRIDGE',
+      THOROUGHFARE_NAME: 'GOAT HILL',
+      DOUBLE_DEPENDENT_LOCALITY: 'SLAITHWAITE',
+      DEPENDENT_LOCALITY: 'SLAITH',
+      POST_TOWN: 'HUDDERSFIELD',
       POSTCODE: 'HD7 5UZ',
-      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'Kirklees'
-    }, {
+      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'KIRKLEES'
+    },
+    {
       ADDRESS: '10a, Mayfield Avenue, Weston-Super-Mare',
-      BUILDING_NAME: '10a',
-      THOROUGHFARE_NAME: 'Mayfield Avenue',
-      POST_TOWN: 'Weston-Super-Mare',
+      BUILDING_NAME: '10A',
+      THOROUGHFARE_NAME: 'MAYFIELD AVENUE',
+      POST_TOWN: 'WESTON-SUPER-MARE',
       POSTCODE: 'BS22 6AA',
-      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'North Somerset'
+      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'NORTH SOMERSET'
     }
   ]
 
@@ -116,10 +86,5 @@ test('transformOsPlacesApiResponse() returns empty array if no results on respon
   const expected = []
 
   t.deepEqual(result, expected, 'returns empty array if no results on response')
-  t.end()
-})
-
-test('single word regex is safe()', (t) => {
-  t.equal(safeRegex(SINGLE_WORD_REGEX), true)
   t.end()
 })

--- a/src/web/routes/application/address/postcode/postcode.test.js
+++ b/src/web/routes/application/address/postcode/postcode.test.js
@@ -47,49 +47,53 @@ test('behaviourForPost() handles successful address lookup', async (t) => {
   const expectedAddresses = [
     {
       ADDRESS: 'Alan Jeffery Engineering, 1, Valley Road, Plymouth',
-      ORGANISATION_NAME: 'Alan Jeffery Engineering',
+      ORGANISATION_NAME: 'ALAN JEFFERY ENGINEERING',
       BUILDING_NUMBER: '1',
-      THOROUGHFARE_NAME: 'Valley Road',
-      DEPENDENT_THOROUGHFARE_NAME: 'Upper Valley Road',
-      POST_TOWN: 'Plymouth',
+      DEPENDENT_THOROUGHFARE_NAME: 'UPPER VALLEY ROAD',
+      THOROUGHFARE_NAME: 'VALLEY ROAD',
+      POST_TOWN: 'PLYMOUTH',
       POSTCODE: 'PL7 1RF',
-      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'City Of Plymouth'
-    }, {
+      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'CITY OF PLYMOUTH'
+    },
+    {
       ADDRESS: 'Dulux Decorator Centre, 2, Valley Road, Plymouth',
-      ORGANISATION_NAME: 'Dulux Decorator Centre',
+      ORGANISATION_NAME: 'DULUX DECORATOR CENTRE',
       BUILDING_NUMBER: '2',
-      THOROUGHFARE_NAME: 'Valley Road',
-      DEPENDENT_THOROUGHFARE_NAME: 'Upper Valley Road',
-      POST_TOWN: 'Plymouth',
+      DEPENDENT_THOROUGHFARE_NAME: 'UPPER VALLEY ROAD',
+      THOROUGHFARE_NAME: 'VALLEY ROAD',
+      POST_TOWN: 'PLYMOUTH',
       POSTCODE: 'PL7 1RF',
-      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'City Of Plymouth'
-    }, {
+      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'CITY OF PLYMOUTH'
+    },
+    {
       ADDRESS: 'Mill Autos, 3, Valley Road, Plymouth',
-      ORGANISATION_NAME: 'Mill Autos',
+      ORGANISATION_NAME: 'MILL AUTOS',
       BUILDING_NUMBER: '3',
-      THOROUGHFARE_NAME: 'Valley Road',
-      DEPENDENT_THOROUGHFARE_NAME: 'Upper Valley Road',
-      POST_TOWN: 'Plymouth',
+      DEPENDENT_THOROUGHFARE_NAME: 'UPPER VALLEY ROAD',
+      THOROUGHFARE_NAME: 'VALLEY ROAD',
+      POST_TOWN: 'PLYMOUTH',
       POSTCODE: 'PL7 1RF',
-      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'City Of Plymouth'
-    }, {
+      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'CITY OF PLYMOUTH'
+    },
+    {
       ADDRESS: 'Goat Hill Farm, 2, Troll Bridge, Goat Hill, Slaithwaite, Slaith, Huddersfield',
-      ORGANISATION_NAME: 'Goat Hill Farm',
+      ORGANISATION_NAME: 'GOAT HILL FARM',
       BUILDING_NUMBER: '2',
-      THOROUGHFARE_NAME: 'Goat Hill',
-      DEPENDENT_THOROUGHFARE_NAME: 'Troll Bridge',
-      DOUBLE_DEPENDENT_LOCALITY: 'Slaithwaite',
-      DEPENDENT_LOCALITY: 'Slaith',
-      POST_TOWN: 'Huddersfield',
+      DEPENDENT_THOROUGHFARE_NAME: 'TROLL BRIDGE',
+      THOROUGHFARE_NAME: 'GOAT HILL',
+      DOUBLE_DEPENDENT_LOCALITY: 'SLAITHWAITE',
+      DEPENDENT_LOCALITY: 'SLAITH',
+      POST_TOWN: 'HUDDERSFIELD',
       POSTCODE: 'HD7 5UZ',
-      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'Kirklees'
-    }, {
+      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'KIRKLEES'
+    },
+    {
       ADDRESS: '10a, Mayfield Avenue, Weston-Super-Mare',
-      BUILDING_NAME: '10a',
-      THOROUGHFARE_NAME: 'Mayfield Avenue',
-      POST_TOWN: 'Weston-Super-Mare',
+      BUILDING_NAME: '10A',
+      THOROUGHFARE_NAME: 'MAYFIELD AVENUE',
+      POST_TOWN: 'WESTON-SUPER-MARE',
       POSTCODE: 'BS22 6AA',
-      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'North Somerset'
+      LOCAL_CUSTODIAN_CODE_DESCRIPTION: 'NORTH SOMERSET'
     }
   ]
 

--- a/src/web/routes/application/address/select-address/adapters.addresses.test.js
+++ b/src/web/routes/application/address/select-address/adapters.addresses.test.js
@@ -13,10 +13,10 @@ test('transformAddress() builds address A', (t) => {
   }
 
   const expected = {
-    addressLine1: 'ALAN JEFFERY ENGINEERING',
-    addressLine2: '1 VALLEY ROAD',
-    townOrCity: 'PLYMOUTH',
-    county: 'CITY OF PLYMOUTH',
+    addressLine1: 'Alan Jeffery Engineering',
+    addressLine2: '1 Valley Road',
+    townOrCity: 'Plymouth',
+    county: 'City Of Plymouth',
     postcode: 'PL7 1RF'
   }
 
@@ -39,10 +39,10 @@ test('transformAddress() builds address B', (t) => {
   }
 
   const expected = {
-    addressLine1: 'TRELLEBORG MARINE SYSTEMS LTD',
-    addressLine2: 'AIRFIELD VIEW, MANOR LANE, HAWARDEN INDUSTRIAL PARK, PENARLAG',
-    townOrCity: 'GLANNAU DYFRDWY',
-    county: 'FLINTSHIRE',
+    addressLine1: 'Trelleborg Marine Systems Ltd',
+    addressLine2: 'Airfield View, Manor Lane, Hawarden Industrial Park, Penarlag',
+    townOrCity: 'Glannau Dyfrdwy',
+    county: 'Flintshire',
     postcode: 'CH5 3QW'
   }
 
@@ -62,10 +62,10 @@ test('transformAddress() builds address C', (t) => {
   }
 
   const expected = {
-    addressLine1: '101 ELECTRICITY HOUSE',
-    addressLine2: 'COLSTON AVENUE',
-    townOrCity: 'BRISTOL',
-    county: 'BRISTOL CITY',
+    addressLine1: '101 Electricity House',
+    addressLine2: 'Colston Avenue',
+    townOrCity: 'Bristol',
+    county: 'Bristol City',
     postcode: 'BS1 4TB'
   }
 
@@ -86,10 +86,10 @@ test('transformAddress() builds address D', (t) => {
   }
 
   const expected = {
-    addressLine1: '68 PARK ROAD',
-    addressLine2: 'STAPLETON',
-    townOrCity: 'BRISTOL',
-    county: 'BRISTOL CITY',
+    addressLine1: '68 Park Road',
+    addressLine2: 'Stapleton',
+    townOrCity: 'Bristol',
+    county: 'Bristol City',
     postcode: 'BS16 1AU'
   }
 
@@ -111,10 +111,10 @@ test('transformAddress() builds address E', (t) => {
   }
 
   const expected = {
-    addressLine1: '10, CONCERT SQUARE APARTMENTS',
-    addressLine2: '29 FLEET STREET',
-    townOrCity: 'LIVERPOOL',
-    county: 'LIVERPOOL',
+    addressLine1: '10, Concert Square Apartments',
+    addressLine2: '29 Fleet Street',
+    townOrCity: 'Liverpool',
+    county: 'Liverpool',
     postcode: 'L1 4AR'
   }
 
@@ -135,10 +135,10 @@ test('transformAddress() builds address F', (t) => {
   }
 
   const expected = {
-    addressLine1: 'GARDEN FLAT',
-    addressLine2: '51 LANSDOWN',
-    townOrCity: 'STROUD',
-    county: 'STROUD',
+    addressLine1: 'Garden Flat',
+    addressLine2: '51 Lansdown',
+    townOrCity: 'Stroud',
+    county: 'Stroud',
     postcode: 'GL5 1BN'
   }
 
@@ -158,10 +158,10 @@ test('transformAddress() builds address G', (t) => {
   }
 
   const expected = {
-    addressLine1: 'THE RETREAT',
-    addressLine2: 'BLACKERSTONE',
-    townOrCity: 'DUNS',
-    county: 'SCOTTISH BORDERS',
+    addressLine1: 'The Retreat',
+    addressLine2: 'Blackerstone',
+    townOrCity: 'Duns',
+    county: 'Scottish Borders',
     postcode: 'TD11 3RY'
   }
 
@@ -180,10 +180,10 @@ test('transformAddress() builds address H', (t) => {
   }
 
   const expected = {
-    addressLine1: 'BLACKERSTONE SHEPHERDS HOUSE',
+    addressLine1: 'Blackerstone Shepherds House',
     addressLine2: '',
-    townOrCity: 'DUNS',
-    county: 'SCOTTISH BORDERS',
+    townOrCity: 'Duns',
+    county: 'Scottish Borders',
     postcode: 'TD11 3RY'
   }
 
@@ -202,10 +202,10 @@ test('transformAddress() builds address I', (t) => {
   }
 
   const expected = {
-    addressLine1: '10A MAYFIELD AVENUE',
+    addressLine1: '10a Mayfield Avenue',
     addressLine2: '',
-    townOrCity: 'WESTON-SUPER-MARE',
-    county: 'NORTH SOMERSET',
+    townOrCity: 'Weston-Super-Mare',
+    county: 'North Somerset',
     postcode: 'BS22 6AA'
   }
 

--- a/src/web/routes/application/address/select-address/adapters.js
+++ b/src/web/routes/application/address/select-address/adapters.js
@@ -1,5 +1,6 @@
 const { props, propOr, pickAll, compose, map, join, filter, not, isEmpty, split, head, tail, defaultTo } = require('ramda')
 const { OS_PLACES_ADDRESS_KEYS } = require('../constants')
+const { toTitleCase } = require('../formats')
 
 /**
  * Map address returned from OS places API to format required by claimant service
@@ -67,10 +68,10 @@ const transformAddress = addressFields => {
   const addressLineOneAndTwo = buildAddressLineOneAndTwo(addressFields)
 
   return {
-    addressLine1: addressLineOneAndTwo[0],
-    addressLine2: addressLineOneAndTwo[1],
-    townOrCity: addressFields.POST_TOWN,
-    county: addressFields.LOCAL_CUSTODIAN_CODE_DESCRIPTION,
+    addressLine1: toTitleCase(addressLineOneAndTwo[0]),
+    addressLine2: toTitleCase(addressLineOneAndTwo[1]),
+    townOrCity: toTitleCase(addressFields.POST_TOWN),
+    county: toTitleCase(addressFields.LOCAL_CUSTODIAN_CODE_DESCRIPTION),
     postcode: addressFields.POSTCODE
   }
 }

--- a/src/web/routes/application/address/select-address/adapters.js
+++ b/src/web/routes/application/address/select-address/adapters.js
@@ -14,6 +14,8 @@ const { toTitleCase } = require('../formats')
  *    d) Locality
  * 3. Split a single part address into two parts if a comma exists in the first part
  * 4. Convert a multipart address into two parts by joining all parts except the first with a comma
+ * 5. Build the full address
+ * 5. Convert address to title case
  */
 
 const DELIMITER = ', '

--- a/src/web/routes/application/address/select-address/select-address.test.js
+++ b/src/web/routes/application/address/select-address/select-address.test.js
@@ -122,10 +122,10 @@ test('behaviourForPost() adds transformed address to claim', (t) => {
 
   const expectedClaim = {
     nino: 'QQ123456C',
-    addressLine1: 'ALAN JEFFERY ENGINEERING',
-    addressLine2: '1 UPPER VALLEY ROAD, VALLEY ROAD',
-    townOrCity: 'PLYMOUTH',
-    county: 'CITY OF PLYMOUTH',
+    addressLine1: 'Alan Jeffery Engineering',
+    addressLine2: '1 Upper Valley Road, Valley Road',
+    townOrCity: 'Plymouth',
+    county: 'City Of Plymouth',
     postcode: 'PL7 1RF'
   }
 


### PR DESCRIPTION
Minimise the number of address transforms performed during postcode lookup by:

- Only transforming the single line address field of each result from OS Places API response to title case (instead of all address fields)
- Only converting the full address of the selected address to title case (instead of all addresses)