### PR TITLE
Feature/os places language

### DIFF
--- a/src/web/routes/application/steps/address/postcode/os-places.js
+++ b/src/web/routes/application/steps/address/postcode/os-places.js
@@ -1,12 +1,9 @@
 const request = require('request-promise')
 const moment = require('moment')
-const { isNil } = require('ramda')
 const { logger } = require('../../../../../logger')
 
 const REQUEST_TIMEOUT = 5000
 const OS_PLACES_API_PATH = '/places/v1/addresses/postcode'
-const OS_PLACES_LANGUAGES = ['en', 'cy']
-const DEFAULT_LANGUAGE = 'en'
 
 const standardisePostcode = (postcode) => postcode.toUpperCase().replace(/\s/g, '')
 
@@ -14,10 +11,9 @@ const getAddressLookupResults = async (config, postcode, language) => {
   const { OS_PLACES_URI, OS_PLACES_API_KEY } = config.environment
   const standardisedPostcode = standardisePostcode(postcode)
   const requestStartTime = moment()
-  const osPlacesLanguage = getOSPlacesLanguage(language)
 
   const response = await request({
-    uri: `${OS_PLACES_URI}${OS_PLACES_API_PATH}?postcode=${standardisedPostcode}&key=${OS_PLACES_API_KEY}&lr=${osPlacesLanguage}`,
+    uri: `${OS_PLACES_URI}${OS_PLACES_API_PATH}?postcode=${standardisedPostcode}&key=${OS_PLACES_API_KEY}&lr=en`,
     json: true,
     timeout: REQUEST_TIMEOUT
   })
@@ -27,14 +23,6 @@ const getAddressLookupResults = async (config, postcode, language) => {
   logger.debug(`OS Places API request time in seconds: ${requestTimeInSeconds}`)
 
   return response
-}
-
-const getOSPlacesLanguage = (language) => {
-  if (isNil(language)) {
-    return DEFAULT_LANGUAGE
-  }
-
-  return OS_PLACES_LANGUAGES.includes(language.toLowerCase()) ? language.toLowerCase() : DEFAULT_LANGUAGE
 }
 
 const buildGoogleAnalyticsFullUri = (gaBaseUrl, trackingId, result, ipAddress, numberOfResults, sessionId) =>
@@ -63,6 +51,5 @@ module.exports = {
   auditFailedPostcodeLookup,
   auditInvalidPostcodeLookup,
   getAddressLookupResults,
-  standardisePostcode,
-  getOSPlacesLanguage
+  standardisePostcode
 }

--- a/src/web/routes/application/steps/address/postcode/os-places.test.js
+++ b/src/web/routes/application/steps/address/postcode/os-places.test.js
@@ -9,6 +9,7 @@ const {
   auditInvalidPostcodeLookup,
   auditFailedPostcodeLookup,
   standardisePostcode,
+  getOSPlacesLanguage,
   getAddressLookupResults } = proxyquire(
   './os-places', {
     'request-promise': request
@@ -88,10 +89,10 @@ test('standardisePostcode() standardises the postcode', (t) => {
 })
 
 test('getAddressLookupResults() calls os places with the correct arguments', async (t) => {
-  await getAddressLookupResults(config, 'AB1 1AB')
+  await getAddressLookupResults(config, 'AB1 1AB', 'en')
 
   const expectedOSPlacesRequestArgs = {
-    uri: 'localhost:8150/places/v1/addresses/postcode?postcode=AB11AB&key=123',
+    uri: 'localhost:8150/places/v1/addresses/postcode?postcode=AB11AB&key=123&lr=en',
     json: true,
     timeout: 5000
   }
@@ -99,5 +100,33 @@ test('getAddressLookupResults() calls os places with the correct arguments', asy
   t.deepEqual(request.getCall(0).args[0], expectedOSPlacesRequestArgs, 'should call os places with the correct arguments')
 
   request.resetHistory()
+  t.end()
+})
+
+test('getOSPlacesLanguage should return cy when user\'s language is welsh', (t) => {
+  const language = getOSPlacesLanguage('cy')
+
+  t.equal(language, 'cy')
+  t.end()
+})
+
+test('getOSPlacesLanguage should return lowercase when user\'s language is uppercase', (t) => {
+  const language = getOSPlacesLanguage('CY')
+
+  t.equal(language, 'cy')
+  t.end()
+})
+
+test('getOSPlacesLanguage should return en when user\'s language is not English or Welsh', (t) => {
+  const language = getOSPlacesLanguage('de')
+
+  t.equal(language, 'en')
+  t.end()
+})
+
+test('getOSPlacesLanguage should return en when user\'s language is undefined', (t) => {
+  const language = getOSPlacesLanguage(undefined)
+
+  t.equal(language, 'en')
   t.end()
 })

--- a/src/web/routes/application/steps/address/postcode/os-places.test.js
+++ b/src/web/routes/application/steps/address/postcode/os-places.test.js
@@ -9,7 +9,6 @@ const {
   auditInvalidPostcodeLookup,
   auditFailedPostcodeLookup,
   standardisePostcode,
-  getOSPlacesLanguage,
   getAddressLookupResults } = proxyquire(
   './os-places', {
     'request-promise': request
@@ -100,33 +99,5 @@ test('getAddressLookupResults() calls os places with the correct arguments', asy
   t.deepEqual(request.getCall(0).args[0], expectedOSPlacesRequestArgs, 'should call os places with the correct arguments')
 
   request.resetHistory()
-  t.end()
-})
-
-test('getOSPlacesLanguage should return cy when user\'s language is welsh', (t) => {
-  const language = getOSPlacesLanguage('cy')
-
-  t.equal(language, 'cy')
-  t.end()
-})
-
-test('getOSPlacesLanguage should return lowercase when user\'s language is uppercase', (t) => {
-  const language = getOSPlacesLanguage('CY')
-
-  t.equal(language, 'cy')
-  t.end()
-})
-
-test('getOSPlacesLanguage should return en when user\'s language is not English or Welsh', (t) => {
-  const language = getOSPlacesLanguage('de')
-
-  t.equal(language, 'en')
-  t.end()
-})
-
-test('getOSPlacesLanguage should return en when user\'s language is undefined', (t) => {
-  const language = getOSPlacesLanguage(undefined)
-
-  t.equal(language, 'en')
   t.end()
 })

--- a/src/web/routes/application/steps/address/postcode/postcode.js
+++ b/src/web/routes/application/steps/address/postcode/postcode.js
@@ -21,7 +21,7 @@ const behaviourForPost = (config) => async (req, res, next) => {
   req.session.claim = resetAddressOnClaim(req.session.claim)
 
   try {
-    const addressLookupResults = await getAddressLookupResults(config, req.body.postcode)
+    const addressLookupResults = await getAddressLookupResults(config, req.body.postcode, req.language)
 
     req.session.postcodeLookupResults = transformOsPlacesApiResponse(addressLookupResults)
     auditSuccessfulPostcodeLookup(config, req, addressLookupResults.header.totalresults)

--- a/test_versions.properties
+++ b/test_versions.properties
@@ -1,3 +1,3 @@
 # This file is `source`d by the cd pipeline when running tests
 PERF_TESTS_VERSION=1.0.67
-ACCEPTANCE_TESTS_VERSION=0.0.65
+ACCEPTANCE_TESTS_VERSION=0.0.67


### PR DESCRIPTION
Postcode lookup now adds a language query param to the os places uri.
The user's language (from their user agent) will be used if it is either 'en' or 'cy', otherwise the default of 'en' will be used.