### PR TITLE
HTBHF-2490 fix decision redirect

### DIFF
--- a/src/web/routes/application/steps/terms-and-conditions/post.js
+++ b/src/web/routes/application/steps/terms-and-conditions/post.js
@@ -11,7 +11,7 @@ const { createRequestBody } = require('./create-request-body')
 const { isErrorStatusCode } = require('./predicates')
 const { NO_ELIGIBILITY_STATUS_MESSAGE } = require('./constants')
 const { render } = require('./get')
-const { DECISION_URL } = require('../../paths')
+const { DECISION_URL, prefixPath } = require('../../paths')
 
 const { COMPLETED } = states
 const { INCREMENT_NEXT_ALLOWED_PATH } = actions
@@ -26,7 +26,7 @@ const handleErrorResponse = (body, response) => {
 
 const postTermsAndConditions = (config, journey) => (req, res, next) => {
   const errors = validationResult(req)
-  const { steps } = journey
+  const { steps, pathPrefix } = journey
 
   if (!errors.isEmpty()) {
     res.locals.errors = errors.array()
@@ -66,7 +66,7 @@ const postTermsAndConditions = (config, journey) => (req, res, next) => {
 
         stateMachine.setState(COMPLETED, req, journey)
         stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, journey)
-        return res.redirect(DECISION_URL)
+        return res.redirect(prefixPath(pathPrefix, DECISION_URL))
       },
       (error) => {
         next(wrapError({

--- a/src/web/routes/application/steps/terms-and-conditions/post.test.js
+++ b/src/web/routes/application/steps/terms-and-conditions/post.test.js
@@ -125,6 +125,7 @@ test('unsuccessful post calls next with error', async (t) => {
 test(`successful post sets next allowed step to ${DECISION_URL} and sets returned fields in session`, async (t) => {
   const journey = {
     name: 'apply',
+    pathPrefix: '/apply',
     steps: []
   }
 
@@ -144,11 +145,11 @@ test(`successful post sets next allowed step to ${DECISION_URL} and sets returne
 
   postTermsAndConditions(CONFIG, journey)(req, res, next)
     .then(() => {
-      t.equal(getNextAllowedPathForJourney('apply', req), DECISION_URL, `it sets next allowed step to ${DECISION_URL}`)
+      t.equal(getNextAllowedPathForJourney('apply', req), `/apply${DECISION_URL}`, `it sets next allowed step to ${DECISION_URL}`)
       t.equal(req.session.eligibilityStatus, ELIGIBLE, 'it sets the eligibility status to ELIGIBLE')
       t.deepEqual(req.session.voucherEntitlement, { totalVoucherValueInPence: 310 }, 'it sets the voucher entitlement field')
       t.equal(req.session.claimUpdated, true, 'it sets the claim updated field')
-      t.equal(redirect.called, true, 'it calls redirect()')
+      t.equal(redirect.calledWith(`/apply${DECISION_URL}`), true, 'it calls redirect() with the correct URL')
       t.equal(render.called, false, 'it does not call render()')
       t.end()
     })

--- a/test_versions.properties
+++ b/test_versions.properties
@@ -1,3 +1,3 @@
 # This file is `source`d by the cd pipeline when running tests
 PERF_TESTS_VERSION=1.0.67
-ACCEPTANCE_TESTS_VERSION=0.0.70
+ACCEPTANCE_TESTS_VERSION=0.0.71


### PR DESCRIPTION
Fix bug where redirect to `/decision` page did not include journey path prefix URL segment. This resulted in always redirecting to the `nextAllowedPath` in the apply journey.

Also incremented acceptance tests version to latest release.