### PR TITLE
HTBHF-2547 initialise journey in session

### DIFF
--- a/src/web/routes/application/flow-control/middleware/session-details.js
+++ b/src/web/routes/application/flow-control/middleware/session-details.js
@@ -1,5 +1,15 @@
-const getSessionDetails = (req, res, next) => {
+const initialiseProp = (prop, obj, value = {}) => {
+  if (!obj.hasOwnProperty(prop)) {
+    obj[prop] = value
+  }
+
+  return obj
+}
+
+const getSessionDetails = (journey) => (req, res, next) => {
   res.locals.claim = req.session.claim
+  req.session = initialiseProp('journeys', req.session)
+  req.session.journeys = initialiseProp(journey.name, req.session.journeys)
   next()
 }
 

--- a/src/web/routes/application/flow-control/middleware/session-details.js
+++ b/src/web/routes/application/flow-control/middleware/session-details.js
@@ -13,7 +13,7 @@ const defaultJourneyState = (journey) => ({
   state: states.IN_PROGRESS
 })
 
-const getSessionDetails = (journey) => (req, res, next) => {
+const configureSessionDetails = (journey) => (req, res, next) => {
   res.locals.claim = req.session.claim
   req.session = initialiseProp('journeys', req.session)
   req.session.journeys = initialiseProp(journey.name, req.session.journeys, defaultJourneyState(journey))
@@ -21,5 +21,5 @@ const getSessionDetails = (journey) => (req, res, next) => {
 }
 
 module.exports = {
-  getSessionDetails
+  configureSessionDetails
 }

--- a/src/web/routes/application/flow-control/middleware/session-details.js
+++ b/src/web/routes/application/flow-control/middleware/session-details.js
@@ -1,3 +1,5 @@
+const { states } = require('../state-machine')
+
 const initialiseProp = (prop, obj, value = {}) => {
   if (!obj.hasOwnProperty(prop)) {
     obj[prop] = value
@@ -6,10 +8,15 @@ const initialiseProp = (prop, obj, value = {}) => {
   return obj
 }
 
+const defaultJourneyState = (journey) => ({
+  nextAllowedStep: journey.pathsInSequence[0],
+  state: states.IN_PROGRESS
+})
+
 const getSessionDetails = (journey) => (req, res, next) => {
   res.locals.claim = req.session.claim
   req.session = initialiseProp('journeys', req.session)
-  req.session.journeys = initialiseProp(journey.name, req.session.journeys)
+  req.session.journeys = initialiseProp(journey.name, req.session.journeys, defaultJourneyState(journey))
   next()
 }
 

--- a/src/web/routes/application/flow-control/middleware/session-details.test.js
+++ b/src/web/routes/application/flow-control/middleware/session-details.test.js
@@ -1,0 +1,100 @@
+const test = require('tape')
+const sinon = require('sinon')
+const { getSessionDetails } = require('./session-details')
+
+test('getSessionDetails() sets claim on res.locals', (t) => {
+  const journey = {}
+
+  const req = {
+    session: {
+      claim: {
+        name: 'Lisa'
+      }
+    }
+  }
+
+  const res = { locals: {} }
+  const next = sinon.stub()
+
+  const expectedLocals = {
+    claim: {
+      name: 'Lisa'
+    }
+  }
+
+  getSessionDetails(journey)(req, res, next)
+  t.deepEqual(res.locals, expectedLocals, 'sets claim on res.locals')
+  t.equal(next.called, true, 'calls next()')
+  t.end()
+})
+
+test('getSessionDetails() initialises journey in session when session.journeys is undefined', (t) => {
+  const journey = { name: 'apply' }
+  const req = { session: {} }
+  const res = { locals: {} }
+  const next = sinon.stub()
+
+  const expectedSession = {
+    journeys: {
+      apply: {}
+    }
+  }
+
+  getSessionDetails(journey)(req, res, next)
+  t.deepEqual(req.session, expectedSession, 'initialises journey in session')
+  t.equal(next.called, true, 'calls next()')
+  t.end()
+})
+
+test('getSessionDetails() initialises journey in session when session.journeys is defined', (t) => {
+  const journey = { name: 'report-a-change' }
+  const req = {
+    session: {
+      journeys: {
+        apply: {}
+      }
+    }
+  }
+  const res = { locals: {} }
+  const next = sinon.stub()
+
+  const expectedSession = {
+    journeys: {
+      apply: {},
+      'report-a-change': {}
+    }
+  }
+
+  getSessionDetails(journey)(req, res, next)
+  t.deepEqual(req.session, expectedSession, 'initialises journey in session')
+  t.equal(next.called, true, 'calls next()')
+  t.end()
+})
+
+test('getSessionDetails() does not reinitialise a journey that already exists in session', (t) => {
+  const journey = { name: 'apply' }
+  const req = {
+    session: {
+      journeys: {
+        apply: {
+          state: 'IN_REVIEW'
+        }
+      }
+    }
+  }
+  const res = { locals: {} }
+  const next = sinon.stub()
+
+  const expectedSession = {
+    journeys: {
+      apply: {
+        state: 'IN_REVIEW'
+      }
+    }
+  }
+
+  getSessionDetails(journey)(req, res, next)
+  t.deepEqual(req.session, expectedSession, 'does not reinitialise a journey')
+  t.equal(next.called, true, 'calls next()')
+  t.end()
+})

--- a/src/web/routes/application/flow-control/middleware/session-details.test.js
+++ b/src/web/routes/application/flow-control/middleware/session-details.test.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 const sinon = require('sinon')
 const { states } = require('../state-machine')
-const { getSessionDetails } = require('./session-details')
+const { configureSessionDetails } = require('./session-details')
 
 const apply = {
   name: 'apply',
@@ -13,7 +13,7 @@ const reportChange = {
   pathsInSequence: ['/one', '/two']
 }
 
-test('getSessionDetails() sets claim on res.locals', (t) => {
+test('configureSessionDetails() sets claim on res.locals', (t) => {
   const journey = apply
 
   const req = {
@@ -33,13 +33,13 @@ test('getSessionDetails() sets claim on res.locals', (t) => {
     }
   }
 
-  getSessionDetails(journey)(req, res, next)
+  configureSessionDetails(journey)(req, res, next)
   t.deepEqual(res.locals, expectedLocals, 'sets claim on res.locals')
   t.equal(next.called, true, 'calls next()')
   t.end()
 })
 
-test('getSessionDetails() initialises journey in session when session.journeys is undefined', (t) => {
+test('configureSessionDetails() initialises journey in session when session.journeys is undefined', (t) => {
   const journey = apply
   const req = { session: {} }
   const res = { locals: {} }
@@ -54,13 +54,13 @@ test('getSessionDetails() initialises journey in session when session.journeys i
     }
   }
 
-  getSessionDetails(journey)(req, res, next)
+  configureSessionDetails(journey)(req, res, next)
   t.deepEqual(req.session, expectedSession, 'initialises journey in session')
   t.equal(next.called, true, 'calls next()')
   t.end()
 })
 
-test('getSessionDetails() initialises journey in session when session.journeys is defined', (t) => {
+test('configureSessionDetails() initialises journey in session when session.journeys is defined', (t) => {
   const journey = reportChange
 
   const req = {
@@ -84,13 +84,13 @@ test('getSessionDetails() initialises journey in session when session.journeys i
     }
   }
 
-  getSessionDetails(journey)(req, res, next)
+  configureSessionDetails(journey)(req, res, next)
   t.deepEqual(req.session, expectedSession, 'initialises journey in session')
   t.equal(next.called, true, 'calls next()')
   t.end()
 })
 
-test('getSessionDetails() does not reinitialise a journey that already exists in session', (t) => {
+test('configureSessionDetails() does not reinitialise a journey that already exists in session', (t) => {
   const journey = apply
 
   const req = {
@@ -115,7 +115,7 @@ test('getSessionDetails() does not reinitialise a journey that already exists in
     }
   }
 
-  getSessionDetails(journey)(req, res, next)
+  configureSessionDetails(journey)(req, res, next)
   t.deepEqual(req.session, expectedSession, 'does not reinitialise a journey')
   t.equal(next.called, true, 'calls next()')
   t.end()

--- a/src/web/routes/application/journey-definitions.js
+++ b/src/web/routes/application/journey-definitions.js
@@ -17,6 +17,7 @@ const {
 } = require('./steps')
 
 const APPLY = {
+  name: 'apply',
   steps: [
     scotland,
     inScotland,

--- a/src/web/routes/application/register-journey-routes.js
+++ b/src/web/routes/application/register-journey-routes.js
@@ -32,7 +32,7 @@ const createRoute = (config, csrfProtection, journey, router) => (step) => {
     .get(
       csrfProtection,
       configureGet(steps, step),
-      getSessionDetails,
+      getSessionDetails(journey),
       handleRequestForPath(config, journey, step),
       optionalMiddleware(step.behaviourForGet),
       renderView(step)
@@ -43,7 +43,7 @@ const createRoute = (config, csrfProtection, journey, router) => (step) => {
       sanitize,
       optionalMiddleware(step.sanitize),
       optionalMiddleware(step.validate),
-      getSessionDetails,
+      getSessionDetails(journey),
       optionalMiddleware(step.behaviourForPost),
       handlePost(journey, step),
       handleRequestForPath(config, journey, step),

--- a/src/web/routes/application/register-journey-routes.js
+++ b/src/web/routes/application/register-journey-routes.js
@@ -9,7 +9,7 @@ const {
 const {
   configureGet,
   configurePost,
-  getSessionDetails,
+  configureSessionDetails,
   handlePost,
   handleRequestForPath,
   handlePostRedirects,
@@ -32,7 +32,7 @@ const createRoute = (config, csrfProtection, journey, router) => (step) => {
     .get(
       csrfProtection,
       configureGet(steps, step),
-      getSessionDetails(journey),
+      configureSessionDetails(journey),
       handleRequestForPath(config, journey, step),
       optionalMiddleware(step.behaviourForGet),
       renderView(step)
@@ -43,7 +43,7 @@ const createRoute = (config, csrfProtection, journey, router) => (step) => {
       sanitize,
       optionalMiddleware(step.sanitize),
       optionalMiddleware(step.validate),
-      getSessionDetails(journey),
+      configureSessionDetails(journey),
       optionalMiddleware(step.behaviourForPost),
       handlePost(journey, step),
       handleRequestForPath(config, journey, step),

--- a/test_versions.properties
+++ b/test_versions.properties
@@ -1,3 +1,3 @@
 # This file is `source`d by the cd pipeline when running tests
 PERF_TESTS_VERSION=1.0.67
-ACCEPTANCE_TESTS_VERSION=0.0.62
+ACCEPTANCE_TESTS_VERSION=0.0.63


### PR DESCRIPTION
Initialise journey in session on route request. This is a non breaking change as the application has not been updated to determine flow control from journey state:

- Initialise a default journey state when a journey path is requested
- Rename session details middleware and give it a reference to the journey
- Add missing unit test for session details (adding claim to `res.locals`)
- Name the apply journey to enable the journey session initialisation