### PR TITLE
HTBHF-2482 Remove unnecessary padding from form description macro.

### DIFF
--- a/src/web/views/macros/htbhf-form-description.njk
+++ b/src/web/views/macros/htbhf-form-description.njk
@@ -1,5 +1,5 @@
 {% macro htbhfFormDescription(formDescription) %}
 
-<p class="govuk-body govuk-!-padding-bottom-4">{{formDescription}}</p>
+<p class="govuk-body">{{formDescription}}</p>
 
 {% endmacro %}


### PR DESCRIPTION
The update of govuk frontend to version 3 added a bottom margin to the class `govuk-body`, we therefore now no longer need to add `govuk-!-padding-bottom-4` to htbhfFormDescription. Doing so adds too much spacing (noticeably more than the prototype).