### PR TITLE
Call state machine to set next allowed path

### DIFF
--- a/src/web/routes/application/address/select-address/select-address.js
+++ b/src/web/routes/application/address/select-address/select-address.js
@@ -2,6 +2,9 @@ const { path } = require('ramda')
 const { transformAddress } = require('./adapters')
 const { addressContentSummary } = require('../content-summary')
 const { requestBody } = require('../request-body')
+const { stateMachine, actions } = require('../../common/state-machine')
+
+const { SET_NEXT_ALLOWED_PATH } = actions
 
 const pageContent = ({ translate }) => ({
   title: translate('address.title'),
@@ -36,7 +39,7 @@ const behaviourForGet = () => (req, res, next) => {
     res.locals.addresses = req.session.postcodeLookupResults.map(buildAddressOption)
   }
   // Manual address is further in the flow than select-address, therefore this line is needed to prevent the state machine from redirecting the user back to select-address.
-  req.session.nextAllowedStep = '/manual-address'
+  stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, '/manual-address')
   next()
 }
 

--- a/src/web/routes/application/check-answers/get.js
+++ b/src/web/routes/application/check-answers/get.js
@@ -3,7 +3,8 @@ const { getPreviousPath } = require('../common/get-previous-path')
 const { getSummaryListsForSteps } = require('./get-row-data')
 const { getChildrensDatesOfBirthRows } = require('./get-childrens-dates-of-birth-rows')
 
-const { GET_NEXT_PATH, SET_NEXT_ALLOWED_PATH } = actions
+const { INCREMENT_NEXT_ALLOWED_PATH } = actions
+const { IN_REVIEW } = states
 
 const pageContent = ({ translate }) => ({
   title: translate('checkAnswers.title'),
@@ -37,9 +38,8 @@ const getCheckAnswers = (steps) => (req, res) => {
   const localisation = pageContent({ translate: req.t })
   const getLocalisedChildrensDatesOfBirthRows = getChildrensDatesOfBirthRows(localisation)
 
-  stateMachine.setState(states.IN_REVIEW, req)
-  const nextAllowedPath = stateMachine.dispatch(GET_NEXT_PATH, req, steps)
-  stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, nextAllowedPath)
+  stateMachine.setState(IN_REVIEW, req)
+  stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, steps)
 
   res.render('check-answers', {
     ...localisation,

--- a/src/web/routes/application/check-answers/get.js
+++ b/src/web/routes/application/check-answers/get.js
@@ -3,6 +3,8 @@ const { getPreviousPath } = require('../common/get-previous-path')
 const { getSummaryListsForSteps } = require('./get-row-data')
 const { getChildrensDatesOfBirthRows } = require('./get-childrens-dates-of-birth-rows')
 
+const { GET_NEXT_PATH, SET_NEXT_ALLOWED_PATH } = actions
+
 const pageContent = ({ translate }) => ({
   title: translate('checkAnswers.title'),
   heading: translate('checkAnswers.heading'),
@@ -36,7 +38,8 @@ const getCheckAnswers = (steps) => (req, res) => {
   const getLocalisedChildrensDatesOfBirthRows = getChildrensDatesOfBirthRows(localisation)
 
   stateMachine.setState(states.IN_REVIEW, req)
-  req.session.nextAllowedStep = stateMachine.dispatch(actions.GET_NEXT_PATH, req, steps)
+  const nextAllowedPath = stateMachine.dispatch(GET_NEXT_PATH, req, steps)
+  stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, nextAllowedPath)
 
   res.render('check-answers', {
     ...localisation,

--- a/src/web/routes/application/common/state-machine/state-machine.test.js
+++ b/src/web/routes/application/common/state-machine/state-machine.test.js
@@ -10,7 +10,7 @@ const { stateMachine, states, actions, isPathAllowed } = proxyquire('./state-mac
   '../../../../logger': { logger }
 })
 
-const { GET_NEXT_PATH, INVALIDATE_REVIEW } = actions
+const { GET_NEXT_PATH, INVALIDATE_REVIEW, SET_NEXT_ALLOWED_PATH } = actions
 
 const steps = [
   { path: '/first', next: () => '/second' },
@@ -131,5 +131,28 @@ test('setState sets the state if the new state is different from the current sta
 
   t.equal(req.session.state, states.COMPLETED, 'Should set state')
   t.equal(info.called, true, 'Should log a change in state')
+  t.end()
+})
+
+test(`Dispatching ${SET_NEXT_ALLOWED_PATH} sets next allowed path in session`, (t) => {
+  const appStates = [
+    { state: states.IN_PROGRESS, path: '/name' },
+    { state: states.IN_REVIEW, path: '/check' },
+    { state: states.COMPLETED, path: '/success' }
+  ]
+
+  appStates.forEach(appState => {
+    const { state, path } = appState
+
+    const req = {
+      session: {
+        state
+      }
+    }
+
+    stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, path)
+    t.equal(req.session.nextAllowedStep, path, `sets next allowed path in session for ${state}`)
+  })
+
   t.end()
 })

--- a/src/web/routes/application/common/state-machine/state-machine.test.js
+++ b/src/web/routes/application/common/state-machine/state-machine.test.js
@@ -10,7 +10,7 @@ const { stateMachine, states, actions, isPathAllowed } = proxyquire('./state-mac
   '../../../../logger': { logger }
 })
 
-const { GET_NEXT_PATH, INVALIDATE_REVIEW, SET_NEXT_ALLOWED_PATH } = actions
+const { GET_NEXT_PATH, INVALIDATE_REVIEW, SET_NEXT_ALLOWED_PATH, INCREMENT_NEXT_ALLOWED_PATH } = actions
 
 const steps = [
   { path: '/first', next: () => '/second' },
@@ -152,6 +152,30 @@ test(`Dispatching ${SET_NEXT_ALLOWED_PATH} sets next allowed path in session`, (
 
     stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, path)
     t.equal(req.session.nextAllowedStep, path, `sets next allowed path in session for ${state}`)
+  })
+
+  t.end()
+})
+
+test(`Dispatching ${INCREMENT_NEXT_ALLOWED_PATH} updates next allowed step in session with the next allowed path in sequence`, (t) => {
+  const appStates = [
+    { state: states.IN_PROGRESS, path: '/first', expectedNextPath: '/second' },
+    { state: states.IN_REVIEW, path: CHECK_ANSWERS_URL, expectedNextPath: TERMS_AND_CONDITIONS_URL },
+    { state: states.COMPLETED, path: CONFIRM_URL, expectedNextPath: CONFIRM_URL }
+  ]
+
+  appStates.forEach(appState => {
+    const { state, path, expectedNextPath } = appState
+
+    const req = {
+      path,
+      session: {
+        state
+      }
+    }
+
+    stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, steps)
+    t.equal(req.session.nextAllowedStep, expectedNextPath, `increments next allowed path in session for ${state}`)
   })
 
   t.end()

--- a/src/web/routes/application/middleware/handle-post.js
+++ b/src/web/routes/application/middleware/handle-post.js
@@ -3,7 +3,7 @@ const { validationResult } = require('express-validator')
 const { wrapError } = require('../common/formatters')
 const { stateMachine, actions } = require('../common/state-machine')
 
-const { GET_NEXT_PATH, INVALIDATE_REVIEW, SET_NEXT_ALLOWED_PATH } = actions
+const { INVALIDATE_REVIEW, INCREMENT_NEXT_ALLOWED_PATH } = actions
 
 const stepInvalidatesReview = (step, claim) => typeof step.shouldInvalidateReview === 'function' && step.shouldInvalidateReview(claim)
 
@@ -26,8 +26,7 @@ const handlePost = (steps, step) => (req, res, next) => {
       stateMachine.dispatch(INVALIDATE_REVIEW, req)
     }
 
-    const nextAllowedPath = stateMachine.dispatch(GET_NEXT_PATH, req, steps)
-    stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, nextAllowedPath)
+    stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, steps)
 
     return next()
   } catch (error) {

--- a/src/web/routes/application/middleware/handle-post.js
+++ b/src/web/routes/application/middleware/handle-post.js
@@ -3,7 +3,7 @@ const { validationResult } = require('express-validator')
 const { wrapError } = require('../common/formatters')
 const { stateMachine, actions } = require('../common/state-machine')
 
-const { GET_NEXT_PATH, INVALIDATE_REVIEW } = actions
+const { GET_NEXT_PATH, INVALIDATE_REVIEW, SET_NEXT_ALLOWED_PATH } = actions
 
 const stepInvalidatesReview = (step, claim) => typeof step.shouldInvalidateReview === 'function' && step.shouldInvalidateReview(claim)
 
@@ -26,7 +26,8 @@ const handlePost = (steps, step) => (req, res, next) => {
       stateMachine.dispatch(INVALIDATE_REVIEW, req)
     }
 
-    req.session.nextAllowedStep = stateMachine.dispatch(GET_NEXT_PATH, req, steps)
+    const nextAllowedPath = stateMachine.dispatch(GET_NEXT_PATH, req, steps)
+    stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, nextAllowedPath)
 
     return next()
   } catch (error) {

--- a/src/web/routes/application/terms-and-conditions/post.js
+++ b/src/web/routes/application/terms-and-conditions/post.js
@@ -12,6 +12,9 @@ const { isErrorStatusCode } = require('./predicates')
 const { CLAIMS_ENDPOINT, NO_ELIGIBILITY_STATUS_MESSAGE } = require('./constants')
 const { render } = require('./get')
 
+const { COMPLETED } = states
+const { GET_NEXT_PATH, SET_NEXT_ALLOWED_PATH } = actions
+
 const handleErrorResponse = (body, response) => {
   if (isErrorStatusCode(response.statusCode)) {
     throw new Error(JSON.stringify(body))
@@ -59,8 +62,9 @@ const postTermsAndConditions = (steps, config) => (req, res, next) => {
         req.session.voucherEntitlement = voucherEntitlement
         req.session.claimUpdated = claimUpdated
 
-        stateMachine.setState(states.COMPLETED, req)
-        req.session.nextAllowedStep = stateMachine.dispatch(actions.GET_NEXT_PATH, req, steps, req.path)
+        stateMachine.setState(COMPLETED, req)
+        const nextAllowedPath = stateMachine.dispatch(GET_NEXT_PATH, req, steps, req.path)
+        stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, nextAllowedPath)
         return res.redirect('confirm')
       },
       (error) => {

--- a/src/web/routes/application/terms-and-conditions/post.js
+++ b/src/web/routes/application/terms-and-conditions/post.js
@@ -13,7 +13,7 @@ const { CLAIMS_ENDPOINT, NO_ELIGIBILITY_STATUS_MESSAGE } = require('./constants'
 const { render } = require('./get')
 
 const { COMPLETED } = states
-const { GET_NEXT_PATH, SET_NEXT_ALLOWED_PATH } = actions
+const { INCREMENT_NEXT_ALLOWED_PATH } = actions
 
 const handleErrorResponse = (body, response) => {
   if (isErrorStatusCode(response.statusCode)) {
@@ -63,8 +63,7 @@ const postTermsAndConditions = (steps, config) => (req, res, next) => {
         req.session.claimUpdated = claimUpdated
 
         stateMachine.setState(COMPLETED, req)
-        const nextAllowedPath = stateMachine.dispatch(GET_NEXT_PATH, req, steps, req.path)
-        stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, nextAllowedPath)
+        stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, steps)
         return res.redirect('confirm')
       },
       (error) => {


### PR DESCRIPTION
EPIC: UI support multiple journeys

Route all middleware operations that set the next allowed path in session through the state machine (instead of mutating the session directly). Future PRs will update the state machine to query the user journey when setting this state.

- Create state machine `SET_NEXT_ALLOWED_PATH` action 
- Update middleware session mutations to call state machine