### PR TITLE
HTBHF-2523 consume journey in route handlers

### DIFF
--- a/src/web/routes/application/check-answers/check-answers.js
+++ b/src/web/routes/application/check-answers/check-answers.js
@@ -2,10 +2,10 @@ const { getCheckAnswers } = require('./get')
 const { CHECK_ANSWERS_URL } = require('../common/constants')
 const { handleRequestForPath } = require('../middleware')
 
-const registerCheckAnswersRoutes = (steps, config, app) => {
+const registerCheckAnswersRoutes = (journey, config, app) => {
   app
     .route(CHECK_ANSWERS_URL)
-    .get(handleRequestForPath(config, steps), getCheckAnswers(steps))
+    .get(handleRequestForPath(config, journey), getCheckAnswers(journey.steps))
 }
 
 module.exports = {

--- a/src/web/routes/application/check-answers/check-answers.js
+++ b/src/web/routes/application/check-answers/check-answers.js
@@ -5,7 +5,7 @@ const { handleRequestForPath } = require('../middleware')
 const registerCheckAnswersRoutes = (journey, config, app) => {
   app
     .route(CHECK_ANSWERS_URL)
-    .get(handleRequestForPath(config, journey), getCheckAnswers(journey.steps))
+    .get(handleRequestForPath(config, journey), getCheckAnswers(journey))
 }
 
 module.exports = {

--- a/src/web/routes/application/check-answers/get.js
+++ b/src/web/routes/application/check-answers/get.js
@@ -33,10 +33,11 @@ const getLastNavigablePath = (steps, req) => {
     : getPreviousPath(steps, lastStep, req.session)
 }
 
-const getCheckAnswers = (steps) => (req, res) => {
+const getCheckAnswers = (journey) => (req, res) => {
   const { children } = req.session
   const localisation = pageContent({ translate: req.t })
   const getLocalisedChildrensDatesOfBirthRows = getChildrensDatesOfBirthRows(localisation)
+  const { steps } = journey
 
   stateMachine.setState(IN_REVIEW, req)
   stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, steps)

--- a/src/web/routes/application/confirm/confirm.js
+++ b/src/web/routes/application/confirm/confirm.js
@@ -48,8 +48,8 @@ const getConfirmPage = (req, res, next) => {
   })
 }
 
-const registerConfirmRoute = (config, steps, app) => {
-  app.get(CONFIRM_URL, handleRequestForPath(config, steps), getConfirmPage)
+const registerConfirmRoute = (config, journey, app) => {
+  app.get(CONFIRM_URL, handleRequestForPath(config, journey), getConfirmPage)
 }
 
 module.exports = {

--- a/src/web/routes/application/middleware/handle-path-request/handle-path-request.js
+++ b/src/web/routes/application/middleware/handle-path-request/handle-path-request.js
@@ -43,7 +43,7 @@ const middleware = (config, pathsInSequence, step) => (req, res, next) => {
   next()
 }
 
-const handleRequestForPath = (config, steps, step) => middleware(config, getPathsInSequence(steps), step)
+const handleRequestForPath = (config, journey, step) => middleware(config, getPathsInSequence(journey.steps), step)
 
 module.exports = {
   handleRequestForPath

--- a/src/web/routes/application/middleware/handle-path-request/handle-path-request.test.js
+++ b/src/web/routes/application/middleware/handle-path-request/handle-path-request.test.js
@@ -4,7 +4,9 @@ const { CONFIRM_URL } = require('../../common/constants')
 const { handleRequestForPath } = require('./handle-path-request')
 const { states } = require('../../common/state-machine')
 
-const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
+const journey = {
+  steps: [{ path: '/first', next: () => '/second' }, { path: '/second' }]
+}
 
 const config = {
   environment: {
@@ -20,7 +22,7 @@ test('handleRequestForPath() should set next allowed path to first in sequence i
   const res = {}
   const next = sinon.spy()
 
-  handleRequestForPath(config, steps)(req, res, next)
+  handleRequestForPath(config, journey)(req, res, next)
 
   t.equal(req.session.nextAllowedStep, '/first', 'it should set next allowed path to first in sequence')
   t.equal(next.called, true, 'it should call next()')
@@ -39,7 +41,7 @@ test('handleRequestForPath() should redirect to next allowed step if requested p
   const res = { redirect }
   const next = sinon.spy()
 
-  handleRequestForPath(config, steps)(req, res, next)
+  handleRequestForPath(config, journey)(req, res, next)
 
   t.equal(redirect.calledWith('/first'), true, 'it should call redirect() with next allowed step')
   t.equal(next.called, false, 'it should not call next()')
@@ -58,7 +60,7 @@ test('handleRequestForPath() should call next() if requested path is allowed', (
   const res = { redirect }
   const next = sinon.spy()
 
-  handleRequestForPath(config, steps)(req, res, next)
+  handleRequestForPath(config, journey)(req, res, next)
 
   t.equal(redirect.called, false, 'it should not call redirect()')
   t.equal(next.called, true, 'it should call next()')
@@ -84,7 +86,7 @@ test(`handleRequestForPath() should destroy the session and redirect to root whe
     redirect
   }
 
-  handleRequestForPath(config, steps)(req, res, next)
+  handleRequestForPath(config, journey)(req, res, next)
 
   t.equal(destroy.called, true, 'it should destroy the session')
   t.equal(clearCookie.calledWith('lang'), true, 'it should clear language preference cookie')
@@ -111,7 +113,7 @@ test(`handleRequestForPath() should destroy the session when navigating away fro
     redirect
   }
 
-  handleRequestForPath(config, steps)(req, res, next)
+  handleRequestForPath(config, journey)(req, res, next)
 
   t.equal(destroy.called, true, 'it should destroy the session')
   t.equal(clearCookie.calledWith('lang'), true, 'it should clear language preference cookie')

--- a/src/web/routes/application/middleware/handle-post-redirects.js
+++ b/src/web/routes/application/middleware/handle-post-redirects.js
@@ -1,11 +1,11 @@
 const { stateMachine, actions } = require('../common/state-machine')
 
-const handlePostRedirects = (steps) => (req, res, next) => {
+const handlePostRedirects = (journey) => (req, res, next) => {
   if (res.locals.errors) {
     return next()
   }
 
-  const nextPage = stateMachine.dispatch(actions.GET_NEXT_PATH, req, steps)
+  const nextPage = stateMachine.dispatch(actions.GET_NEXT_PATH, req, journey.steps)
   return res.redirect(nextPage)
 }
 

--- a/src/web/routes/application/middleware/handle-post-redirects.test.js
+++ b/src/web/routes/application/middleware/handle-post-redirects.test.js
@@ -2,7 +2,9 @@ const test = require('tape')
 const sinon = require('sinon')
 const { handlePostRedirects } = require('./handle-post-redirects')
 
-const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
+const journey = {
+  steps: [{ path: '/first', next: () => '/second' }, { path: '/second' }]
+}
 
 test('handlePostRedirects() should redirect when no response errors', async (t) => {
   const redirect = sinon.spy()
@@ -18,7 +20,7 @@ test('handlePostRedirects() should redirect when no response errors', async (t) 
     locals: {}
   }
 
-  handlePostRedirects(steps)(req, res, next)
+  handlePostRedirects(journey)(req, res, next)
 
   t.equal(redirect.called, true)
   t.equal(next.called, false)
@@ -44,7 +46,7 @@ test('handlePostRedirects() should call next() when response errors are present'
     }
   }
 
-  handlePostRedirects(steps)(req, res, next)
+  handlePostRedirects(journey)(req, res, next)
 
   t.equal(redirect.called, false)
   t.equal(next.called, true)

--- a/src/web/routes/application/middleware/handle-post.js
+++ b/src/web/routes/application/middleware/handle-post.js
@@ -7,7 +7,7 @@ const { INVALIDATE_REVIEW, INCREMENT_NEXT_ALLOWED_PATH } = actions
 
 const stepInvalidatesReview = (step, claim) => typeof step.shouldInvalidateReview === 'function' && step.shouldInvalidateReview(claim)
 
-const handlePost = (steps, step) => (req, res, next) => {
+const handlePost = (journey, step) => (req, res, next) => {
   try {
     const errors = validationResult(req)
 
@@ -26,7 +26,7 @@ const handlePost = (steps, step) => (req, res, next) => {
       stateMachine.dispatch(INVALIDATE_REVIEW, req)
     }
 
-    stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, steps)
+    stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, journey.steps)
 
     return next()
   } catch (error) {

--- a/src/web/routes/application/middleware/handle-post.test.js
+++ b/src/web/routes/application/middleware/handle-post.test.js
@@ -23,13 +23,14 @@ test('handlePost() should add errors and claim to locals if errors exist', (t) =
   })
 
   const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
+  const journey = { steps }
   const step = steps[0]
   const claim = 'claim'
   const req = { body: claim }
   const res = { locals: {} }
   const next = sinon.spy()
 
-  handlePost(steps, step)(req, res, next)
+  handlePost(journey, step)(req, res, next)
 
   t.deepEqual(res.locals.errors, errors, 'it should add errors to locals')
   t.deepEqual(res.locals.claim, claim, 'it should add claim to locals')
@@ -41,6 +42,7 @@ test('handlePost() adds body to the session if no errors exist', (t) => {
   const { handlePost } = proxyquire('./handle-post', { ...defaultValidator })
 
   const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
+  const journey = { steps }
   const step = steps[0]
   const req = {
     session: {
@@ -60,7 +62,7 @@ test('handlePost() adds body to the session if no errors exist', (t) => {
     new: 'claim data'
   }
 
-  handlePost(steps, step)(req, {}, next)
+  handlePost(journey, step)(req, {}, next)
 
   t.deepEqual(req.session.claim, expected, 'it should add body to session')
   t.equal(next.called, true, 'it should call next()')
@@ -78,6 +80,7 @@ test('handlePost() calls next() with error on error', (t) => {
   })
 
   const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
+  const journey = { steps }
   const step = steps[0]
   const req = {
     session: {
@@ -89,7 +92,7 @@ test('handlePost() calls next() with error on error', (t) => {
   const res = { locals: {} }
   const next = sinon.spy()
 
-  handlePost(steps, step)(req, res, next)
+  handlePost(journey, step)(req, res, next)
 
   t.equal(next.calledWith(sinon.match.instanceOf(Error)), true, 'it should call next() with error')
   t.end()
@@ -99,6 +102,7 @@ test('handlePost() adds next allowed step to session', (t) => {
   const { handlePost } = proxyquire('./handle-post', { ...defaultValidator })
 
   const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
+  const journey = { steps }
   const step = steps[0]
   const req = {
     session: {},
@@ -108,7 +112,7 @@ test('handlePost() adds next allowed step to session', (t) => {
   const res = {}
   const next = () => {}
 
-  handlePost(steps, step)(req, res, next)
+  handlePost(journey, step)(req, res, next)
 
   t.equal(req.session.nextAllowedStep, '/second', 'it should add next allowed step to session')
   t.end()
@@ -126,6 +130,7 @@ test('handlePost() should invalidate review if required by step', (t) => {
   })
 
   const steps = [{ path: '/first', next: () => '/second', shouldInvalidateReview: () => true }, { path: '/second' }]
+  const journey = { steps }
   const step = steps[0]
 
   const req = {
@@ -136,7 +141,7 @@ test('handlePost() should invalidate review if required by step', (t) => {
   const res = {}
   const next = () => {}
 
-  handlePost(steps, step)(req, res, next)
+  handlePost(journey, step)(req, res, next)
 
   t.equal(dispatch.calledWith(INVALIDATE_REVIEW, req), true, 'it calls dispatch with the correct arguments')
   t.end()

--- a/src/web/routes/application/register-journey-routes.js
+++ b/src/web/routes/application/register-journey-routes.js
@@ -21,8 +21,8 @@ const handleOptionalMiddleware = (args) => (operation, fallback = middlewareNoop
 
 const createRoute = (config, csrfProtection, journey, router) => (step) => {
   const { steps } = journey
-  // Make [config, steps, step] available as arguments to all optional middleware
-  const optionalMiddleware = handleOptionalMiddleware([config, steps, step])
+  // Make [config, journey, step] available as arguments to all optional middleware
+  const optionalMiddleware = handleOptionalMiddleware([config, journey, step])
 
   return router
     .route(step.path)

--- a/src/web/routes/application/register-journey-routes.js
+++ b/src/web/routes/application/register-journey-routes.js
@@ -42,17 +42,16 @@ const createRoute = (config, csrfProtection, journey, router) => (step) => {
       optionalMiddleware(step.validate),
       getSessionDetails,
       optionalMiddleware(step.behaviourForPost),
-      handlePost(steps, step),
+      handlePost(journey, step),
       handleRequestForPath(config, journey, step),
-      handlePostRedirects(steps),
+      handlePostRedirects(journey),
       renderView(step)
     )
 }
 
 const registerJourneyRoutes = (config, csrfProtection, app) => (journey) => {
   const wizard = express.Router()
-  const { steps } = journey
-  steps.forEach(createRoute(config, csrfProtection, journey, wizard))
+  journey.steps.forEach(createRoute(config, csrfProtection, journey, wizard))
   app.use(wizard)
 
   registerCheckAnswersRoutes(journey, config, app)

--- a/src/web/routes/application/register-journey-routes.js
+++ b/src/web/routes/application/register-journey-routes.js
@@ -30,7 +30,7 @@ const createRoute = (config, csrfProtection, journey, router) => (step) => {
       csrfProtection,
       configureGet(steps, step),
       getSessionDetails,
-      handleRequestForPath(config, steps, step),
+      handleRequestForPath(config, journey, step),
       optionalMiddleware(step.behaviourForGet),
       renderView(step)
     )
@@ -43,7 +43,7 @@ const createRoute = (config, csrfProtection, journey, router) => (step) => {
       getSessionDetails,
       optionalMiddleware(step.behaviourForPost),
       handlePost(steps, step),
-      handleRequestForPath(config, steps, step),
+      handleRequestForPath(config, journey, step),
       handlePostRedirects(steps),
       renderView(step)
     )
@@ -55,9 +55,9 @@ const registerJourneyRoutes = (config, csrfProtection, app) => (journey) => {
   steps.forEach(createRoute(config, csrfProtection, journey, wizard))
   app.use(wizard)
 
-  registerCheckAnswersRoutes(steps, config, app)
-  registerTermsAndConditionsRoutes(csrfProtection, steps, config, app)
-  registerConfirmRoute(config, steps, app)
+  registerCheckAnswersRoutes(journey, config, app)
+  registerTermsAndConditionsRoutes(csrfProtection, journey, config, app)
+  registerConfirmRoute(config, journey, app)
 }
 
 module.exports = {

--- a/src/web/routes/application/terms-and-conditions/get.js
+++ b/src/web/routes/application/terms-and-conditions/get.js
@@ -16,7 +16,7 @@ function render (res, req) {
   })
 }
 
-const getTermsAndConditions = (steps) => (req, res) => {
+const getTermsAndConditions = (journey) => (req, res) => {
   stateMachine.setState(states.IN_REVIEW, req)
 
   render(res, req)

--- a/src/web/routes/application/terms-and-conditions/post.js
+++ b/src/web/routes/application/terms-and-conditions/post.js
@@ -23,8 +23,9 @@ const handleErrorResponse = (body, response) => {
   return response
 }
 
-const postTermsAndConditions = (steps, config) => (req, res, next) => {
+const postTermsAndConditions = (config, journey) => (req, res, next) => {
   const errors = validationResult(req)
+  const { steps } = journey
 
   if (!errors.isEmpty()) {
     res.locals.errors = errors.array()

--- a/src/web/routes/application/terms-and-conditions/post.test.js
+++ b/src/web/routes/application/terms-and-conditions/post.test.js
@@ -60,7 +60,9 @@ test('failure to agree to terms and conditions returns to the terms-and-conditio
 
   const errors = ['error']
 
-  const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
+  const journey = {
+    steps: [{ path: '/first', next: () => '/second' }, { path: '/second' }]
+  }
 
   const { postTermsAndConditions } = proxyquire('./post', {
     'express-validator': {
@@ -71,7 +73,7 @@ test('failure to agree to terms and conditions returns to the terms-and-conditio
     }
   })
 
-  postTermsAndConditions(steps)(req, res)
+  postTermsAndConditions(config, journey)(req, res)
 
   t.deepEqual(res.locals.errors, errors, 'it should add errors to locals')
   t.equal(render.called, true, 'it should call render()')
@@ -90,7 +92,7 @@ test('unsuccessful post calls next with error', async (t) => {
   const error = new Error('error')
   post.returns(Promise.reject(error))
 
-  postTermsAndConditions({}, config)(req, res, next)
+  postTermsAndConditions(config, {})(req, res, next)
     .then(() => {
       t.equal(next.calledWith(sinon.match.instanceOf(Error)), true, 'calls next with error')
       t.end()
@@ -101,7 +103,7 @@ test('unsuccessful post calls next with error', async (t) => {
 })
 
 test(`successful post sets next allowed step to ${CONFIRM_URL} and returned fields`, async (t) => {
-  const steps = []
+  const journey = { steps: [] }
   const next = sinon.spy()
   const redirect = sinon.spy()
   const render = sinon.spy()
@@ -126,7 +128,7 @@ test(`successful post sets next allowed step to ${CONFIRM_URL} and returned fiel
     }
   }))
 
-  postTermsAndConditions(steps, config)(req, res, next)
+  postTermsAndConditions(config, journey)(req, res, next)
     .then(() => {
       t.equal(req.session.nextAllowedStep, CONFIRM_URL, `it sets next allowed step to ${CONFIRM_URL}`)
       t.equal(req.session.eligibilityStatus, ELIGIBLE, 'it sets the eligibility status to ELIGIBLE')

--- a/src/web/routes/application/terms-and-conditions/terms-and-conditions.js
+++ b/src/web/routes/application/terms-and-conditions/terms-and-conditions.js
@@ -8,11 +8,11 @@ const { handleRequestForPath } = require('../middleware')
 const validate = [
   check('agree').equals('agree').withMessage(translateValidationMessage('validation:acceptTermsAndConditions'))
 ]
-const registerTermsAndConditionsRoutes = (csrfProtection, steps, config, app) => {
+const registerTermsAndConditionsRoutes = (csrfProtection, journey, config, app) => {
   app
     .route(TERMS_AND_CONDITIONS_URL)
-    .get(csrfProtection, handleRequestForPath(config, steps), getTermsAndConditions(steps))
-    .post(csrfProtection, validate, handleRequestForPath(config, steps), postTermsAndConditions(steps, config))
+    .get(csrfProtection, handleRequestForPath(config, journey), getTermsAndConditions(journey.steps))
+    .post(csrfProtection, validate, handleRequestForPath(config, journey), postTermsAndConditions(journey.steps, config))
 }
 
 module.exports = {

--- a/src/web/routes/application/terms-and-conditions/terms-and-conditions.js
+++ b/src/web/routes/application/terms-and-conditions/terms-and-conditions.js
@@ -11,8 +11,8 @@ const validate = [
 const registerTermsAndConditionsRoutes = (csrfProtection, journey, config, app) => {
   app
     .route(TERMS_AND_CONDITIONS_URL)
-    .get(csrfProtection, handleRequestForPath(config, journey), getTermsAndConditions(journey.steps))
-    .post(csrfProtection, validate, handleRequestForPath(config, journey), postTermsAndConditions(journey.steps, config))
+    .get(csrfProtection, handleRequestForPath(config, journey), getTermsAndConditions(journey))
+    .post(csrfProtection, validate, handleRequestForPath(config, journey), postTermsAndConditions(config, journey))
 }
 
 module.exports = {


### PR DESCRIPTION
To enable multiple user journeys the state machine needs to be journey aware. This PR passes the `journey` object to all middleware and route handlers that call the state machine.

Future PRs will call the state machine with the `journey` object to enable journey specific state updates.