### PR TITLE
Decouple guidance pages from journey middleware

### DIFF
--- a/src/web/routes/guidance/guidance.test.js
+++ b/src/web/routes/guidance/guidance.test.js
@@ -1,0 +1,54 @@
+const test = require('tape')
+const sinon = require('sinon')
+const { states } = require('../application/common/state-machine')
+const { handleSession } = require('./guidance')
+
+test(`handleSession() destroys session if journey state is ${states.COMPLETED}`, (t) => {
+  const destroy = sinon.spy()
+  const clearCookie = sinon.spy()
+  const next = sinon.spy()
+
+  const req = {
+    path: '/second',
+    session: {
+      destroy,
+      state: states.COMPLETED
+    }
+  }
+
+  const res = {
+    clearCookie
+  }
+
+  handleSession(req, res, next)
+
+  t.equal(destroy.called, true, 'it should destroy the session')
+  t.equal(clearCookie.calledWith('lang'), true, 'it should clear language preference cookie')
+  t.equal(next.called, true, 'it should call next()')
+  t.end()
+})
+
+test(`handleSession() does not destroy session if journey state is not ${states.COMPLETED}`, (t) => {
+  const destroy = sinon.spy()
+  const clearCookie = sinon.spy()
+  const next = sinon.spy()
+
+  const req = {
+    path: '/second',
+    session: {
+      destroy,
+      state: states.IN_PROGRESS
+    }
+  }
+
+  const res = {
+    clearCookie
+  }
+
+  handleSession(req, res, next)
+
+  t.equal(destroy.called, false, 'it should not destroy the session')
+  t.equal(clearCookie.called, false, 'it should not clear language preference cookie')
+  t.equal(next.called, true, 'it should call next()')
+  t.end()
+})

--- a/src/web/routes/register-routes.js
+++ b/src/web/routes/register-routes.js
@@ -39,7 +39,7 @@ const registerRoutes = (config, app) => {
     registerConfirmRoute(config, registeredSteps, app)
     registerCookiesRoute(app)
     registerPrivacyNoticeRoute(app)
-    registerGuidanceRoutes(config, registeredSteps, app)
+    registerGuidanceRoutes(app)
 
     // Page not found route should always be registered last as it is a catch all route
     registerPageNotFoundRoute(app)

--- a/test_versions.properties
+++ b/test_versions.properties
@@ -1,3 +1,3 @@
 # This file is `source`d by the cd pipeline when running tests
 PERF_TESTS_VERSION=1.0.66
-ACCEPTANCE_TESTS_VERSION=0.0.60
+ACCEPTANCE_TESTS_VERSION=0.0.61


### PR DESCRIPTION
Enabler for implementing multiple user journeys. Removes the handle path request middleware from guidance routes and therefore the requirement for `steps` when registering guidance routes.