### PR TITLE
HTBHF-2598 set default session state for static routes

### DIFF
--- a/src/web/routes/application/steps/check-answers/check-answers.js
+++ b/src/web/routes/application/steps/check-answers/check-answers.js
@@ -1,11 +1,11 @@
 const { getCheckAnswers } = require('./get')
 const { CHECK_ANSWERS_URL, prefixPath } = require('../../paths')
-const { handleRequestForPath } = require('../../flow-control')
+const { configureSessionDetails, handleRequestForPath } = require('../../flow-control')
 
 const registerCheckAnswersRoutes = (journey, app) => {
   app
     .route(prefixPath(journey.pathPrefix, CHECK_ANSWERS_URL))
-    .get(handleRequestForPath(journey), getCheckAnswers(journey))
+    .get(configureSessionDetails(journey), handleRequestForPath(journey), getCheckAnswers(journey))
 }
 
 module.exports = {

--- a/src/web/routes/application/steps/confirm/confirm.js
+++ b/src/web/routes/application/steps/confirm/confirm.js
@@ -1,6 +1,6 @@
 const httpStatus = require('http-status-codes')
 const { path, isNil } = require('ramda')
-const { handleRequestForPath } = require('../../flow-control')
+const { configureSessionDetails, handleRequestForPath } = require('../../flow-control')
 const { CONFIRM_URL, prefixPath } = require('../../paths')
 const { ELIGIBLE } = require('../common/constants')
 const { wrapError } = require('../../errors')
@@ -49,9 +49,8 @@ const getConfirmPage = (req, res, next) => {
   })
 }
 
-const registerConfirmRoute = (journey, app) => {
-  app.get(prefixPath(journey.pathPrefix, CONFIRM_URL), handleRequestForPath(journey), getConfirmPage)
-}
+const registerConfirmRoute = (journey, app) =>
+  app.get(prefixPath(journey.pathPrefix, CONFIRM_URL), configureSessionDetails(journey), handleRequestForPath(journey), getConfirmPage)
 
 module.exports = {
   toPounds,

--- a/src/web/routes/application/steps/terms-and-conditions/terms-and-conditions.js
+++ b/src/web/routes/application/steps/terms-and-conditions/terms-and-conditions.js
@@ -3,7 +3,7 @@ const { getTermsAndConditions } = require('./get')
 const { postTermsAndConditions } = require('./post')
 const { TERMS_AND_CONDITIONS_URL, prefixPath } = require('../../paths')
 const { translateValidationMessage } = require('../common/translate-validation-message')
-const { handleRequestForPath } = require('../../flow-control')
+const { handleRequestForPath, configureSessionDetails } = require('../../flow-control')
 
 const validate = [
   check('agree').equals('agree').withMessage(translateValidationMessage('validation:acceptTermsAndConditions'))
@@ -11,8 +11,9 @@ const validate = [
 const registerTermsAndConditionsRoutes = (csrfProtection, journey, config, app) => {
   app
     .route(prefixPath(journey.pathPrefix, TERMS_AND_CONDITIONS_URL))
-    .get(csrfProtection, handleRequestForPath(journey), getTermsAndConditions(journey))
-    .post(csrfProtection, validate, handleRequestForPath(journey), postTermsAndConditions(config, journey))
+    .all(csrfProtection, configureSessionDetails(journey), handleRequestForPath(journey))
+    .get(getTermsAndConditions(journey))
+    .post(validate, postTermsAndConditions(config, journey))
 }
 
 module.exports = {


### PR DESCRIPTION
Add `configureSessionDetails` middleware to static routes (`/check-answers`, `/terms-and-conditions` and `/confirm`). This avoids errors resulting from uninitialised journeys by ensuring a default journey state is always set in session.

This is handled by default for all other steps in a journey. A better solution would be to register static routes in the same way step routes are registered. This is possible but will take a bit of time (mainly updating unit tests).

There isn't an easy way to write a test for this PR without registering two journeys in the acceptance tests.