### PR TITLE
NO-JIRA tidy environment variables

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -3,8 +3,6 @@ USE_UNSECURE_COOKIE=true
 PORT=8080
 SESSION_SECRET=xxxx-xxxx-xxxx-xxxx-xxxx
 CLAIMANT_SERVICE_URL=http://localhost:8090
-# This is used if you want to test the smoke tests by pointing them to localhost.
-APP_HOST=http://localhost:8080
 NODE_ENV=development
 # Set caching for Nunjucks templates
 NO_CACHE_VIEW_TEMPLATES=false

--- a/sample.env
+++ b/sample.env
@@ -6,9 +6,6 @@ CLAIMANT_SERVICE_URL=http://localhost:8090
 NODE_ENV=development
 # Set caching for Nunjucks templates
 NO_CACHE_VIEW_TEMPLATES=false
-BROWSER_STACK_USER=user1
-BROWSER_STACK_KEY=pass1
-# For compatibility tests, set either:
 APP_BASE_URL=https://temporaryroute.london.cloudapps.digital
 BIN_DIR=./bin/
 LOG_LEVEL='debug'

--- a/sample.env
+++ b/sample.env
@@ -1,21 +1,48 @@
-USE_UNSECURE_COOKIE=true
-# this is the same environment variable as provided by cloud foundry
-PORT=8080
-SESSION_SECRET=xxxx-xxxx-xxxx-xxxx-xxxx
-CLAIMANT_SERVICE_URL=http://localhost:8090
+# Node
+
 NODE_ENV=development
-# Set caching for Nunjucks templates
-NO_CACHE_VIEW_TEMPLATES=false
-APP_BASE_URL=https://temporaryroute.london.cloudapps.digital
+
+
+# App
+
+APP_VERSION=local
+APP_BASE_URL=https://localhost:8080
 BIN_DIR=./bin/
+CLAIMANT_SERVICE_URL=http://localhost:8090
 LOG_LEVEL='debug'
+# Cache setting for Nunjucks templates
+NO_CACHE_VIEW_TEMPLATES=false
+# PORT is provided by Cloud Foundry by default
+PORT=8080
+
+
+# Session
+
+SESSION_SECRET=xxxx-xxxx-xxxx-xxxx-xxxx
+# Set to true for accessing session cookies during testing
+USE_UNSECURE_COOKIE=true
+
+
+# Maintenance
+
 # maintenance mode is optional and defaults to false
 MAINTENANCE_MODE=false
 # date format must be HH:mm DD/MM/YYYY, only used if MAINTENANCE_MODE is true
 SERVICE_AVAILABLE_DATE=14:30 02/03/2019
-APP_VERSION=local
-NOTIFY_API_KEY=notify-test-key-replace-with-real-one
-OS_PLACES_API_KEY=os-places-api-key
+
+
+# Notify
+
+NOTIFY_API_KEY=xxxx-xxxx-xxxx-xxxx-xxxx
+
+
+# OS Places
+
+OS_PLACES_API_KEY=xxxx-xxxx-xxxx-xxxx-xxxx
 OS_PLACES_URI=http://localhost:8150
+
+
+# Analytics
+
 GA_TRACKING_ID=UA-133839203-1
 GOOGLE_ANALYTICS_URI=http://localhost:8150/collect

--- a/src/test/a11y/paths.js
+++ b/src/test/a11y/paths.js
@@ -1,7 +1,6 @@
 require('dotenv').config()
 
-const APP_BASE_URL = process.env.APP_BASE_URL || ''
-const BASE_URL = APP_BASE_URL === '' ? `http://localhost:${process.env.PORT}` : APP_BASE_URL
+const BASE_URL = process.env.APP_BASE_URL || `http://localhost:${process.env.PORT}`
 
 const URLS = {
   DO_YOU_LIVE_IN_SCOTLAND: `${BASE_URL}/scotland`,


### PR DESCRIPTION
- Simplify base URL environment variables
- Remove Browserstack environment variables (not used in UI)
- Create structure for environment variables in `sample.env`