### PR TITLE
HTBHF-2507 destroy session if any COMPLETED journeys exist in session

### DIFF
--- a/src/web/routes/application/flow-control/middleware/handle-path-request/handle-path-request.js
+++ b/src/web/routes/application/flow-control/middleware/handle-path-request/handle-path-request.js
@@ -1,17 +1,15 @@
-const { CONFIRM_URL, prefixPath } = require('../../../paths')
+const { CONFIRM_URL } = require('../../../paths')
 const { stateMachine, actions } = require('../../state-machine')
-const { stepNotNavigable } = require('./predicates')
-const states = require('../../states')
+const { stepNotNavigable, completedJourneyExistsInSession } = require('./predicates')
 
-const { COMPLETED } = states
 const { IS_PATH_ALLOWED, GET_NEXT_ALLOWED_PATH } = actions
 
 const handleRequestForPath = (journey, step) => (req, res, next) => {
-  const { pathsInSequence, pathPrefix } = journey
+  const { pathsInSequence } = journey
   const firstPathInSequence = pathsInSequence[0]
 
-  // Destroy the session on navigating away from CONFIRM_URL
-  if (stateMachine.getState(req, journey) === COMPLETED && req.path !== prefixPath(pathPrefix, CONFIRM_URL)) {
+  // Destroy the session if any COMPLETED journeys exists in session, and path is not a CONFIRM_URL path
+  if (completedJourneyExistsInSession(req) && !req.path.endsWith(CONFIRM_URL)) {
     req.session.destroy()
     res.clearCookie('lang')
     return res.redirect(firstPathInSequence)

--- a/src/web/routes/application/flow-control/middleware/handle-path-request/handle-path-request.test.js
+++ b/src/web/routes/application/flow-control/middleware/handle-path-request/handle-path-request.test.js
@@ -2,10 +2,8 @@ const test = require('tape')
 const sinon = require('sinon')
 const { CONFIRM_URL } = require('../../../paths')
 const { handleRequestForPath } = require('./handle-path-request')
-const states = require('../../states')
+const { IN_PROGRESS, COMPLETED } = require('../../states')
 const { buildSessionForJourney } = require('../../test-utils')
-
-const { IN_PROGRESS, COMPLETED } = states
 
 const APPLY = 'apply'
 
@@ -64,6 +62,34 @@ test(`handleRequestForPath() should destroy the session and redirect to first st
     session: {
       destroy,
       ...buildSessionForJourney({ journeyName: APPLY, state: COMPLETED })
+    }
+  }
+
+  const res = {
+    clearCookie,
+    redirect
+  }
+
+  handleRequestForPath(journey)(req, res, next)
+
+  t.equal(destroy.called, true, 'it should destroy the session')
+  t.equal(clearCookie.calledWith('lang'), true, 'it should clear language preference cookie')
+  t.equal(redirect.calledWith('/first'), true, 'it should call redirect() with correct path')
+  t.end()
+})
+
+test(`handleRequestForPath() destroys the session and redirects to first step in journey when a ${COMPLETED} journey exists in session`, (t) => {
+  const destroy = sinon.spy()
+  const clearCookie = sinon.spy()
+  const redirect = sinon.spy()
+  const next = sinon.spy()
+
+  const req = {
+    path: '/second',
+    session: {
+      destroy,
+      ...buildSessionForJourney({ journeyName: APPLY, state: IN_PROGRESS }),
+      ...buildSessionForJourney({ journeyName: 'another-journey', state: COMPLETED })
     }
   }
 

--- a/src/web/routes/application/flow-control/middleware/handle-path-request/predicates.js
+++ b/src/web/routes/application/flow-control/middleware/handle-path-request/predicates.js
@@ -1,5 +1,15 @@
+const { compose, pluck, map, last, any, equals } = require('ramda')
+const { STATE_KEY } = require('../../keys')
+const { getJourneysFromSession } = require('../../session-accessors')
+const { COMPLETED } = require('../../states')
+
 const stepNotNavigable = (step, req) => step && typeof step.isNavigable === 'function' && !step.isNavigable(req.session)
 
+const getJourneyStatesFromSession = compose(pluck(STATE_KEY), map(last), getJourneysFromSession)
+
+const completedJourneyExistsInSession = compose(any(equals(COMPLETED)), getJourneyStatesFromSession)
+
 module.exports = {
-  stepNotNavigable
+  stepNotNavigable,
+  completedJourneyExistsInSession
 }

--- a/src/web/routes/application/flow-control/middleware/handle-path-request/predicates.test.js
+++ b/src/web/routes/application/flow-control/middleware/handle-path-request/predicates.test.js
@@ -1,6 +1,10 @@
 const test = require('tape')
 const sinon = require('sinon')
-const { stepNotNavigable } = require('./predicates')
+const { stepNotNavigable, completedJourneyExistsInSession } = require('./predicates')
+const testUtils = require('../../test-utils')
+const { IN_PROGRESS, IN_REVIEW, COMPLETED } = require('../../states')
+
+const { buildSessionForJourney } = testUtils
 
 test('stepNotNavigable() returns false if isNavigable prop does not exist', (t) => {
   const step = {
@@ -57,5 +61,41 @@ test('stepNotNavigable() returns false if isNavigable prop returns true', (t) =>
   const result = stepNotNavigable(step, req)
   t.equal(isNavigable.calledWith(session), true, 'calls isNavigable function with session')
   t.equal(result, false, 'returns false if isNavigable prop returns true')
+  t.end()
+})
+
+test('completedJourneyExistsInSession() returns true if completed journey exists in session', (t) => {
+  const req = {
+    session: {
+      ...buildSessionForJourney({ journeyName: 'apply', state: IN_PROGRESS }),
+      ...buildSessionForJourney({ journeyName: 'report-a-change', state: COMPLETED })
+    }
+  }
+
+  const result = completedJourneyExistsInSession(req)
+  t.equal(result, true, 'returns true if completed journey exists in session')
+  t.end()
+})
+
+test('completedJourneyExistsInSession() returns false if completed journey does not exist in session', (t) => {
+  const req = {
+    session: {
+      ...buildSessionForJourney({ journeyName: 'apply', state: IN_PROGRESS }),
+      ...buildSessionForJourney({ journeyName: 'report-a-change', state: IN_REVIEW })
+    }
+  }
+
+  const result = completedJourneyExistsInSession(req)
+  t.equal(result, false, 'returns false if completed journey does not exist in session')
+  t.end()
+})
+
+test('completedJourneyExistsInSession() returns false if no journeys exist in session', (t) => {
+  const req = {
+    session: {}
+  }
+
+  const result = completedJourneyExistsInSession(req)
+  t.equal(result, false, 'returns false if no journeys exist in session')
   t.end()
 })

--- a/src/web/routes/application/flow-control/session-accessors/index.js
+++ b/src/web/routes/application/flow-control/session-accessors/index.js
@@ -2,12 +2,14 @@ const {
   setNextAllowedPathInSession,
   setStateInSession,
   getNextAllowedPathFromSession,
-  getStateFromSession
+  getStateFromSession,
+  getJourneysFromSession
 } = require('./session-accessors')
 
 module.exports = {
   setNextAllowedPathInSession,
   setStateInSession,
   getNextAllowedPathFromSession,
-  getStateFromSession
+  getStateFromSession,
+  getJourneysFromSession
 }

--- a/src/web/routes/application/flow-control/session-accessors/session-accessors.js
+++ b/src/web/routes/application/flow-control/session-accessors/session-accessors.js
@@ -1,6 +1,8 @@
-const { pathOr } = require('ramda')
+const { pathOr, compose, toPairs } = require('ramda')
 const { isUndefined } = require('../../../../../common/predicates')
 const { JOURNEYS_KEY, NEXT_ALLOWED_PATH_KEY, STATE_KEY } = require('../keys')
+
+const JOURNEYS_PATH = ['session', JOURNEYS_KEY]
 
 const setJourneySessionProp = (prop) => (req, journey, value) => {
   if (isUndefined(journey)) {
@@ -19,7 +21,7 @@ const getJourneySessionProp = (prop) => (req, journey) => {
     throw new Error(`No journey defined when trying to get "${prop}"`)
   }
 
-  const sessionPath = ['session', JOURNEYS_KEY, journey.name, prop]
+  const sessionPath = [...JOURNEYS_PATH, journey.name, prop]
   const sessionProp = pathOr(undefined, sessionPath, req)
 
   if (isUndefined(sessionProp)) {
@@ -37,11 +39,14 @@ const getNextAllowedPathFromSession = getJourneySessionProp(NEXT_ALLOWED_PATH_KE
 
 const getStateFromSession = getJourneySessionProp(STATE_KEY)
 
+const getJourneysFromSession = compose(toPairs, pathOr({}, JOURNEYS_PATH))
+
 module.exports = {
   setJourneySessionProp,
   getJourneySessionProp,
   setNextAllowedPathInSession,
   setStateInSession,
   getNextAllowedPathFromSession,
-  getStateFromSession
+  getStateFromSession,
+  getJourneysFromSession
 }

--- a/src/web/routes/application/flow-control/session-accessors/session-accessors.test.js
+++ b/src/web/routes/application/flow-control/session-accessors/session-accessors.test.js
@@ -6,7 +6,8 @@ const {
   setNextAllowedPathInSession,
   setStateInSession,
   getNextAllowedPathFromSession,
-  getStateFromSession
+  getStateFromSession,
+  getJourneysFromSession
 } = require('./session-accessors')
 
 const REPORT_A_CHANGE_JOURNEY = { name: 'report-a-change' }
@@ -187,5 +188,32 @@ test('getStateFromSession() gets state for the correct journey', (t) => {
 
   const result = getStateFromSession(req, REPORT_A_CHANGE_JOURNEY)
   t.equal(result, 'IN_REVIEW', 'gets state for the correct journey')
+  t.end()
+})
+
+test('getJourneysFromSession() returns list of associated journey name and properties from session', (t) => {
+  const req = {
+    session: {
+      [JOURNEYS_KEY]: {
+        apply: {
+          [STATE_KEY]: 'IN_PROGRESS',
+          [NEXT_ALLOWED_PATH_KEY]: '/first'
+        },
+        'report-a-change': {
+          [STATE_KEY]: 'IN_REVIEW',
+          [NEXT_ALLOWED_PATH_KEY]: '/last'
+        }
+      }
+    }
+  }
+
+  const result = getJourneysFromSession(req)
+
+  const expected = [
+    ['apply', { [STATE_KEY]: 'IN_PROGRESS', [NEXT_ALLOWED_PATH_KEY]: '/first' }],
+    ['report-a-change', { [STATE_KEY]: 'IN_REVIEW', [NEXT_ALLOWED_PATH_KEY]: '/last' }]
+  ]
+
+  t.deepEqual(result, expected, 'returns journey name and properties from session')
   t.end()
 })


### PR DESCRIPTION
Fixes a bug where changing between journey routes after completing a journey would not destroy the session.

- Update journey middleware to check the session for **_ANY_** completed journeys
- If a completed journey exists: destroy the session and redirect to the first path of the active journey