### PR TITLE
HTBHF-2544 refactor state machine

### DIFF
--- a/src/web/routes/application/flow-control/state-machine/actions.js
+++ b/src/web/routes/application/flow-control/state-machine/actions.js
@@ -1,0 +1,6 @@
+module.exports.GET_NEXT_PATH = 'getNextPath'
+module.exports.IS_PATH_ALLOWED = 'isPathAllowed'
+module.exports.GET_NEXT_ALLOWED_PATH = 'getNextAllowedPath'
+module.exports.SET_NEXT_ALLOWED_PATH = 'setNextAllowedPath'
+module.exports.INCREMENT_NEXT_ALLOWED_PATH = 'incrementNextAllowedPath'
+module.exports.INVALIDATE_REVIEW = 'invalidateReview'

--- a/src/web/routes/application/flow-control/state-machine/index.js
+++ b/src/web/routes/application/flow-control/state-machine/index.js
@@ -1,4 +1,6 @@
-const { states, actions, stateMachine } = require('./state-machine')
+const { stateMachine } = require('./state-machine')
+const states = require('./states')
+const actions = require('./actions')
 
 module.exports = {
   states,

--- a/src/web/routes/application/flow-control/state-machine/operators.js
+++ b/src/web/routes/application/flow-control/state-machine/operators.js
@@ -1,0 +1,7 @@
+const setNextAllowedPath = (req, path) => {
+  req.session.nextAllowedStep = path
+}
+
+module.exports = {
+  setNextAllowedPath
+}

--- a/src/web/routes/application/flow-control/state-machine/predicates.js
+++ b/src/web/routes/application/flow-control/state-machine/predicates.js
@@ -1,0 +1,14 @@
+const { equals, isNil } = require('ramda')
+
+/**
+ * Next path is navigable if the next step does not exist, if it doesn't define an isNavigable function, or that function returns true.
+ * E.g. if the current step is the end of the 'in-progress' journey, the next path will be /check-answers. There is no step matching /check-answers, so we assume it is navigable.
+ */
+const isNextPathNavigable = (nextStep, req) => isNil(nextStep) || isNil(nextStep.isNavigable) || nextStep.isNavigable(req.session)
+
+const isPathAllowed = (sequence, allowed, path) => sequence.findIndex(equals(path)) <= sequence.findIndex(equals(allowed))
+
+module.exports = {
+  isNextPathNavigable,
+  isPathAllowed
+}

--- a/src/web/routes/application/flow-control/state-machine/predicates.test.js
+++ b/src/web/routes/application/flow-control/state-machine/predicates.test.js
@@ -1,0 +1,22 @@
+const test = require('tape')
+const { isPathAllowed } = require('./predicates')
+
+const paths = ['/first', '/second', '/third', '/fourth']
+
+test('isPathAllowed() should return true if path is before allowed in sequence', (t) => {
+  const result = isPathAllowed(paths, '/third', '/second')
+  t.equal(result, true, 'returns true if path is before allowed in sequence')
+  t.end()
+})
+
+test('isPathAllowed() should return true if path matches allowed', (t) => {
+  const result = isPathAllowed(paths, '/third', '/third')
+  t.equal(result, true, 'returns true if path matches allowed')
+  t.end()
+})
+
+test('isPathAllowed() should return false if path is after allowed in sequence', (t) => {
+  const result = isPathAllowed(paths, '/third', '/fourth')
+  t.equal(result, false, 'returns false if path is after allowed in sequence')
+  t.end()
+})

--- a/src/web/routes/application/flow-control/state-machine/selectors/get-next-for-step.js
+++ b/src/web/routes/application/flow-control/state-machine/selectors/get-next-for-step.js
@@ -1,5 +1,5 @@
 const { compose, equals, prop } = require('ramda')
-const { CHECK_ANSWERS_URL } = require('../../paths')
+const { CHECK_ANSWERS_URL } = require('../../../paths')
 
 const isMatchingPath = path => compose(equals(path), prop('path'))
 

--- a/src/web/routes/application/flow-control/state-machine/selectors/get-next-for-step.test.js
+++ b/src/web/routes/application/flow-control/state-machine/selectors/get-next-for-step.test.js
@@ -1,6 +1,6 @@
 const test = require('tape')
 const { getNextPathFromSteps, getNextForStep } = require('./get-next-for-step')
-const { CHECK_ANSWERS_URL } = require('../../paths')
+const { CHECK_ANSWERS_URL } = require('../../../paths')
 
 const step1 = {
   path: '/first'

--- a/src/web/routes/application/flow-control/state-machine/selectors/index.js
+++ b/src/web/routes/application/flow-control/state-machine/selectors/index.js
@@ -1,0 +1,6 @@
+const { getNextForStep } = require('./get-next-for-step')
+
+module.exports = {
+  ...require('./selectors'),
+  getNextForStep
+}

--- a/src/web/routes/application/flow-control/state-machine/selectors/selectors.js
+++ b/src/web/routes/application/flow-control/state-machine/selectors/selectors.js
@@ -1,0 +1,29 @@
+const { CHECK_ANSWERS_URL, TERMS_AND_CONDITIONS_URL } = require('../../../paths')
+const { isNextPathNavigable } = require('../predicates')
+const { getNextForStep } = require('./get-next-for-step')
+
+const getStepForPath = (path, steps) => steps.find(step => step.path === path)
+
+const getNextInReviewPath = (req) => req.path === CHECK_ANSWERS_URL ? TERMS_AND_CONDITIONS_URL : CHECK_ANSWERS_URL
+
+/**
+ * Ask the current step for the next path. Test whether the step matching that path is navigable. If not, ask that step for the next path; repeat.
+ * @param path the path of the current step
+ * @param req the current request
+ * @param steps the steps of the apply journey
+ * @returns the path of the next step
+ */
+const getNextNavigablePath = (path, req, steps) => {
+  const thisStep = getStepForPath(path, steps)
+  const nextPath = getNextForStep(req, thisStep, steps)
+  const nextStep = getStepForPath(nextPath, steps)
+  if (isNextPathNavigable(nextStep, req)) {
+    return nextPath
+  }
+  return getNextNavigablePath(nextPath, req, steps)
+}
+
+module.exports = {
+  getNextNavigablePath,
+  getNextInReviewPath
+}

--- a/src/web/routes/application/flow-control/state-machine/state-machine.js
+++ b/src/web/routes/application/flow-control/state-machine/state-machine.js
@@ -1,18 +1,12 @@
-const { equals, isNil } = require('ramda')
 const { getNextForStep } = require('./get-next-for-step')
 const { CHECK_ANSWERS_URL, TERMS_AND_CONDITIONS_URL, CONFIRM_URL } = require('../../paths')
 const { logger } = require('../../../../logger')
 const states = require('./states')
+const { isNextPathNavigable, isPathAllowed } = require('./predicates')
 
 const { IN_PROGRESS, IN_REVIEW, COMPLETED } = states
 
 const getStepForPath = (path, steps) => steps.find(step => step.path === path)
-
-/**
- * Next path is navigable if the next step does not exist, if it doesn't define an isNavigable function, or that function returns true.
- * E.g. if the current step is the end of the 'in-progress' journey, the next path will be /check-answers. There is no step matching /check-answers, so we assume it is navigable.
- */
-const isNextPathNavigable = (nextStep, req) => isNil(nextStep) || isNil(nextStep.isNavigable) || nextStep.isNavigable(req.session)
 
 /**
  * Ask the current step for the next path. Test whether the step matching that path is navigable. If not, ask that step for the next path; repeat.
@@ -30,9 +24,6 @@ const getNextNavigablePath = (path, req, steps) => {
   }
   return getNextNavigablePath(nextPath, req, steps)
 }
-
-const isPathAllowed = (sequence, allowed, path) =>
-  sequence.findIndex(equals(path)) <= sequence.findIndex(equals(allowed))
 
 const setNextAllowedPath = (req, path) => {
   req.session.nextAllowedStep = path
@@ -88,6 +79,5 @@ const stateMachine = {
 }
 
 module.exports = {
-  stateMachine,
-  isPathAllowed
+  stateMachine
 }

--- a/src/web/routes/application/flow-control/state-machine/state-machine.js
+++ b/src/web/routes/application/flow-control/state-machine/state-machine.js
@@ -3,12 +3,9 @@ const { logger } = require('../../../../logger')
 const states = require('./states')
 const { isPathAllowed } = require('./predicates')
 const { getNextNavigablePath, getNextInReviewPath } = require('./selectors')
+const { setNextAllowedPath } = require('./operators')
 
 const { IN_PROGRESS, IN_REVIEW, COMPLETED } = states
-
-const setNextAllowedPath = (req, path) => {
-  req.session.nextAllowedStep = path
-}
 
 const stateMachine = {
   [IN_PROGRESS]: {

--- a/src/web/routes/application/flow-control/state-machine/state-machine.js
+++ b/src/web/routes/application/flow-control/state-machine/state-machine.js
@@ -1,35 +1,14 @@
-const { getNextForStep } = require('./get-next-for-step')
-const { CHECK_ANSWERS_URL, TERMS_AND_CONDITIONS_URL, CONFIRM_URL } = require('../../paths')
+const { CONFIRM_URL } = require('../../paths')
 const { logger } = require('../../../../logger')
 const states = require('./states')
-const { isNextPathNavigable, isPathAllowed } = require('./predicates')
+const { isPathAllowed } = require('./predicates')
+const { getNextNavigablePath, getNextInReviewPath } = require('./selectors')
 
 const { IN_PROGRESS, IN_REVIEW, COMPLETED } = states
-
-const getStepForPath = (path, steps) => steps.find(step => step.path === path)
-
-/**
- * Ask the current step for the next path. Test whether the step matching that path is navigable. If not, ask that step for the next path; repeat.
- * @param path the path of the current step
- * @param req the current request
- * @param steps the steps of the apply journey
- * @returns the path of the next step
- */
-const getNextNavigablePath = (path, req, steps) => {
-  const thisStep = getStepForPath(path, steps)
-  const nextPath = getNextForStep(req, thisStep, steps)
-  const nextStep = getStepForPath(nextPath, steps)
-  if (isNextPathNavigable(nextStep, req)) {
-    return nextPath
-  }
-  return getNextNavigablePath(nextPath, req, steps)
-}
 
 const setNextAllowedPath = (req, path) => {
   req.session.nextAllowedStep = path
 }
-
-const getNextInReviewPath = (req) => req.path === CHECK_ANSWERS_URL ? TERMS_AND_CONDITIONS_URL : CHECK_ANSWERS_URL
 
 const stateMachine = {
   [IN_PROGRESS]: {

--- a/src/web/routes/application/flow-control/state-machine/state-machine.test.js
+++ b/src/web/routes/application/flow-control/state-machine/state-machine.test.js
@@ -1,12 +1,14 @@
 const test = require('tape')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-
+const states = require('./states')
+const actions = require('./actions')
 const { CHECK_ANSWERS_URL, TERMS_AND_CONDITIONS_URL, CONFIRM_URL } = require('../../paths')
+
 const info = sinon.spy()
 const logger = { info }
 
-const { stateMachine, states, actions, isPathAllowed } = proxyquire('./state-machine', {
+const { stateMachine, isPathAllowed } = proxyquire('./state-machine', {
   '../../../../logger': { logger }
 })
 

--- a/src/web/routes/application/flow-control/state-machine/state-machine.test.js
+++ b/src/web/routes/application/flow-control/state-machine/state-machine.test.js
@@ -8,7 +8,7 @@ const { CHECK_ANSWERS_URL, TERMS_AND_CONDITIONS_URL, CONFIRM_URL } = require('..
 const info = sinon.spy()
 const logger = { info }
 
-const { stateMachine, isPathAllowed } = proxyquire('./state-machine', {
+const { stateMachine } = proxyquire('./state-machine', {
   '../../../../logger': { logger }
 })
 
@@ -19,7 +19,6 @@ const steps = [
   { path: '/second', next: () => '/third' },
   { path: '/third', isNavigable: () => false, next: () => '/fourth' }
 ]
-const paths = ['/first', '/second', '/third', '/fourth']
 
 test(`Dispatching ${GET_NEXT_PATH} should return next property of associated step when no state defined in session`, async (t) => {
   const req = { method: 'POST', session: {}, path: '/first' }
@@ -67,24 +66,6 @@ test(`Dispatching an invalid action should return null`, async (t) => {
   const req = { method: 'POST', session: {}, path: '/first' }
 
   t.equal(stateMachine.dispatch('INVALID_ACTION', req, steps), null)
-  t.end()
-})
-
-test('isPathAllowed() should return true if path is before allowed in sequence', (t) => {
-  const result = isPathAllowed(paths, '/third', '/second')
-  t.equal(result, true, 'returns true if path is before allowed in sequence')
-  t.end()
-})
-
-test('isPathAllowed() should return true if path matches allowed', (t) => {
-  const result = isPathAllowed(paths, '/third', '/third')
-  t.equal(result, true, 'returns true if path matches allowed')
-  t.end()
-})
-
-test('isPathAllowed() should return false if path is after allowed in sequence', (t) => {
-  const result = isPathAllowed(paths, '/third', '/fourth')
-  t.equal(result, false, 'returns false if path is after allowed in sequence')
   t.end()
 })
 

--- a/src/web/routes/application/flow-control/state-machine/states.js
+++ b/src/web/routes/application/flow-control/state-machine/states.js
@@ -1,0 +1,3 @@
+module.exports.IN_PROGRESS = 'IN_PROGRESS'
+module.exports.IN_REVIEW = 'IN_REVIEW'
+module.exports.COMPLETED = 'COMPLETED'


### PR DESCRIPTION
HTBHF-2515 requires a number of updates to the state machine to enable journey specific updates to the session.

This PR is a precursory refactor to reduce the noise in the state machine and focus on the state specific actions. No new logic has been added:

- Move states and actions to separate files (actions were not used directly in state machine)
- Create predicates and selectors files
- Create an operators file - this will be expanded in future PRs for HTBHF-2544 as it will control how journey state is set in session