### PR TITLE
HTBHF-2546 pass journey as argument when calling state machine dispatch

### DIFF
--- a/src/web/routes/application/flow-control/middleware/handle-path-request/handle-path-request.js
+++ b/src/web/routes/application/flow-control/middleware/handle-path-request/handle-path-request.js
@@ -21,15 +21,15 @@ const handleRequestForPath = (config, journey, step) => (req, res, next) => {
   }
 
   // Initialise nextAllowedPath if none exists in session
-  let nextAllowedPath = stateMachine.dispatch(GET_NEXT_ALLOWED_PATH, req)
+  let nextAllowedPath = stateMachine.dispatch(GET_NEXT_ALLOWED_PATH, req, journey)
 
   if (!nextAllowedPath) {
     const firstPathInSequence = pathsInSequence[0]
-    stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, firstPathInSequence)
+    stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, journey, firstPathInSequence)
     nextAllowedPath = firstPathInSequence
   }
 
-  const isPathAllowed = stateMachine.dispatch(IS_PATH_ALLOWED, req, pathsInSequence)
+  const isPathAllowed = stateMachine.dispatch(IS_PATH_ALLOWED, req, journey)
 
   // Redirect to nextAllowedPath on invalid path request
   if (!isPathAllowed) {

--- a/src/web/routes/application/flow-control/middleware/handle-post-redirects.js
+++ b/src/web/routes/application/flow-control/middleware/handle-post-redirects.js
@@ -5,7 +5,7 @@ const handlePostRedirects = (journey) => (req, res, next) => {
     return next()
   }
 
-  const nextPage = stateMachine.dispatch(actions.GET_NEXT_PATH, req, journey.steps)
+  const nextPage = stateMachine.dispatch(actions.GET_NEXT_PATH, req, journey)
   return res.redirect(nextPage)
 }
 

--- a/src/web/routes/application/flow-control/middleware/handle-post.js
+++ b/src/web/routes/application/flow-control/middleware/handle-post.js
@@ -26,7 +26,7 @@ const handlePost = (journey, step) => (req, res, next) => {
       stateMachine.dispatch(INVALIDATE_REVIEW, req)
     }
 
-    stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, journey.steps)
+    stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, journey)
 
     return next()
   } catch (error) {

--- a/src/web/routes/application/flow-control/state-machine/operators.js
+++ b/src/web/routes/application/flow-control/state-machine/operators.js
@@ -1,4 +1,4 @@
-const setNextAllowedPath = (req, path) => {
+const setNextAllowedPath = (req, journey, path) => {
   req.session.nextAllowedStep = path
 }
 

--- a/src/web/routes/application/flow-control/state-machine/state-machine.test.js
+++ b/src/web/routes/application/flow-control/state-machine/state-machine.test.js
@@ -14,58 +14,60 @@ const { stateMachine } = proxyquire('./state-machine', {
 
 const { GET_NEXT_PATH, INVALIDATE_REVIEW, SET_NEXT_ALLOWED_PATH, INCREMENT_NEXT_ALLOWED_PATH } = actions
 
-const steps = [
-  { path: '/first', next: () => '/second' },
-  { path: '/second', next: () => '/third' },
-  { path: '/third', isNavigable: () => false, next: () => '/fourth' }
-]
+const journey = {
+  steps: [
+    { path: '/first', next: () => '/second' },
+    { path: '/second', next: () => '/third' },
+    { path: '/third', isNavigable: () => false, next: () => '/fourth' }
+  ]
+}
 
 test(`Dispatching ${GET_NEXT_PATH} should return next property of associated step when no state defined in session`, async (t) => {
   const req = { method: 'POST', session: {}, path: '/first' }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps), '/second')
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, journey), '/second')
   t.end()
 })
 
 test(`Dispatching ${GET_NEXT_PATH} should return should return next property of associated step when state of ${states.IN_PROGRESS} defined in session`, async (t) => {
   const req = { method: 'POST', session: { state: states.IN_PROGRESS }, path: '/first' }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps), '/second')
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, journey), '/second')
   t.end()
 })
 
 test(`Dispatching ${GET_NEXT_PATH} should return next navigable path when state of ${states.IN_PROGRESS} defined in session and next step is not navigable`, async (t) => {
   const req = { method: 'POST', session: { state: states.IN_PROGRESS }, path: '/second' }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps), '/fourth')
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, journey), '/fourth')
   t.end()
 })
 
 test(`Dispatching ${GET_NEXT_PATH} should return ${CHECK_ANSWERS_URL} path when state of ${states.IN_REVIEW} defined in session`, async (t) => {
   const req = { method: 'POST', session: { state: states.IN_REVIEW }, path: '/first' }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps), CHECK_ANSWERS_URL)
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, journey), CHECK_ANSWERS_URL)
   t.end()
 })
 
 test(`Dispatching ${GET_NEXT_PATH} should return /terms-and-conditions when state of ${states.IN_REVIEW} and current path is ${CHECK_ANSWERS_URL}`, async (t) => {
   const req = { method: 'POST', session: { state: states.IN_REVIEW }, path: CHECK_ANSWERS_URL }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps), TERMS_AND_CONDITIONS_URL)
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, journey), TERMS_AND_CONDITIONS_URL)
   t.end()
 })
 
 test(`Dispatching ${GET_NEXT_PATH} should return confirm path when state of ${states.COMPLETED} defined in session`, async (t) => {
   const req = { method: 'POST', session: { state: states.COMPLETED }, path: '/first' }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, steps), CONFIRM_URL)
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, journey), CONFIRM_URL)
   t.end()
 })
 
 test(`Dispatching an invalid action should return null`, async (t) => {
   const req = { method: 'POST', session: {}, path: '/first' }
 
-  t.equal(stateMachine.dispatch('INVALID_ACTION', req, steps), null)
+  t.equal(stateMachine.dispatch('INVALID_ACTION', req, journey), null)
   t.end()
 })
 
@@ -133,7 +135,7 @@ test(`Dispatching ${SET_NEXT_ALLOWED_PATH} sets next allowed path in session`, (
       }
     }
 
-    stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, path)
+    stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, journey, path)
     t.equal(req.session.nextAllowedStep, path, `sets next allowed path in session for ${state}`)
   })
 
@@ -157,7 +159,7 @@ test(`Dispatching ${INCREMENT_NEXT_ALLOWED_PATH} updates next allowed step in se
       }
     }
 
-    stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, steps)
+    stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, journey)
     t.equal(req.session.nextAllowedStep, expectedNextPath, `increments next allowed path in session for ${state}`)
   })
 

--- a/src/web/routes/application/steps/address/select-address/select-address.js
+++ b/src/web/routes/application/steps/address/select-address/select-address.js
@@ -32,14 +32,14 @@ const resetAddressState = (req) => {
   }
 }
 
-const behaviourForGet = () => (req, res, next) => {
+const behaviourForGet = (config, journey) => (req, res, next) => {
   resetAddressState(req)
   res.locals.postcodeLookupError = req.session.postcodeLookupError
   if (!res.locals.postcodeLookupError) {
     res.locals.addresses = req.session.postcodeLookupResults.map(buildAddressOption)
   }
   // Manual address is further in the flow than select-address, therefore this line is needed to prevent the state machine from redirecting the user back to select-address.
-  stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, '/manual-address')
+  stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, journey, '/manual-address')
   next()
 }
 

--- a/src/web/routes/application/steps/check-answers/get.js
+++ b/src/web/routes/application/steps/check-answers/get.js
@@ -40,7 +40,7 @@ const getCheckAnswers = (journey) => (req, res) => {
   const { steps } = journey
 
   stateMachine.setState(IN_REVIEW, req)
-  stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, steps)
+  stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, journey)
 
   res.render('check-answers', {
     ...localisation,

--- a/src/web/routes/application/steps/terms-and-conditions/post.js
+++ b/src/web/routes/application/steps/terms-and-conditions/post.js
@@ -64,7 +64,7 @@ const postTermsAndConditions = (config, journey) => (req, res, next) => {
         req.session.claimUpdated = claimUpdated
 
         stateMachine.setState(COMPLETED, req)
-        stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, steps)
+        stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, journey)
         return res.redirect('confirm')
       },
       (error) => {


### PR DESCRIPTION
To implement multiple user journeys the state machine will need to know about the active journey:

- Make `journey` a mandatory argument for `stateMachine.dispatch()`
- Update calls to the state machine to use the `journey` argument, replacing arguments that were previously a property of `journey` (e.g. `journey.steps` and `journey.pathsInSequence`)