### PR TITLE
HTBHF-2503 register all application routes with steps

### DIFF
--- a/src/web/routes/application/index.js
+++ b/src/web/routes/application/index.js
@@ -1,13 +1,7 @@
-const { registerConfirmRoute } = require('./confirm')
-const { registerCheckAnswersRoutes } = require('./check-answers')
-const { registerTermsAndConditionsRoutes } = require('./terms-and-conditions')
 const { registerFormRoutes } = require('./register-form-routes')
 const { steps } = require('./steps')
 
 module.exports = {
-  registerConfirmRoute,
-  registerCheckAnswersRoutes,
-  registerTermsAndConditionsRoutes,
   registerFormRoutes,
   steps
 }

--- a/src/web/routes/application/register-form-routes.js
+++ b/src/web/routes/application/register-form-routes.js
@@ -1,4 +1,7 @@
 const express = require('express')
+const { registerConfirmRoute } = require('./confirm')
+const { registerCheckAnswersRoutes } = require('./check-answers')
+const { registerTermsAndConditionsRoutes } = require('./terms-and-conditions')
 
 const {
   configureGet,
@@ -49,6 +52,10 @@ const registerFormRoutes = (config, csrfProtection, steps, app) => {
   const wizard = express.Router()
   steps.forEach(createRoute(config, csrfProtection, steps, wizard))
   app.use(wizard)
+
+  registerCheckAnswersRoutes(steps, config, app)
+  registerTermsAndConditionsRoutes(csrfProtection, steps, config, app)
+  registerConfirmRoute(config, steps, app)
 }
 
 module.exports = {

--- a/src/web/routes/register-routes.js
+++ b/src/web/routes/register-routes.js
@@ -6,14 +6,7 @@ const { registerHoldingRoute } = require('./holding')
 const { registerPageNotFoundRoute } = require('./page-not-found')
 const { registerGuidanceRoutes } = require('./guidance')
 const { registerSteps } = require('./register-steps')
-
-const {
-  registerConfirmRoute,
-  registerCheckAnswersRoutes,
-  registerTermsAndConditionsRoutes,
-  registerFormRoutes,
-  steps
-} = require('./application')
+const { registerFormRoutes, steps } = require('./application')
 
 const setCommonTemplateValues = (req, res, next) => {
   res.locals.htmlLang = req.language
@@ -34,9 +27,6 @@ const registerRoutes = (config, app) => {
     const csrfProtection = csrf()
 
     registerFormRoutes(config, csrfProtection, registeredSteps, app)
-    registerCheckAnswersRoutes(registeredSteps, config, app)
-    registerTermsAndConditionsRoutes(csrfProtection, registeredSteps, config, app)
-    registerConfirmRoute(config, registeredSteps, app)
     registerCookiesRoute(app)
     registerPrivacyNoticeRoute(app)
     registerGuidanceRoutes(app)


### PR DESCRIPTION
Move registering of `/check-answers`, `/terms-and-conditions` and `/confirm` routes so they are registered alongside the other apply journey routes. This will enable registering of these route handlers for any new journeys.