### PR TITLE
HTBHF-2595 prefix constant journey paths

### DIFF
--- a/src/web/routes/application/flow-control/middleware/handle-path-request/handle-path-request.js
+++ b/src/web/routes/application/flow-control/middleware/handle-path-request/handle-path-request.js
@@ -1,4 +1,4 @@
-const { CONFIRM_URL } = require('../../../paths')
+const { CONFIRM_URL, prefixPath } = require('../../../paths')
 const { stateMachine, actions, states } = require('../../state-machine')
 const { stepNotNavigable } = require('./predicates')
 
@@ -6,11 +6,11 @@ const { COMPLETED } = states
 const { IS_PATH_ALLOWED, GET_NEXT_ALLOWED_PATH } = actions
 
 const handleRequestForPath = (journey, step) => (req, res, next) => {
-  const { pathsInSequence } = journey
+  const { pathsInSequence, pathPrefix } = journey
   const firstPathInSequence = pathsInSequence[0]
 
   // Destroy the session on navigating away from CONFIRM_URL
-  if (stateMachine.getState(req, journey) === COMPLETED && req.path !== CONFIRM_URL) {
+  if (stateMachine.getState(req, journey) === COMPLETED && req.path !== prefixPath(pathPrefix, CONFIRM_URL)) {
     req.session.destroy()
     res.clearCookie('lang')
     return res.redirect(firstPathInSequence)

--- a/src/web/routes/application/flow-control/state-machine/selectors/get-next-for-step.js
+++ b/src/web/routes/application/flow-control/state-machine/selectors/get-next-for-step.js
@@ -1,5 +1,5 @@
 const { compose, equals, prop } = require('ramda')
-const { CHECK_ANSWERS_URL } = require('../../../paths')
+const { CHECK_ANSWERS_URL, prefixPath } = require('../../../paths')
 
 const isMatchingPath = path => compose(equals(path), prop('path'))
 
@@ -7,17 +7,18 @@ const isLastStep = (steps, index) => index === steps.length - 1
 
 const getPathFromNextStep = (steps, index) => prop('path', steps[index + 1])
 
-const getNextPathFromSteps = (steps, step) => {
+const getNextPathFromSteps = (journey, step) => {
+  const { steps, pathPrefix } = journey
   const currentPath = step.path
   const index = steps.findIndex(isMatchingPath(currentPath))
-  return isLastStep(steps, index) ? CHECK_ANSWERS_URL : getPathFromNextStep(steps, index)
+  return isLastStep(steps, index) ? prefixPath(pathPrefix, CHECK_ANSWERS_URL) : getPathFromNextStep(steps, index)
 }
 
-const getNextForStep = (req, step, steps) => {
+const getNextForStep = (req, journey, step) => {
   const { next } = step
 
   if (typeof next === 'undefined') {
-    return getNextPathFromSteps(steps, step)
+    return getNextPathFromSteps(journey, step)
   }
 
   if (typeof next !== 'function') {

--- a/src/web/routes/application/flow-control/state-machine/selectors/get-next-for-step.test.js
+++ b/src/web/routes/application/flow-control/state-machine/selectors/get-next-for-step.test.js
@@ -17,20 +17,23 @@ const step3 = {
 const steps = [step1, step2, step3]
 
 test('getNextPathFromSteps() gets the path for the next step in sequence of steps', (t) => {
-  const result = getNextPathFromSteps(steps, step1)
+  const journey = { steps }
+  const result = getNextPathFromSteps(journey, step1)
   t.equal(result, '/second')
   t.end()
 })
 
 test(`getNextPathFromSteps() returns ${CHECK_ANSWERS_URL} for final step`, (t) => {
-  const result = getNextPathFromSteps(steps, step3)
+  const journey = { steps }
+  const result = getNextPathFromSteps(journey, step3)
   t.equal(result, CHECK_ANSWERS_URL)
   t.end()
 })
 
 test('getNextForStep() returns path for next step in sequence if next property is undefined on step', (t) => {
   const req = {}
-  const result = getNextForStep(req, step2, steps)
+  const journey = { steps }
+  const result = getNextForStep(req, journey, step2)
 
   t.equal(result, '/third', 'returns path for next step in sequence if next property is undefined on step')
   t.end()
@@ -39,7 +42,8 @@ test('getNextForStep() returns path for next step in sequence if next property i
 test('getNextForStep() throws error if next is not a function', (t) => {
   const step = { next: 'This is not a function' }
   const req = {}
-  const result = () => getNextForStep(req, step, [...steps, step])
+  const journey = { steps: [...steps, step] }
+  const result = () => getNextForStep(req, journey, step)
 
   t.throws(result, /Next property for step must be a function/, 'throws error if next is not a function')
   t.end()
@@ -48,7 +52,8 @@ test('getNextForStep() throws error if next is not a function', (t) => {
 test('getNextForStep() throws error if result of calling next is not a string', (t) => {
   const step = { next: () => null }
   const req = {}
-  const result = () => getNextForStep(req, step, [...steps, step])
+  const journey = { steps: [...steps, step] }
+  const result = () => getNextForStep(req, journey, step)
 
   t.throws(result, /Next function must return a string starting with a forward slash/, 'throws error if result of calling next is not a string')
   t.end()
@@ -57,7 +62,8 @@ test('getNextForStep() throws error if result of calling next is not a string', 
 test('getNextForStep() throws error if result of calling next does not start with forward slash', (t) => {
   const step = { next: () => 'path-without-forward-slash' }
   const req = {}
-  const result = () => getNextForStep(req, step, [...steps, step])
+  const journey = { steps: [...steps, step] }
+  const result = () => getNextForStep(req, journey, step)
 
   t.throws(result, /Next function must return a string starting with a forward slash/, 'throws error if result of calling next does not start with forward slash')
   t.end()
@@ -66,7 +72,8 @@ test('getNextForStep() throws error if result of calling next does not start wit
 test('getNextForStep() should return the result of calling next', (t) => {
   const step = { next: () => '/the-next-path' }
   const req = {}
-  const result = getNextForStep(req, step, [...steps, step])
+  const journey = { steps: [...steps, step] }
+  const result = getNextForStep(req, journey, step)
 
   t.equals(result, '/the-next-path', 'return the result of calling next')
   t.end()
@@ -76,8 +83,8 @@ test('getNextForStep() passes request as an argument when calling next function'
   const req = { session: { some: '/path' } }
   const next = (req) => req.session.some
   const step = { next }
-
-  const result = getNextForStep(req, step, [...steps, step])
+  const journey = { steps: [...steps, step] }
+  const result = getNextForStep(req, journey, step)
 
   t.equals(result, '/path', 'passes request as an argument when calling next function')
   t.end()

--- a/src/web/routes/application/flow-control/state-machine/selectors/selectors.js
+++ b/src/web/routes/application/flow-control/state-machine/selectors/selectors.js
@@ -1,10 +1,10 @@
-const { CHECK_ANSWERS_URL, TERMS_AND_CONDITIONS_URL } = require('../../../paths')
+const { CHECK_ANSWERS_URL, TERMS_AND_CONDITIONS_URL, prefixPath } = require('../../../paths')
 const { isNextPathNavigable } = require('../predicates')
 const { getNextForStep } = require('./get-next-for-step')
 
 const getStepForPath = (path, steps) => steps.find(step => step.path === path)
 
-const getNextInReviewPath = (req) => req.path === CHECK_ANSWERS_URL ? TERMS_AND_CONDITIONS_URL : CHECK_ANSWERS_URL
+const getNextInReviewPath = (req, prefix) => req.path === prefixPath(prefix, CHECK_ANSWERS_URL) ? prefixPath(prefix, TERMS_AND_CONDITIONS_URL) : prefixPath(prefix, CHECK_ANSWERS_URL)
 
 /**
  * Ask the current step for the next path. Test whether the step matching that path is navigable. If not, ask that step for the next path; repeat.
@@ -13,14 +13,15 @@ const getNextInReviewPath = (req) => req.path === CHECK_ANSWERS_URL ? TERMS_AND_
  * @param steps the steps of the apply journey
  * @returns the path of the next step
  */
-const getNextNavigablePath = (path, req, steps) => {
+const getNextNavigablePath = (path, req, journey) => {
+  const { steps } = journey
   const thisStep = getStepForPath(path, steps)
-  const nextPath = getNextForStep(req, thisStep, steps)
+  const nextPath = getNextForStep(req, journey, thisStep)
   const nextStep = getStepForPath(nextPath, steps)
   if (isNextPathNavigable(nextStep, req)) {
     return nextPath
   }
-  return getNextNavigablePath(nextPath, req, steps)
+  return getNextNavigablePath(nextPath, req, journey)
 }
 
 module.exports = {

--- a/src/web/routes/application/flow-control/state-machine/selectors/selectors.js
+++ b/src/web/routes/application/flow-control/state-machine/selectors/selectors.js
@@ -4,7 +4,11 @@ const { getNextForStep } = require('./get-next-for-step')
 
 const getStepForPath = (path, steps) => steps.find(step => step.path === path)
 
-const getNextInReviewPath = (req, prefix) => req.path === prefixPath(prefix, CHECK_ANSWERS_URL) ? prefixPath(prefix, TERMS_AND_CONDITIONS_URL) : prefixPath(prefix, CHECK_ANSWERS_URL)
+const getNextInReviewPath = (req, prefix) => {
+  const checkAnswersUrl = prefixPath(prefix, CHECK_ANSWERS_URL)
+  const termsAndConditionsUrl = prefixPath(prefix, TERMS_AND_CONDITIONS_URL)
+  return req.path === checkAnswersUrl ? termsAndConditionsUrl : checkAnswersUrl
+}
 
 /**
  * Ask the current step for the next path. Test whether the step matching that path is navigable. If not, ask that step for the next path; repeat.

--- a/src/web/routes/application/flow-control/state-machine/state-machine.js
+++ b/src/web/routes/application/flow-control/state-machine/state-machine.js
@@ -1,4 +1,4 @@
-const { CONFIRM_URL } = require('../../paths')
+const { CONFIRM_URL, prefixPath } = require('../../paths')
 const { logger } = require('../../../../logger')
 const states = require('./states')
 const { isPathAllowed } = require('./predicates')
@@ -14,26 +14,26 @@ const { IN_PROGRESS, IN_REVIEW, COMPLETED } = states
 
 const stateMachine = {
   [IN_PROGRESS]: {
-    getNextPath: (req, journey) => getNextNavigablePath(req.path, req, journey.steps),
+    getNextPath: (req, journey) => getNextNavigablePath(req.path, req, journey),
     isPathAllowed: (req, journey) => isPathAllowed(journey.pathsInSequence, getNextAllowedPathFromSession(req, journey), req.path),
     getNextAllowedPath: getNextAllowedPathFromSession,
     setNextAllowedPath: setNextAllowedPathInSession,
-    incrementNextAllowedPath: (req, journey) => setNextAllowedPathInSession(req, journey, getNextNavigablePath(req.path, req, journey.steps))
+    incrementNextAllowedPath: (req, journey) => setNextAllowedPathInSession(req, journey, getNextNavigablePath(req.path, req, journey))
   },
   [IN_REVIEW]: {
-    getNextPath: getNextInReviewPath,
+    getNextPath: (req, journey) => getNextInReviewPath(req, journey.pathPrefix),
     isPathAllowed: (req, journey) => isPathAllowed(journey.pathsInSequence, getNextAllowedPathFromSession(req, journey), req.path),
     getNextAllowedPath: getNextAllowedPathFromSession,
     setNextAllowedPath: setNextAllowedPathInSession,
-    incrementNextAllowedPath: (req, journey) => setNextAllowedPathInSession(req, journey, getNextInReviewPath(req)),
+    incrementNextAllowedPath: (req, journey) => setNextAllowedPathInSession(req, journey, getNextInReviewPath(req, journey.pathPrefix)),
     invalidateReview: (req, journey) => setStateInSession(req, journey, IN_PROGRESS)
   },
   [COMPLETED]: {
-    getNextPath: () => CONFIRM_URL,
-    isPathAllowed: (req) => req.path === CONFIRM_URL,
-    getNextAllowedPath: () => CONFIRM_URL,
+    getNextPath: (req, journey) => prefixPath(journey.pathPrefix, CONFIRM_URL),
+    isPathAllowed: (req, journey) => req.path === prefixPath(journey.pathPrefix, CONFIRM_URL),
+    getNextAllowedPath: (req, journey) => prefixPath(journey.pathPrefix, CONFIRM_URL),
     setNextAllowedPath: setNextAllowedPathInSession,
-    incrementNextAllowedPath: (req, journey) => setNextAllowedPathInSession(req, journey, CONFIRM_URL)
+    incrementNextAllowedPath: (req, journey) => setNextAllowedPathInSession(req, journey, prefixPath(journey.pathPrefix, CONFIRM_URL))
   },
 
   getState: getStateFromSession,

--- a/src/web/routes/application/steps/check-answers/check-answers.js
+++ b/src/web/routes/application/steps/check-answers/check-answers.js
@@ -1,10 +1,10 @@
 const { getCheckAnswers } = require('./get')
-const { CHECK_ANSWERS_URL } = require('../../paths')
+const { CHECK_ANSWERS_URL, prefixPath } = require('../../paths')
 const { handleRequestForPath } = require('../../flow-control')
 
 const registerCheckAnswersRoutes = (journey, app) => {
   app
-    .route(CHECK_ANSWERS_URL)
+    .route(prefixPath(journey.pathPrefix, CHECK_ANSWERS_URL))
     .get(handleRequestForPath(journey), getCheckAnswers(journey))
 }
 

--- a/src/web/routes/application/steps/check-answers/get.js
+++ b/src/web/routes/application/steps/check-answers/get.js
@@ -2,6 +2,7 @@ const { stateMachine, states, actions } = require('../../flow-control')
 const { getPreviousPath } = require('../../flow-control')
 const { getSummaryListsForSteps } = require('./get-row-data')
 const { getChildrensDatesOfBirthRows } = require('./get-childrens-dates-of-birth-rows')
+const { TERMS_AND_CONDITIONS_URL, prefixPath } = require('../../paths')
 
 const { INCREMENT_NEXT_ALLOWED_PATH } = actions
 const { IN_REVIEW } = states
@@ -37,7 +38,7 @@ const getCheckAnswers = (journey) => (req, res) => {
   const { children } = req.session
   const localisation = pageContent({ translate: req.t })
   const getLocalisedChildrensDatesOfBirthRows = getChildrensDatesOfBirthRows(localisation)
-  const { steps } = journey
+  const { steps, pathPrefix } = journey
 
   stateMachine.setState(IN_REVIEW, req, journey)
   stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, journey)
@@ -46,7 +47,8 @@ const getCheckAnswers = (journey) => (req, res) => {
     ...localisation,
     claimSummaryLists: getSummaryListsForSteps({ req, steps }),
     childrensDatesOfBirthRows: children ? getLocalisedChildrensDatesOfBirthRows(children) : [],
-    previous: getLastNavigablePath(steps, req)
+    previous: getLastNavigablePath(steps, req),
+    termsAndConditionsUrl: prefixPath(pathPrefix, TERMS_AND_CONDITIONS_URL)
   })
 }
 

--- a/src/web/routes/application/steps/confirm/confirm.js
+++ b/src/web/routes/application/steps/confirm/confirm.js
@@ -1,7 +1,7 @@
 const httpStatus = require('http-status-codes')
 const { path, isNil } = require('ramda')
 const { handleRequestForPath } = require('../../flow-control')
-const { CONFIRM_URL } = require('../../paths')
+const { CONFIRM_URL, prefixPath } = require('../../paths')
 const { ELIGIBLE } = require('../common/constants')
 const { wrapError } = require('../../errors')
 
@@ -50,7 +50,7 @@ const getConfirmPage = (req, res, next) => {
 }
 
 const registerConfirmRoute = (journey, app) => {
-  app.get(CONFIRM_URL, handleRequestForPath(journey), getConfirmPage)
+  app.get(prefixPath(journey.pathPrefix, CONFIRM_URL), handleRequestForPath(journey), getConfirmPage)
 }
 
 module.exports = {

--- a/src/web/routes/application/steps/terms-and-conditions/get.js
+++ b/src/web/routes/application/steps/terms-and-conditions/get.js
@@ -1,5 +1,5 @@
 const { stateMachine, states } = require('../../flow-control')
-const { CHECK_ANSWERS_URL } = require('../common/constants')
+const { CHECK_ANSWERS_URL, prefixPath } = require('../../paths')
 
 const pageContent = ({ translate }) => ({
   title: translate('terms-and-conditions.title'),
@@ -8,18 +8,18 @@ const pageContent = ({ translate }) => ({
   termsAndConditions: translate('terms-and-conditions.statement')
 })
 
-function render (res, req) {
+const render = (req, res, journey) => {
   res.render('terms-and-conditions', {
     ...pageContent({ translate: req.t }),
     csrfToken: req.csrfToken(),
-    previous: CHECK_ANSWERS_URL
+    previous: prefixPath(journey.pathPrefix, CHECK_ANSWERS_URL)
   })
 }
 
 const getTermsAndConditions = (journey) => (req, res) => {
   stateMachine.setState(states.IN_REVIEW, req, journey)
 
-  render(res, req)
+  render(req, res, journey)
 }
 
 module.exports = {

--- a/src/web/routes/application/steps/terms-and-conditions/post.js
+++ b/src/web/routes/application/steps/terms-and-conditions/post.js
@@ -30,7 +30,7 @@ const postTermsAndConditions = (config, journey) => (req, res, next) => {
   if (!errors.isEmpty()) {
     res.locals.errors = errors.array()
     res.locals.errorTitleText = req.t('validation:errorTitleText')
-    return render(res, req)
+    return render(req, res, journey)
   }
 
   logger.info('Sending claim', { req })

--- a/src/web/routes/application/steps/terms-and-conditions/terms-and-conditions.js
+++ b/src/web/routes/application/steps/terms-and-conditions/terms-and-conditions.js
@@ -1,7 +1,7 @@
 const { check } = require('express-validator')
 const { getTermsAndConditions } = require('./get')
 const { postTermsAndConditions } = require('./post')
-const { TERMS_AND_CONDITIONS_URL } = require('../../paths')
+const { TERMS_AND_CONDITIONS_URL, prefixPath } = require('../../paths')
 const { translateValidationMessage } = require('../common/translate-validation-message')
 const { handleRequestForPath } = require('../../flow-control')
 
@@ -10,7 +10,7 @@ const validate = [
 ]
 const registerTermsAndConditionsRoutes = (csrfProtection, journey, config, app) => {
   app
-    .route(TERMS_AND_CONDITIONS_URL)
+    .route(prefixPath(journey.pathPrefix, TERMS_AND_CONDITIONS_URL))
     .get(csrfProtection, handleRequestForPath(journey), getTermsAndConditions(journey))
     .post(csrfProtection, validate, handleRequestForPath(journey), postTermsAndConditions(config, journey))
 }

--- a/src/web/views/check-answers.njk
+++ b/src/web/views/check-answers.njk
@@ -40,7 +40,7 @@
 
   {{ govukButton({
       text: buttonText,
-      href: "/terms-and-conditions",
+      href: termsAndConditionsUrl,
       attributes: {
         id: 'submit-button'
       }


### PR DESCRIPTION
Update any uses of constant journey URLs (`CHECK_ANSWERS_URL` / `TERMS_AND_CONDITIONS_URL` / `CONFIRM_URL`) to implement `pathPrefix()`. This ensures these URLs are prefixed with `journey.pathPrefix` where required.

As there is no `pathPrefix` property defined on the apply journey this does not impact the routing of the current apply journey:

- Update signature of state machine selector functions to use `journey` instead of `steps` where `journey.pathPrefix` is required
- Implement `pathPrefix` when referencing constant URLs in route handlers / state machine
- Implement `pathPrefix` when registering routes using constant URLs
- Update template references to constant URLs to implement `pathPrefix`