### PR TITLE
HTBHF-2548 get and set journey session state

### DIFF
--- a/src/web/routes/application/flow-control/middleware/handle-path-request/handle-path-request.js
+++ b/src/web/routes/application/flow-control/middleware/handle-path-request/handle-path-request.js
@@ -3,27 +3,21 @@ const { stateMachine, actions, states } = require('../../state-machine')
 const { stepNotNavigable } = require('./predicates')
 
 const { COMPLETED } = states
-const { IS_PATH_ALLOWED, GET_NEXT_ALLOWED_PATH, SET_NEXT_ALLOWED_PATH } = actions
+const { IS_PATH_ALLOWED, GET_NEXT_ALLOWED_PATH } = actions
 
+// TODO HTBHF-2506 remove config from signature as no longer required
 const handleRequestForPath = (config, journey, step) => (req, res, next) => {
   const { pathsInSequence } = journey
   const firstPathInSequence = pathsInSequence[0]
 
   // Destroy the session on navigating away from CONFIRM_URL
-  if (stateMachine.getState(req) === COMPLETED && req.path !== CONFIRM_URL) {
+  if (stateMachine.getState(req, journey) === COMPLETED && req.path !== CONFIRM_URL) {
     req.session.destroy()
     res.clearCookie('lang')
     return res.redirect(firstPathInSequence)
   }
 
-  // Initialise nextAllowedPath if none exists in session
-  let nextAllowedPath = stateMachine.dispatch(GET_NEXT_ALLOWED_PATH, req, journey)
-
-  if (!nextAllowedPath) {
-    stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, journey, firstPathInSequence)
-    nextAllowedPath = firstPathInSequence
-  }
-
+  const nextAllowedPath = stateMachine.dispatch(GET_NEXT_ALLOWED_PATH, req, journey)
   const isPathAllowed = stateMachine.dispatch(IS_PATH_ALLOWED, req, journey)
 
   // Redirect to nextAllowedPath on invalid path request

--- a/src/web/routes/application/flow-control/middleware/handle-path-request/handle-path-request.test.js
+++ b/src/web/routes/application/flow-control/middleware/handle-path-request/handle-path-request.test.js
@@ -2,9 +2,15 @@ const test = require('tape')
 const sinon = require('sinon')
 const { CONFIRM_URL } = require('../../../paths')
 const { handleRequestForPath } = require('./handle-path-request')
-const { states } = require('../../state-machine')
+const { states, testUtils } = require('../../state-machine')
+
+const { IN_PROGRESS, COMPLETED } = states
+const { buildSessionForJourney } = testUtils
+
+const APPLY = 'apply'
 
 const journey = {
+  name: APPLY,
   steps: [{ path: '/first', next: () => '/second' }, { path: '/second' }],
   pathsInSequence: ['/first', '/second']
 }
@@ -15,26 +21,11 @@ const config = {
   }
 }
 
-test('handleRequestForPath() should set next allowed path to first in sequence if none exists on session', (t) => {
-  const req = {
-    session: {}
-  }
-
-  const res = {}
-  const next = sinon.spy()
-
-  handleRequestForPath(config, journey)(req, res, next)
-
-  t.equal(req.session.nextAllowedStep, '/first', 'it should set next allowed path to first in sequence')
-  t.equal(next.called, true, 'it should call next()')
-  t.end()
-})
-
 test('handleRequestForPath() should redirect to next allowed step if requested path is not allowed', (t) => {
   const req = {
     path: '/second',
     session: {
-      nextAllowedStep: '/first'
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_PROGRESS, nextAllowedPath: '/first' })
     }
   }
 
@@ -53,7 +44,7 @@ test('handleRequestForPath() should call next() if requested path is allowed', (
   const req = {
     path: '/second',
     session: {
-      nextAllowedStep: '/second'
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_PROGRESS, nextAllowedPath: '/second' })
     }
   }
 
@@ -78,7 +69,7 @@ test(`handleRequestForPath() should destroy the session and redirect to first st
     path: '/second',
     session: {
       destroy,
-      state: states.COMPLETED
+      ...buildSessionForJourney({ journeyName: APPLY, state: COMPLETED })
     }
   }
 

--- a/src/web/routes/application/flow-control/middleware/handle-post-redirects.test.js
+++ b/src/web/routes/application/flow-control/middleware/handle-post-redirects.test.js
@@ -1,8 +1,15 @@
 const test = require('tape')
 const sinon = require('sinon')
 const { handlePostRedirects } = require('./handle-post-redirects')
+const { states, testUtils } = require('../state-machine')
+
+const { buildSessionForJourney } = testUtils
+const { IN_PROGRESS } = states
+
+const APPLY = 'apply'
 
 const journey = {
+  name: APPLY,
   steps: [{ path: '/first', next: () => '/second' }, { path: '/second' }]
 }
 
@@ -11,7 +18,9 @@ test('handlePostRedirects() should redirect when no response errors', async (t) 
   const next = sinon.spy()
   const req = {
     method: 'POST',
-    session: {},
+    session: {
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_PROGRESS })
+    },
     path: '/first'
   }
 
@@ -35,7 +44,9 @@ test('handlePostRedirects() should call next() when response errors are present'
     method: 'POST',
     csrfToken: () => {},
     t: () => {},
-    session: {},
+    session: {
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_PROGRESS })
+    },
     path: '/first'
   }
 

--- a/src/web/routes/application/flow-control/middleware/handle-post.js
+++ b/src/web/routes/application/flow-control/middleware/handle-post.js
@@ -23,7 +23,7 @@ const handlePost = (journey, step) => (req, res, next) => {
     }
 
     if (stepInvalidatesReview(step, req.session.claim)) {
-      stateMachine.dispatch(INVALIDATE_REVIEW, req)
+      stateMachine.dispatch(INVALIDATE_REVIEW, req, journey)
     }
 
     stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, journey)

--- a/src/web/routes/application/flow-control/middleware/handle-post.test.js
+++ b/src/web/routes/application/flow-control/middleware/handle-post.test.js
@@ -120,7 +120,7 @@ test('handlePost() adds next allowed step to session', (t) => {
 
   handlePost(journey, step)(req, res, next)
 
-  t.equal(getNextAllowedPathForJourney('apply')(req), '/second', 'it should add next allowed step to session')
+  t.equal(getNextAllowedPathForJourney('apply', req), '/second', 'it should add next allowed step to session')
   t.end()
 })
 

--- a/src/web/routes/application/flow-control/middleware/handle-post.test.js
+++ b/src/web/routes/application/flow-control/middleware/handle-post.test.js
@@ -1,6 +1,9 @@
 const test = require('tape')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
+const { states, testUtils } = require('../state-machine')
+
+const { buildSessionForJourney, getNextAllowedPathForJourney } = testUtils
 
 const defaultValidator = {
   'express-validator': {
@@ -23,7 +26,7 @@ test('handlePost() should add errors and claim to locals if errors exist', (t) =
   })
 
   const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
-  const journey = { steps }
+  const journey = { name: 'apply', steps }
   const step = steps[0]
   const claim = 'claim'
   const req = { body: claim }
@@ -42,7 +45,7 @@ test('handlePost() adds body to the session if no errors exist', (t) => {
   const { handlePost } = proxyquire('./handle-post', { ...defaultValidator })
 
   const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
-  const journey = { steps }
+  const journey = { name: 'apply', steps }
   const step = steps[0]
   const req = {
     session: {
@@ -102,10 +105,13 @@ test('handlePost() adds next allowed step to session', (t) => {
   const { handlePost } = proxyquire('./handle-post', { ...defaultValidator })
 
   const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
-  const journey = { steps }
+  const journey = { name: 'apply', steps, pathsInSequence: ['/first', '/second'] }
   const step = steps[0]
+
   const req = {
-    session: {},
+    session: {
+      ...buildSessionForJourney({ journeyName: 'apply', state: states.IN_PROGRESS, nextAllowedPath: '/first' })
+    },
     path: '/first'
   }
 
@@ -114,7 +120,7 @@ test('handlePost() adds next allowed step to session', (t) => {
 
   handlePost(journey, step)(req, res, next)
 
-  t.equal(req.session.nextAllowedStep, '/second', 'it should add next allowed step to session')
+  t.equal(getNextAllowedPathForJourney('apply')(req), '/second', 'it should add next allowed step to session')
   t.end()
 })
 

--- a/src/web/routes/application/flow-control/state-machine/session-accessors.js
+++ b/src/web/routes/application/flow-control/state-machine/session-accessors.js
@@ -2,10 +2,6 @@ const { pathOr } = require('ramda')
 const { isUndefined } = require('../../../../../common/predicates')
 const { JOURNEYS_KEY, NEXT_ALLOWED_PATH_KEY, STATE_KEY } = require('./keys')
 
-const setNextAllowedPath = (req, journey, path) => {
-  req.session.nextAllowedStep = path
-}
-
 const setJourneySessionProp = (prop) => (req, journey, value) => {
   if (isUndefined(journey)) {
     throw new Error(`No journey defined when trying to set "${prop}" as "${value}"`)
@@ -44,7 +40,6 @@ const getStateFromSession = getJourneySessionProp(STATE_KEY)
 module.exports = {
   setJourneySessionProp,
   getJourneySessionProp,
-  setNextAllowedPath,
   setNextAllowedPathInSession,
   setStateInSession,
   getNextAllowedPathFromSession,

--- a/src/web/routes/application/flow-control/state-machine/state-machine.js
+++ b/src/web/routes/application/flow-control/state-machine/state-machine.js
@@ -3,47 +3,50 @@ const { logger } = require('../../../../logger')
 const states = require('./states')
 const { isPathAllowed } = require('./predicates')
 const { getNextNavigablePath, getNextInReviewPath } = require('./selectors')
-const { setNextAllowedPath } = require('./session-accessors')
+const {
+  setNextAllowedPathInSession,
+  setStateInSession,
+  getNextAllowedPathFromSession,
+  getStateFromSession
+} = require('./session-accessors')
 
 const { IN_PROGRESS, IN_REVIEW, COMPLETED } = states
 
 const stateMachine = {
   [IN_PROGRESS]: {
     getNextPath: (req, journey) => getNextNavigablePath(req.path, req, journey.steps),
-    isPathAllowed: (req, journey) => isPathAllowed(journey.pathsInSequence, req.session.nextAllowedStep, req.path),
-    getNextAllowedPath: (req) => req.session.nextAllowedStep,
-    setNextAllowedPath,
-    incrementNextAllowedPath: (req, journey) => setNextAllowedPath(req, journey, getNextNavigablePath(req.path, req, journey.steps))
+    isPathAllowed: (req, journey) => isPathAllowed(journey.pathsInSequence, getNextAllowedPathFromSession(req, journey), req.path),
+    getNextAllowedPath: getNextAllowedPathFromSession,
+    setNextAllowedPath: setNextAllowedPathInSession,
+    incrementNextAllowedPath: (req, journey) => setNextAllowedPathInSession(req, journey, getNextNavigablePath(req.path, req, journey.steps))
   },
   [IN_REVIEW]: {
     getNextPath: getNextInReviewPath,
-    isPathAllowed: (req, journey) => isPathAllowed(journey.pathsInSequence, req.session.nextAllowedStep, req.path),
-    getNextAllowedPath: (req) => req.session.nextAllowedStep,
-    setNextAllowedPath,
-    incrementNextAllowedPath: (req, journey) => setNextAllowedPath(req, journey, getNextInReviewPath(req)),
-    invalidateReview: (req) => stateMachine.setState(IN_PROGRESS, req)
+    isPathAllowed: (req, journey) => isPathAllowed(journey.pathsInSequence, getNextAllowedPathFromSession(req, journey), req.path),
+    getNextAllowedPath: getNextAllowedPathFromSession,
+    setNextAllowedPath: setNextAllowedPathInSession,
+    incrementNextAllowedPath: (req, journey) => setNextAllowedPathInSession(req, journey, getNextInReviewPath(req)),
+    invalidateReview: (req, journey) => setStateInSession(req, journey, IN_PROGRESS)
   },
   [COMPLETED]: {
     getNextPath: () => CONFIRM_URL,
     isPathAllowed: (req) => req.path === CONFIRM_URL,
     getNextAllowedPath: () => CONFIRM_URL,
-    setNextAllowedPath,
-    incrementNextAllowedPath: (req, journey) => setNextAllowedPath(req, journey, CONFIRM_URL)
+    setNextAllowedPath: setNextAllowedPathInSession,
+    incrementNextAllowedPath: (req, journey) => setNextAllowedPathInSession(req, journey, CONFIRM_URL)
   },
 
-  getState: (req) => {
-    return req.session.hasOwnProperty('state') ? states[req.session.state] : IN_PROGRESS
-  },
+  getState: getStateFromSession,
 
-  setState: (state, req) => {
-    if (stateMachine.getState(req) !== state) {
+  setState: (state, req, journey) => {
+    if (getStateFromSession(req, journey) !== state) {
       logger.info(`State set to ${state}`, { req })
-      req.session.state = state
+      setStateInSession(req, journey, state)
     }
   },
 
   dispatch: (actionType, req, journey, ...args) => {
-    const state = stateMachine.getState(req)
+    const state = getStateFromSession(req, journey)
     const action = stateMachine[state][actionType]
 
     if (typeof action !== 'undefined') {

--- a/src/web/routes/application/flow-control/state-machine/state-machine.test.js
+++ b/src/web/routes/application/flow-control/state-machine/state-machine.test.js
@@ -1,9 +1,10 @@
 const test = require('tape')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-const states = require('./states')
-const actions = require('./actions')
+const { IN_PROGRESS, IN_REVIEW, COMPLETED } = require('./states')
+const { GET_NEXT_PATH, INVALIDATE_REVIEW, SET_NEXT_ALLOWED_PATH, INCREMENT_NEXT_ALLOWED_PATH } = require('./actions')
 const { CHECK_ANSWERS_URL, TERMS_AND_CONDITIONS_URL, CONFIRM_URL } = require('../../paths')
+const { buildSessionForJourney, getStateForJourney, getNextAllowedPathForJourney } = require('./test-utils')
 
 const info = sinon.spy()
 const logger = { info }
@@ -12,79 +13,118 @@ const { stateMachine } = proxyquire('./state-machine', {
   '../../../../logger': { logger }
 })
 
-const { GET_NEXT_PATH, INVALIDATE_REVIEW, SET_NEXT_ALLOWED_PATH, INCREMENT_NEXT_ALLOWED_PATH } = actions
+const APPLY = 'apply'
 
-const journey = {
+const APPLY_JOURNEY = {
+  name: APPLY,
   steps: [
     { path: '/first', next: () => '/second' },
     { path: '/second', next: () => '/third' },
     { path: '/third', isNavigable: () => false, next: () => '/fourth' }
-  ]
+  ],
+  pathsInSequence: ['/first', '/second', '/third']
 }
 
-test(`Dispatching ${GET_NEXT_PATH} should return next property of associated step when no state defined in session`, async (t) => {
-  const req = { method: 'POST', session: {}, path: '/first' }
+const getStateForApplyJourney = getStateForJourney(APPLY)
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, journey), '/second')
+const getNextAllowedPathForApplyJourney = getNextAllowedPathForJourney(APPLY)
+
+test(`Dispatching ${GET_NEXT_PATH} should return next property of associated step when state of ${IN_PROGRESS} defined in session`, (t) => {
+  const req = {
+    session: {
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_PROGRESS })
+    },
+    path: '/first'
+  }
+
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, APPLY_JOURNEY), '/second')
   t.end()
 })
 
-test(`Dispatching ${GET_NEXT_PATH} should return should return next property of associated step when state of ${states.IN_PROGRESS} defined in session`, async (t) => {
-  const req = { method: 'POST', session: { state: states.IN_PROGRESS }, path: '/first' }
+test(`Dispatching ${GET_NEXT_PATH} should return next navigable path when state of ${IN_PROGRESS} defined in session and next step is not navigable`, (t) => {
+  const req = {
+    session: {
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_PROGRESS })
+    },
+    path: '/second'
+  }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, journey), '/second')
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, APPLY_JOURNEY), '/fourth')
   t.end()
 })
 
-test(`Dispatching ${GET_NEXT_PATH} should return next navigable path when state of ${states.IN_PROGRESS} defined in session and next step is not navigable`, async (t) => {
-  const req = { method: 'POST', session: { state: states.IN_PROGRESS }, path: '/second' }
+test(`Dispatching ${GET_NEXT_PATH} should return ${CHECK_ANSWERS_URL} path when state of ${IN_REVIEW} defined in session`, (t) => {
+  const req = {
+    session: {
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_REVIEW })
+    },
+    path: '/first'
+  }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, journey), '/fourth')
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, APPLY_JOURNEY), CHECK_ANSWERS_URL)
   t.end()
 })
 
-test(`Dispatching ${GET_NEXT_PATH} should return ${CHECK_ANSWERS_URL} path when state of ${states.IN_REVIEW} defined in session`, async (t) => {
-  const req = { method: 'POST', session: { state: states.IN_REVIEW }, path: '/first' }
+test(`Dispatching ${GET_NEXT_PATH} should return ${TERMS_AND_CONDITIONS_URL} when state of ${IN_REVIEW} and current path is ${CHECK_ANSWERS_URL}`, (t) => {
+  const req = {
+    session: {
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_REVIEW })
+    },
+    path: CHECK_ANSWERS_URL
+  }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, journey), CHECK_ANSWERS_URL)
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, APPLY_JOURNEY), TERMS_AND_CONDITIONS_URL)
   t.end()
 })
 
-test(`Dispatching ${GET_NEXT_PATH} should return /terms-and-conditions when state of ${states.IN_REVIEW} and current path is ${CHECK_ANSWERS_URL}`, async (t) => {
-  const req = { method: 'POST', session: { state: states.IN_REVIEW }, path: CHECK_ANSWERS_URL }
+test(`Dispatching ${GET_NEXT_PATH} should return ${CONFIRM_URL} path when state of ${COMPLETED} defined in session`, (t) => {
+  const req = {
+    session: {
+      ...buildSessionForJourney({ journeyName: APPLY, state: COMPLETED })
+    },
+    path: '/first'
+  }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, journey), TERMS_AND_CONDITIONS_URL)
+  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, APPLY_JOURNEY), CONFIRM_URL)
   t.end()
 })
 
-test(`Dispatching ${GET_NEXT_PATH} should return confirm path when state of ${states.COMPLETED} defined in session`, async (t) => {
-  const req = { method: 'POST', session: { state: states.COMPLETED }, path: '/first' }
+test(`Dispatching an invalid action should return null`, (t) => {
+  const req = {
+    session: {
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_PROGRESS })
+    },
+    path: '/first'
+  }
 
-  t.equal(stateMachine.dispatch(GET_NEXT_PATH, req, journey), CONFIRM_URL)
+  t.equal(stateMachine.dispatch('INVALID_ACTION', req, APPLY_JOURNEY), null)
   t.end()
 })
 
-test(`Dispatching an invalid action should return null`, async (t) => {
-  const req = { method: 'POST', session: {}, path: '/first' }
+test(`Dispatching ${INVALIDATE_REVIEW} should set state to ${IN_PROGRESS} when state is ${IN_REVIEW}`, (t) => {
+  const req = {
+    session: {
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_REVIEW })
+    },
+    path: '/first'
+  }
 
-  t.equal(stateMachine.dispatch('INVALID_ACTION', req, journey), null)
+  stateMachine.dispatch(INVALIDATE_REVIEW, req, APPLY_JOURNEY)
+  t.equal(getStateForApplyJourney(req), IN_PROGRESS, `sets state to ${IN_PROGRESS}`)
   t.end()
 })
 
-test(`Dispatching ${INVALIDATE_REVIEW} should set state to ${states.IN_PROGRESS} when session.state is ${states.IN_REVIEW}`, async (t) => {
-  const req = { method: 'POST', session: { state: states.IN_REVIEW }, path: '/first' }
+test(`Dispatching ${INVALIDATE_REVIEW} should not update state when session.state is not ${IN_REVIEW}`, (t) => {
+  [IN_PROGRESS, COMPLETED].forEach(state => {
+    const req = {
+      session: {
+        ...buildSessionForJourney({ journeyName: APPLY, state })
+      },
+      path: '/first'
+    }
 
-  stateMachine.dispatch(INVALIDATE_REVIEW, req)
-
-  t.equal(req.session.state, states.IN_PROGRESS, `sets state to ${states.IN_PROGRESS}`)
-  t.end()
-})
-
-test(`Dispatching ${INVALIDATE_REVIEW} should not update state when session.state is not ${states.IN_REVIEW}`, async (t) => {
-  [states.IN_PROGRESS, states.COMPLETED].forEach(state => {
-    const req = { method: 'POST', session: { state }, path: '/first' }
-    stateMachine.dispatch(INVALIDATE_REVIEW, req)
-    t.equal(req.session.state, state, `does not update state for ${state}`)
+    stateMachine.dispatch(INVALIDATE_REVIEW, req, APPLY_JOURNEY)
+    t.equal(getStateForApplyJourney(req), state, `does not update state for ${state}`)
   })
 
   t.end()
@@ -94,11 +134,11 @@ test('setState does not log a change in state if the new state is the same as th
   info.resetHistory()
   const req = {
     session: {
-      state: states.IN_PROGRESS
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_PROGRESS })
     }
   }
 
-  stateMachine.setState(states.IN_PROGRESS, req)
+  stateMachine.setState(IN_PROGRESS, req, APPLY_JOURNEY)
 
   t.equal(info.called, false, 'Should not log a change in state')
   t.end()
@@ -108,59 +148,56 @@ test('setState sets the state if the new state is different from the current sta
   info.resetHistory()
   const req = {
     session: {
-      state: states.IN_PROGRESS
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_PROGRESS })
     }
   }
 
-  stateMachine.setState(states.COMPLETED, req)
-
-  t.equal(req.session.state, states.COMPLETED, 'Should set state')
+  stateMachine.setState(COMPLETED, req, APPLY_JOURNEY)
+  t.equal(getStateForApplyJourney(req), COMPLETED, 'Should set state')
   t.equal(info.called, true, 'Should log a change in state')
   t.end()
 })
 
 test(`Dispatching ${SET_NEXT_ALLOWED_PATH} sets next allowed path in session`, (t) => {
   const appStates = [
-    { state: states.IN_PROGRESS, path: '/name' },
-    { state: states.IN_REVIEW, path: '/check' },
-    { state: states.COMPLETED, path: '/success' }
+    { state: IN_PROGRESS, path: '/name' },
+    { state: IN_REVIEW, path: '/check' },
+    { state: COMPLETED, path: '/success' }
   ]
 
   appStates.forEach(appState => {
     const { state, path } = appState
-
     const req = {
       session: {
-        state
+        ...buildSessionForJourney({ journeyName: APPLY, state })
       }
     }
 
-    stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, journey, path)
-    t.equal(req.session.nextAllowedStep, path, `sets next allowed path in session for ${state}`)
+    stateMachine.dispatch(SET_NEXT_ALLOWED_PATH, req, APPLY_JOURNEY, path)
+    t.equal(getNextAllowedPathForApplyJourney(req), path, `sets next allowed path in session for ${state}`)
   })
 
   t.end()
 })
 
-test(`Dispatching ${INCREMENT_NEXT_ALLOWED_PATH} updates next allowed step in session with the next allowed path in sequence`, (t) => {
+test(`Dispatching ${INCREMENT_NEXT_ALLOWED_PATH} updates next allowed path in session with the next allowed path in sequence`, (t) => {
   const appStates = [
-    { state: states.IN_PROGRESS, path: '/first', expectedNextPath: '/second' },
-    { state: states.IN_REVIEW, path: CHECK_ANSWERS_URL, expectedNextPath: TERMS_AND_CONDITIONS_URL },
-    { state: states.COMPLETED, path: CONFIRM_URL, expectedNextPath: CONFIRM_URL }
+    { state: IN_PROGRESS, path: '/first', expectedNextPath: '/second' },
+    { state: IN_REVIEW, path: CHECK_ANSWERS_URL, expectedNextPath: TERMS_AND_CONDITIONS_URL },
+    { state: COMPLETED, path: CONFIRM_URL, expectedNextPath: CONFIRM_URL }
   ]
 
   appStates.forEach(appState => {
     const { state, path, expectedNextPath } = appState
-
     const req = {
       path,
       session: {
-        state
+        ...buildSessionForJourney({ journeyName: APPLY, state })
       }
     }
 
-    stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, journey)
-    t.equal(req.session.nextAllowedStep, expectedNextPath, `increments next allowed path in session for ${state}`)
+    stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, APPLY_JOURNEY)
+    t.equal(getNextAllowedPathForApplyJourney(req), expectedNextPath, `increments next allowed path in session for ${state}`)
   })
 
   t.end()

--- a/src/web/routes/application/flow-control/state-machine/state-machine.test.js
+++ b/src/web/routes/application/flow-control/state-machine/state-machine.test.js
@@ -1,6 +1,7 @@
 const test = require('tape')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
+const { partial } = require('ramda')
 const { IN_PROGRESS, IN_REVIEW, COMPLETED } = require('./states')
 const { GET_NEXT_PATH, INVALIDATE_REVIEW, SET_NEXT_ALLOWED_PATH, INCREMENT_NEXT_ALLOWED_PATH } = require('./actions')
 const { CHECK_ANSWERS_URL, TERMS_AND_CONDITIONS_URL, CONFIRM_URL } = require('../../paths')
@@ -25,9 +26,9 @@ const APPLY_JOURNEY = {
   pathsInSequence: ['/first', '/second', '/third']
 }
 
-const getStateForApplyJourney = getStateForJourney(APPLY)
+const getStateForApplyJourney = partial(getStateForJourney, [APPLY])
 
-const getNextAllowedPathForApplyJourney = getNextAllowedPathForJourney(APPLY)
+const getNextAllowedPathForApplyJourney = partial(getNextAllowedPathForJourney, [APPLY])
 
 test(`Dispatching ${GET_NEXT_PATH} should return next property of associated step when state of ${IN_PROGRESS} defined in session`, (t) => {
   const req = {

--- a/src/web/routes/application/flow-control/state-machine/test-utils/test-utils.js
+++ b/src/web/routes/application/flow-control/state-machine/test-utils/test-utils.js
@@ -14,9 +14,9 @@ const JOURNEYS_PATH = ['session', JOURNEYS_KEY]
 
 const getJourneyPath = name => [...JOURNEYS_PATH, name]
 
-const getStateForJourney = name => path([...getJourneyPath(name), STATE_KEY])
+const getStateForJourney = (name, req) => path([...getJourneyPath(name), STATE_KEY], req)
 
-const getNextAllowedPathForJourney = (name) => path([...getJourneyPath(name), NEXT_ALLOWED_PATH_KEY])
+const getNextAllowedPathForJourney = (name, req) => path([...getJourneyPath(name), NEXT_ALLOWED_PATH_KEY], req)
 
 module.exports = {
   buildSessionForJourney,

--- a/src/web/routes/application/flow-control/state-machine/test-utils/test-utils.test.js
+++ b/src/web/routes/application/flow-control/state-machine/test-utils/test-utils.test.js
@@ -38,7 +38,7 @@ test('getStateForJourney() gets the state for the correct journey', (t) => {
     }
   }
 
-  const result = getStateForJourney('apply')(req)
+  const result = getStateForJourney('apply', req)
   t.equal(result, 'IN_PROGRESS', 'gets the state for the correct journey')
   t.end()
 })
@@ -59,7 +59,7 @@ test('getNextAllowedPathForJourney() gets the next allowed path for the correct 
     }
   }
 
-  const result = getNextAllowedPathForJourney('apply')(req)
+  const result = getNextAllowedPathForJourney('apply', req)
   t.equal(result, '/name', 'gets the next allowed path for the correct journey')
   t.end()
 })

--- a/src/web/routes/application/steps/address/postcode/postcode.js
+++ b/src/web/routes/application/steps/address/postcode/postcode.js
@@ -46,9 +46,9 @@ const resetPostcodeLookupError = (req) => {
   }
 }
 
-const behaviourForGet = () => (req, res, next) => {
+const behaviourForGet = (config, journey) => (req, res, next) => {
   resetPostcodeLookupError(req)
-  stateMachine.setState(states.IN_PROGRESS, req)
+  stateMachine.setState(states.IN_PROGRESS, req, journey)
   next()
 }
 

--- a/src/web/routes/application/steps/address/postcode/postcode.test.js
+++ b/src/web/routes/application/steps/address/postcode/postcode.test.js
@@ -254,7 +254,7 @@ test(`behaviourForGet() sets state to ${IN_PROGRESS} and resets postcodeLookupEr
   behaviourForGet(config, journey)(req, res, next)
 
   t.equal(next.called, true, 'calls next()')
-  t.equal(getStateForJourney('apply')(req), IN_PROGRESS, `updates state to ${IN_PROGRESS}`)
+  t.equal(getStateForJourney('apply', req), IN_PROGRESS, `updates state to ${IN_PROGRESS}`)
   t.equal(req.session.postcodeLookupError, undefined, 'resets postcodeLookupError')
   t.end()
 })

--- a/src/web/routes/application/steps/address/postcode/postcode.test.js
+++ b/src/web/routes/application/steps/address/postcode/postcode.test.js
@@ -2,7 +2,10 @@ const test = require('tape')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const TEST_FIXTURES = require('./test-fixtures.json')
-const { states } = require('../../../flow-control')
+const { states, testUtils } = require('../../../flow-control')
+
+const { IN_PROGRESS, IN_REVIEW } = states
+const { buildSessionForJourney, getStateForJourney } = testUtils
 
 const errorSpy = sinon.spy()
 const logger = { error: errorSpy }
@@ -234,21 +237,24 @@ test('behaviourForPost() does not reset address in session if validation errors 
   t.end()
 })
 
-test(`behaviourForGet() sets state to ${states.IN_PROGRESS} and resets postcodeLookupError`, (t) => {
+test(`behaviourForGet() sets state to ${IN_PROGRESS} and resets postcodeLookupError`, (t) => {
+  const config = {}
+  const journey = { name: 'apply' }
+
   const req = {
     session: {
-      state: states.IN_REVIEW,
-      postcodeLookupError: true
+      postcodeLookupError: true,
+      ...buildSessionForJourney({ journeyName: 'apply', state: IN_REVIEW })
     }
   }
 
   const res = {}
   const next = sinon.spy()
 
-  behaviourForGet()(req, res, next)
+  behaviourForGet(config, journey)(req, res, next)
 
   t.equal(next.called, true, 'calls next()')
-  t.equal(req.session.state, states.IN_PROGRESS, `updates state to ${states.IN_PROGRESS}`)
+  t.equal(getStateForJourney('apply')(req), IN_PROGRESS, `updates state to ${IN_PROGRESS}`)
   t.equal(req.session.postcodeLookupError, undefined, 'resets postcodeLookupError')
   t.end()
 })

--- a/src/web/routes/application/steps/address/select-address/select-address.test.js
+++ b/src/web/routes/application/steps/address/select-address/select-address.test.js
@@ -1,5 +1,6 @@
 const test = require('tape')
 const sinon = require('sinon')
+const { partial } = require('ramda')
 const { behaviourForGet, behaviourForPost, findAddress, contentSummary } = require('./select-address')
 const { states, testUtils } = require('../../../flow-control')
 
@@ -10,7 +11,7 @@ const CONFIG = {}
 const APPLY = 'apply'
 const JOURNEY = { name: APPLY }
 
-const getNextAllowedPathForApplyJourney = getNextAllowedPathForJourney(APPLY)
+const getNextAllowedPathForApplyJourney = partial(getNextAllowedPathForJourney, [APPLY])
 
 const POSTCODE_LOOKUP_RESULTS = [
   {

--- a/src/web/routes/application/steps/address/select-address/select-address.test.js
+++ b/src/web/routes/application/steps/address/select-address/select-address.test.js
@@ -1,6 +1,16 @@
 const test = require('tape')
 const sinon = require('sinon')
 const { behaviourForGet, behaviourForPost, findAddress, contentSummary } = require('./select-address')
+const { states, testUtils } = require('../../../flow-control')
+
+const { buildSessionForJourney, getNextAllowedPathForJourney } = testUtils
+const { IN_PROGRESS } = states
+
+const CONFIG = {}
+const APPLY = 'apply'
+const JOURNEY = { name: APPLY }
+
+const getNextAllowedPathForApplyJourney = getNextAllowedPathForJourney(APPLY)
 
 const POSTCODE_LOOKUP_RESULTS = [
   {
@@ -40,9 +50,11 @@ test('behaviourForGet() adds addresses to res.locals and resets the address', (t
       postcodeLookupError: false,
       claim: {
         selectedAddress: 'ALAN JEFFERY ENGINEERING, 1, VALLEY ROAD, PLYMOUTH, PL7 1RF'
-      }
+      },
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_PROGRESS })
     }
   }
+
   const res = { locals: {} }
   const next = sinon.spy()
   const expected = [
@@ -58,10 +70,10 @@ test('behaviourForGet() adds addresses to res.locals and resets the address', (t
     }
   ]
 
-  behaviourForGet()(req, res, next)
+  behaviourForGet(CONFIG, JOURNEY)(req, res, next)
 
   t.equal(req.session.claim.selectAddress, undefined, 'should reset the selected address')
-  t.equal(req.session.nextAllowedStep, '/manual-address', 'next allowed step should be manual address')
+  t.equal(getNextAllowedPathForApplyJourney(req), '/manual-address', 'next allowed step should be manual address')
   t.deepEqual(res.locals.addresses, expected, 'adds addresses to res.locals')
   t.equal(res.locals.postcodeLookupError, false, 'sets res.locals.postcodeLookupError')
   t.equal(next.called, true, 'calls next()')
@@ -72,16 +84,20 @@ test('behaviourForGet() handles postcodeLookupErrors', (t) => {
   const req = {
     session: {
       postcodeLookupError: true,
-      claim: {}
+      claim: {
+        selectedAddress: {}
+      },
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_PROGRESS })
     }
   }
+
   const res = { locals: {} }
   const next = sinon.spy()
 
-  behaviourForGet()(req, res, next)
+  behaviourForGet(CONFIG, JOURNEY)(req, res, next)
 
   t.equal(res.locals.postcodeLookupError, true, 'should set res.locals.postcodeLookupError to value on session')
-  t.equal(req.session.nextAllowedStep, '/manual-address', 'next allowed step should be manual address')
+  t.equal(getNextAllowedPathForApplyJourney(req), '/manual-address', 'next allowed step should be manual address')
   t.end()
 })
 

--- a/src/web/routes/application/steps/check-answers/get.js
+++ b/src/web/routes/application/steps/check-answers/get.js
@@ -39,7 +39,7 @@ const getCheckAnswers = (journey) => (req, res) => {
   const getLocalisedChildrensDatesOfBirthRows = getChildrensDatesOfBirthRows(localisation)
   const { steps } = journey
 
-  stateMachine.setState(IN_REVIEW, req)
+  stateMachine.setState(IN_REVIEW, req, journey)
   stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, journey)
 
   res.render('check-answers', {

--- a/src/web/routes/application/steps/common/confirmation-code.js
+++ b/src/web/routes/application/steps/common/confirmation-code.js
@@ -2,10 +2,10 @@ const { CONFIRMATION_CODE_ENTERED_SESSION_PROPERTY } = require('./constants')
 const { stateMachine, states } = require('../../flow-control')
 
 // reset confirmation code and reset state to in progress so that the user is not taken straight back to check answers.
-const handleConfirmationCodeReset = req => {
+const handleConfirmationCodeReset = (req, journey) => {
   req.session[CONFIRMATION_CODE_ENTERED_SESSION_PROPERTY] = false
   req.session.claim.confirmationCode = null
-  stateMachine.setState(states.IN_PROGRESS, req)
+  stateMachine.setState(states.IN_PROGRESS, req, journey)
 }
 
 const getConfirmationCodeChannel = req => req.session.claim.channelForCode

--- a/src/web/routes/application/steps/common/confirmation-code.test.js
+++ b/src/web/routes/application/steps/common/confirmation-code.test.js
@@ -1,23 +1,28 @@
 const test = require('tape')
 
 const { handleConfirmationCodeReset } = require('./confirmation-code')
-const { states } = require('../../flow-control')
+const { states, testUtils } = require('../../flow-control')
+
+const { buildSessionForJourney, getStateForJourney } = testUtils
+const { IN_PROGRESS, IN_REVIEW } = states
 
 test('handleConfirmationCodeReset', (t) => {
+  const journey = { name: 'apply' }
+
   const req = {
     session: {
       confirmationCodeEntered: true,
       claim: {
         confirmationCode: '123456'
       },
-      state: states.IN_REVIEW
+      ...buildSessionForJourney({ journeyName: 'apply', state: IN_REVIEW })
     }
   }
 
-  handleConfirmationCodeReset(req)
+  handleConfirmationCodeReset(req, journey)
 
   t.equal(req.session.confirmationCodeEntered, false)
   t.equal(req.session.claim.confirmationCode, null)
-  t.equal(req.session.state, states.IN_PROGRESS)
+  t.equal(getStateForJourney('apply')(req), IN_PROGRESS)
   t.end()
 })

--- a/src/web/routes/application/steps/common/confirmation-code.test.js
+++ b/src/web/routes/application/steps/common/confirmation-code.test.js
@@ -23,6 +23,6 @@ test('handleConfirmationCodeReset', (t) => {
 
   t.equal(req.session.confirmationCodeEntered, false)
   t.equal(req.session.claim.confirmationCode, null)
-  t.equal(getStateForJourney('apply')(req), IN_PROGRESS)
+  t.equal(getStateForJourney('apply', req), IN_PROGRESS)
   t.end()
 })

--- a/src/web/routes/application/steps/email-address/email-address.js
+++ b/src/web/routes/application/steps/email-address/email-address.js
@@ -20,9 +20,9 @@ const emailAddressHasBeenUpdated = req => req.body.emailAddress !== req.session.
 
 const confirmationChannelIsEmail = req => getConfirmationCodeChannel(req) === EMAIL
 
-const behaviourForPost = () => (req, res, next) => {
+const behaviourForPost = (config, journey) => (req, res, next) => {
   if (confirmationChannelIsEmail(req) && emailAddressHasBeenUpdated(req)) {
-    handleConfirmationCodeReset(req)
+    handleConfirmationCodeReset(req, journey)
   }
 
   next()

--- a/src/web/routes/application/steps/phone-number/phone-number.js
+++ b/src/web/routes/application/steps/phone-number/phone-number.js
@@ -21,9 +21,9 @@ const phoneNumberHasBeenUpdated = req => req.body.phoneNumber !== req.session.cl
 
 const confirmationChannelIsText = req => getConfirmationCodeChannel(req) === TEXT
 
-const behaviourForPost = () => (req, res, next) => {
+const behaviourForPost = (config, journey) => (req, res, next) => {
   if (confirmationChannelIsText(req) && phoneNumberHasBeenUpdated(req)) {
-    handleConfirmationCodeReset(req)
+    handleConfirmationCodeReset(req, journey)
   }
 
   next()

--- a/src/web/routes/application/steps/terms-and-conditions/get.js
+++ b/src/web/routes/application/steps/terms-and-conditions/get.js
@@ -17,7 +17,7 @@ function render (res, req) {
 }
 
 const getTermsAndConditions = (journey) => (req, res) => {
-  stateMachine.setState(states.IN_REVIEW, req)
+  stateMachine.setState(states.IN_REVIEW, req, journey)
 
   render(res, req)
 }

--- a/src/web/routes/application/steps/terms-and-conditions/post.js
+++ b/src/web/routes/application/steps/terms-and-conditions/post.js
@@ -63,7 +63,7 @@ const postTermsAndConditions = (config, journey) => (req, res, next) => {
         req.session.voucherEntitlement = voucherEntitlement
         req.session.claimUpdated = claimUpdated
 
-        stateMachine.setState(COMPLETED, req)
+        stateMachine.setState(COMPLETED, req, journey)
         stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, journey)
         return res.redirect('confirm')
       },

--- a/src/web/routes/application/steps/terms-and-conditions/post.test.js
+++ b/src/web/routes/application/steps/terms-and-conditions/post.test.js
@@ -139,7 +139,7 @@ test(`successful post sets next allowed step to ${CONFIRM_URL} and returned fiel
 
   postTermsAndConditions(config, journey)(req, res, next)
     .then(() => {
-      t.equal(getNextAllowedPathForJourney('apply')(req), CONFIRM_URL, `it sets next allowed step to ${CONFIRM_URL}`)
+      t.equal(getNextAllowedPathForJourney('apply', req), CONFIRM_URL, `it sets next allowed step to ${CONFIRM_URL}`)
       t.equal(req.session.eligibilityStatus, ELIGIBLE, 'it sets the eligibility status to ELIGIBLE')
       t.deepEqual(req.session.voucherEntitlement, { totalVoucherValueInPence: 310 }, 'it sets the voucher entitlement field')
       t.equal(req.session.claimUpdated, true, 'it sets the claim updated field')


### PR DESCRIPTION
This is a breaking change as the shape of the session is being updated. Any active users with active sessions when this update reaches production will encounter errors the next time they make a request from the server:

- Update the state machine to read and write to the correct part of the session depending on the journey associated with the requested route
- Update all code that calls the state machine to pass the journey as an argument
- Update unit tests to reflect the change in session shape