### PR TITLE
Feature/fix error ids

### DIFF
--- a/src/test/common/page/are-you-pregnant.js
+++ b/src/test/common/page/are-you-pregnant.js
@@ -12,7 +12,7 @@ const PAGE_TITLES = {
 }
 
 const ARE_YOU_PREGNANT_ERROR_LINK_CSS = 'a[href="#are-you-pregnant-error"]'
-const ARE_YOU_PREGNANT_FIELD_ERROR_ID = 'areYouPregnant-error'
+const ARE_YOU_PREGNANT_FIELD_ERROR_ID = 'are-you-pregnant-error'
 const EXPECTED_DELIVERY_DATE_ERROR_LINK_CSS = 'a[href="#expected-delivery-date-error"]'
 const EXPECTED_DELIVERY_DATE_FIELD_ERROR_ID = 'expected-delivery-date-error'
 

--- a/src/test/common/page/do-you-have-children.js
+++ b/src/test/common/page/do-you-have-children.js
@@ -3,7 +3,7 @@
 const SubmittablePageWithRadioButtons = require('./submittable-page-with-radio-buttons')
 
 const DO_YOU_HAVE_CHILDREN_ERROR_LINK_CSS = 'a[href="#do-you-have-children-error"]'
-const DO_YOU_HAVE_CHILDREN_FIELD_ERROR_ID = 'doYouHaveChildren-error'
+const DO_YOU_HAVE_CHILDREN_FIELD_ERROR_ID = 'do-you-have-children-error'
 
 const PAGE_TITLES = {
   en: 'GOV.UK - Do you have any children under 4 years old?',

--- a/src/test/common/page/send-code.js
+++ b/src/test/common/page/send-code.js
@@ -4,7 +4,7 @@ const SubmittablePageWithRadioButtons = require('./submittable-page-with-radio-b
 const { TEXT, EMAIL } = require('../steps/constants')
 
 const SEND_CODE_ERROR_LINK_CSS = 'a[href="#channel-for-code-error"]'
-const SEND_CODE_FIELD_ERROR_ID = 'channelForCode-error'
+const SEND_CODE_FIELD_ERROR_ID = 'channel-for-code-error'
 
 const PAGE_TITLES = {
   en: 'GOV.UK - We’re sending you a code',

--- a/src/web/views/are-you-pregnant.njk
+++ b/src/web/views/are-you-pregnant.njk
@@ -20,6 +20,7 @@
 {% block formContent %}
     {{ govukRadios({
       id: "are-you-pregnant",
+      idPrefix: "are-you-pregnant",
       name: "areYouPregnant",
       fieldset: {
         legend: {

--- a/src/web/views/do-you-have-children.njk
+++ b/src/web/views/do-you-have-children.njk
@@ -8,6 +8,7 @@
   {{ govukRadios({
       classes: "govuk-radios--inline",
       id: "do-you-have-children",
+      idPrefix: "do-you-have-children",
       name: "doYouHaveChildren",
       hint: {
         html: htbhfFormDescription(formDescription)

--- a/src/web/views/scotland.njk
+++ b/src/web/views/scotland.njk
@@ -5,6 +5,7 @@
     {{ govukRadios({
       classes: "govuk-radios--inline",
       id: "scotland",
+      idPrefix: "scotland",
       name: "scotland",
       fieldset: {
         legend: {

--- a/src/web/views/send-code.njk
+++ b/src/web/views/send-code.njk
@@ -5,6 +5,7 @@
 {% block formContent %}
     {{ govukRadios({
         id: "channel-for-code",
+        idPrefix: "channel-for-code",
         name: "channelForCode",
         fieldset: {
             legend: {

--- a/test_versions.properties
+++ b/test_versions.properties
@@ -1,3 +1,3 @@
 # This file is `source`d by the cd pipeline when running tests
 PERF_TESTS_VERSION=1.0.65
-ACCEPTANCE_TESTS_VERSION=0.0.41
+ACCEPTANCE_TESTS_VERSION=0.0.42


### PR DESCRIPTION
Fix bug where links in error summary did not match ID of field errors, meaning clicking on error anchor did not navigate to correct point on the page.