### PR TITLE
No-JIRA use library email validation

### DIFF
--- a/src/web/routes/application/common/test/apply-express-validation.js
+++ b/src/web/routes/application/common/test/apply-express-validation.js
@@ -26,6 +26,9 @@ const applyExpressValidation = async (req, middleware) => {
     locals: {}
   }
 
+  // Ensure translation function is applied to request object
+  req.t = str => str
+
   try {
     await callMiddlewareQueue(req, res, middleware)
     return validationResult(req)

--- a/src/web/routes/application/email-address/validate.js
+++ b/src/web/routes/application/email-address/validate.js
@@ -1,21 +1,15 @@
 const { check } = require('express-validator')
 const { translateValidationMessage } = require('../common/translate-validation-message')
 
-// See https://stackoverflow.com/questions/201323/how-to-validate-an-email-address-using-a-regular-expression for regex explanation
-const EMAIL_ADDRESS_REGEX = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
 const MAX_EMAIL_ADDRESS_LENGTH = 256
 
 const validate = () => [
   check('emailAddress')
-    .matches(EMAIL_ADDRESS_REGEX)
-    .withMessage(translateValidationMessage('validation:invalidEmail')),
-
-  check('emailAddress')
-    .isLength({ max: MAX_EMAIL_ADDRESS_LENGTH })
+    .isEmail()
     .withMessage(translateValidationMessage('validation:invalidEmail'))
 ]
 
 module.exports = {
   validate,
-  EMAIL_ADDRESS_REGEX
+  MAX_EMAIL_ADDRESS_LENGTH
 }

--- a/src/web/routes/application/email-address/validate.js
+++ b/src/web/routes/application/email-address/validate.js
@@ -1,8 +1,6 @@
 const { check } = require('express-validator')
 const { translateValidationMessage } = require('../common/translate-validation-message')
 
-const MAX_EMAIL_ADDRESS_LENGTH = 256
-
 const validate = () => [
   check('emailAddress')
     .isEmail()
@@ -10,6 +8,5 @@ const validate = () => [
 ]
 
 module.exports = {
-  validate,
-  MAX_EMAIL_ADDRESS_LENGTH
+  validate
 }

--- a/src/web/routes/application/email-address/validate.test.js
+++ b/src/web/routes/application/email-address/validate.test.js
@@ -1,7 +1,9 @@
 const test = require('tape')
 const Promise = require('bluebird')
 const { applyExpressValidation } = require('../common/test/apply-express-validation')
-const { validate, MAX_EMAIL_ADDRESS_LENGTH } = require('./validate')
+const { validate } = require('./validate')
+
+const MAX_EMAIL_ADDRESS_LENGTH = 256
 
 test('validation fails for long email addresses', async (t) => {
   const domain = '@domain.com'

--- a/src/web/routes/application/email-address/validate.test.js
+++ b/src/web/routes/application/email-address/validate.test.js
@@ -1,8 +1,36 @@
 const test = require('tape')
+const Promise = require('bluebird')
+const { applyExpressValidation } = require('../common/test/apply-express-validation')
+const { validate, MAX_EMAIL_ADDRESS_LENGTH } = require('./validate')
 
-const { EMAIL_ADDRESS_REGEX } = require('./validate')
+test('validation fails for long email addresses', async (t) => {
+  const domain = '@domain.com'
+  const emailAddressWithLongPrefix = `${'a'.repeat(MAX_EMAIL_ADDRESS_LENGTH - domain.length)}${domain}`
 
-test('valid email', (t) => {
+  const prefix = 'name'
+  const suffix = '.com'
+  const EmailAddressWithLongDomain = `${prefix}@${'a'.repeat(MAX_EMAIL_ADDRESS_LENGTH - (prefix.length + suffix.length))}.com`
+
+  const emailAddresses = [emailAddressWithLongPrefix, EmailAddressWithLongDomain]
+
+  Promise.each(emailAddresses, async emailAddress => {
+    const req = {
+      body: {
+        emailAddress
+      }
+    }
+
+    const result = await applyExpressValidation(req, validate())
+    const error = result.array()[0]
+    t.equal(result.array().length, 1, 'contains exactly one error')
+    t.equal(error.param, 'emailAddress', 'error is associated with correct field')
+    t.equal(error.msg, 'validation:invalidEmail', 'error has correct message')
+  })
+
+  t.end()
+})
+
+test('validation middleware passes with valid email address', async (t) => {
   const emailAddresses = [
     'email@domain.com',
     'firstname.lastname@domain.com',
@@ -14,17 +42,24 @@ test('valid email', (t) => {
     'email@domain.name',
     'email@domain.co.jp',
     'firstname-lastname@domain.com',
-    'Pälé@example.com']
+    'Pälé@example.com'
+  ]
 
-  emailAddresses.forEach(emailAddress => {
-    const matches = EMAIL_ADDRESS_REGEX.test(emailAddress)
-    t.equal(matches, true)
+  Promise.each(emailAddresses, async emailAddress => {
+    const req = {
+      body: {
+        emailAddress
+      }
+    }
+
+    const result = await applyExpressValidation(req, validate())
+    t.equal(result.isEmpty(), true)
   })
 
   t.end()
 })
 
-test('invalid email', (t) => {
+test('validation middleware fails with invalid email address', async (t) => {
   const emailAddresses = [
     '',
     'plainaddress',
@@ -41,10 +76,18 @@ test('invalid email', (t) => {
     'email@domain..com'
   ]
 
-  emailAddresses.forEach(emailAddress => {
-    console.log(emailAddress)
-    const matches = EMAIL_ADDRESS_REGEX.test(emailAddress)
-    t.equal(matches, false)
+  Promise.each(emailAddresses, async emailAddress => {
+    const req = {
+      body: {
+        emailAddress
+      }
+    }
+
+    const result = await applyExpressValidation(req, validate())
+    const error = result.array()[0]
+    t.equal(result.array().length, 1, 'contains exactly one error')
+    t.equal(error.param, 'emailAddress', 'error is associated with correct field')
+    t.equal(error.msg, 'validation:invalidEmail', 'error has correct message')
   })
 
   t.end()


### PR DESCRIPTION
The express validation library we implement wraps validator JS which implements an email validation check. It seems better to use an actively maintained validator rather than trying to maintain our own regex (unoptimised regex can have significant performance implications for node).

- Replace custom regex email validation with validator from validation library
- Remove explicit max length validation as email validation implicitly checks for length
- Add unit tests for validation middleware
- Add translation function to express validation test helper function