### PR TITLE
HTBHF-2482 Added form description to are you pregnant page.

### DIFF
--- a/src/web/routes/application/steps/are-you-pregnant/are-you-pregnant.js
+++ b/src/web/routes/application/steps/are-you-pregnant/are-you-pregnant.js
@@ -31,7 +31,8 @@ const pageContent = ({ translate }) => ({
   no: translate('no'),
   expectedDeliveryDateText: translate('areYouPregnant.expectedDeliveryDateText'),
   expectedDeliveryDateHint: translate('areYouPregnant.expectedDeliveryDateHint', { exampleDate: getExampleDate({ monthOffset: 5 }) }),
-  explanation: translate('areYouPregnant.explanation')
+  explanation: translate('areYouPregnant.explanation'),
+  formDescription: translate('areYouPregnant.formDescription')
 })
 
 const areYouPregnant = {

--- a/src/web/server/locales/cy/common.json
+++ b/src/web/server/locales/cy/common.json
@@ -52,7 +52,8 @@
     "expectedDeliveryDateHint": "Eget velit, {{exampleDate}}",
     "summaryKey": "Egestas sed sed risu?",
     "expectedDeliveryDateSummaryKey": "In nulla posuere",
-    "explanation": "Consectetur adipiscing elit Sceela"
+    "explanation": "Consectetur adipiscing elit Sceela",
+    "formDescription": "Consectetur adipiscing elit Sceela"
   },
   "address": {
     "title": "Urna condimentum mattis?",

--- a/src/web/server/locales/en/common.json
+++ b/src/web/server/locales/en/common.json
@@ -53,7 +53,8 @@
     "expectedDeliveryDateHint": "For example, {{exampleDate}}",
     "summaryKey": "Are you pregnant?",
     "expectedDeliveryDateSummaryKey": "Baby’s due date",
-    "explanation": "We need this to work out how much money you should get."
+    "explanation": "We need this to work out how much money you should get.",
+    "formDescription": "If you’re pregnant you must tell the benefits agency when your baby is born."
   },
   "address": {
     "title": "What’s your address?",

--- a/src/web/views/are-you-pregnant.njk
+++ b/src/web/views/are-you-pregnant.njk
@@ -2,33 +2,38 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "macros/htbhf-date-input.njk" import htbhfDateInput %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "macros/htbhf-form-description.njk" import htbhfFormDescription %}
 
 {% set eddHtml %}
-{{ htbhfDateInput({
-  fieldNamePrefix: "expectedDeliveryDate",
-  claim: claim,
-  errors: errors,
-  legend: {
-    text: expectedDeliveryDateText
-  },
-  hint: {
-    text: expectedDeliveryDateHint
-  }
-}) }}
+  {{ htbhfDateInput({
+    fieldNamePrefix: "expectedDeliveryDate",
+    claim: claim,
+    errors: errors,
+    legend: {
+      text: expectedDeliveryDateText
+    },
+    hint: {
+      text: expectedDeliveryDateHint
+    }
+  }) }}
 {% endset -%}
 
 {% block formContent %}
+  {% call govukFieldset({
+    legend: {
+      text: heading,
+      classes: "govuk-fieldset__legend--xl",
+      isPageHeading: true
+    }
+  }) %}
+
+    {{ htbhfFormDescription(formDescription) }}
+
     {{ govukRadios({
       id: "are-you-pregnant",
       idPrefix: "are-you-pregnant",
       name: "areYouPregnant",
-      fieldset: {
-        legend: {
-          text: heading,
-          isPageHeading: true,
-          classes: "govuk-fieldset__legend--xl"
-        }
-      },
       errorMessage: errors | getErrorForField('areYouPregnant'),
       items: [
         {
@@ -36,8 +41,8 @@
           text: yes,
           checked : claim.areYouPregnant === "yes",
           conditional: {
-            html: eddHtml
-          }
+          html: eddHtml
+        }
         },
         {
           value: "no",
@@ -47,7 +52,10 @@
       ]
     }) }}
 
-  {{ govukInsetText({
-    text: explanation
-  }) }}
+    {{ govukInsetText({
+      text: explanation
+    }) }}
+
+  {% endcall %}
 {% endblock %}
+


### PR DESCRIPTION
- Added a form description to the are you pregnant page.
- The fieldSet options within govukRadios does not support having hint text (hint text is only available for the labels), so the radio buttons were extracted to be wrapped within a govukFieldset block and a htbhfFormDescription is used for the hint. (This is the same pattern we use for manual-address).