### PR TITLE
HTBHF-2595 apply path prefix when registering journeys

### DIFF
--- a/src/web/routes/application/register-journeys.js
+++ b/src/web/routes/application/register-journeys.js
@@ -1,13 +1,21 @@
 const csrf = require('csurf')
 const { registerJourneyRoutes } = require('./register-journey-routes')
 const { registerSteps } = require('../register-steps')
-const { CHECK_ANSWERS_URL, TERMS_AND_CONDITIONS_URL, CONFIRM_URL } = require('./paths')
+const { CHECK_ANSWERS_URL, TERMS_AND_CONDITIONS_URL, CONFIRM_URL, prefixPath } = require('./paths')
 
-const getPathsInSequence = (steps) => [...steps.map(step => step.path), CHECK_ANSWERS_URL, TERMS_AND_CONDITIONS_URL, CONFIRM_URL]
+const getPathsInSequence = (prefix, steps) => [
+  ...steps.map(step => prefixPath(prefix, step.path)),
+  prefixPath(prefix, CHECK_ANSWERS_URL),
+  prefixPath(prefix, TERMS_AND_CONDITIONS_URL),
+  prefixPath(prefix, CONFIRM_URL)
+]
+
+const prefixPathForStep = prefix => step => ({ ...step, path: prefixPath(prefix, step.path) })
 
 const registerJourney = (features) => (journey) => {
-  const steps = registerSteps(features, journey.steps)
-  const pathsInSequence = getPathsInSequence(steps)
+  const registeredSteps = registerSteps(features, journey.steps)
+  const steps = registeredSteps.map(prefixPathForStep(journey.pathPrefix))
+  const pathsInSequence = getPathsInSequence(journey.pathPrefix, registeredSteps)
 
   return {
     ...journey,
@@ -24,6 +32,7 @@ const registerJourneys = (journeys) => (config, app) => {
 }
 
 module.exports = {
+  prefixPath,
   getPathsInSequence,
   registerJourney,
   registerJourneys

--- a/src/web/routes/application/register-journeys.test.js
+++ b/src/web/routes/application/register-journeys.test.js
@@ -15,15 +15,24 @@ const steps = [
   }
 ]
 
-test('getPathsInSequence() returns the correct sequence of paths', (t) => {
+test('getPathsInSequence() returns the correct sequence of paths when no prefix is defined', (t) => {
   const expected = ['/first', '/second', '/third', CHECK_ANSWERS_URL, TERMS_AND_CONDITIONS_URL, CONFIRM_URL]
-  const result = getPathsInSequence(steps)
+  const result = getPathsInSequence(undefined, steps)
 
   t.deepEqual(result, expected, 'returns the correct sequence of paths')
   t.end()
 })
 
-test('registerJourney() registers journeys with correct properties', (t) => {
+test('getPathsInSequence() returns the correct sequence of paths when a prefix is defined', (t) => {
+  const prefix = '/my-journey'
+  const expected = ['/my-journey/first', '/my-journey/second', '/my-journey/third', `/my-journey${CHECK_ANSWERS_URL}`, `/my-journey${TERMS_AND_CONDITIONS_URL}`, `/my-journey${CONFIRM_URL}`]
+  const result = getPathsInSequence(prefix, steps)
+
+  t.deepEqual(result, expected, 'returns the correct sequence of paths')
+  t.end()
+})
+
+test('registerJourney() registers journeys with correct properties when no path prefix is defined', (t) => {
   const features = {
     STEP_TWO_ENABLED: false
   }
@@ -37,6 +46,30 @@ test('registerJourney() registers journeys with correct properties', (t) => {
   const expected = {
     steps: [{ path: '/first' }, { path: '/third' }],
     pathsInSequence: ['/first', '/third', CHECK_ANSWERS_URL, TERMS_AND_CONDITIONS_URL, CONFIRM_URL]
+  }
+
+  t.deepEqual(result, expected, 'registers journeys with correct properties')
+  t.end()
+})
+
+test('registerJourney() registers journeys with correct properties when path prefix is defined', (t) => {
+  const features = {
+    STEP_TWO_ENABLED: false
+  }
+
+  const pathPrefix = '/my-journey'
+
+  const journey = {
+    steps,
+    pathPrefix
+  }
+
+  const result = registerJourney(features)(journey)
+
+  const expected = {
+    steps: [{ path: '/my-journey/first' }, { path: '/my-journey/third' }],
+    pathPrefix: '/my-journey',
+    pathsInSequence: ['/my-journey/first', '/my-journey/third', `/my-journey${CHECK_ANSWERS_URL}`, `/my-journey${TERMS_AND_CONDITIONS_URL}`, `/my-journey${CONFIRM_URL}`]
   }
 
   t.deepEqual(result, expected, 'registers journeys with correct properties')


### PR DESCRIPTION
Apply path prefix to journey steps when registering a journey:

- Apply path prefix to the `path` property of each journey step
- Apply path prefix to each path in `journey.pathsInSequence` array