### PR TITLE
HTBHF-2675 Add the claim as well as request body to res.locals in error cases

### DIFF
--- a/src/web/routes/application/flow-control/middleware/handle-post.js
+++ b/src/web/routes/application/flow-control/middleware/handle-post.js
@@ -13,7 +13,10 @@ const handlePost = (journey, step) => (req, res, next) => {
 
     if (!errors.isEmpty()) {
       res.locals.errors = errors.array()
-      res.locals.claim = req.body
+      res.locals.claim = {
+        ...res.locals.claim,
+        ...req.body
+      }
       return next()
     }
 

--- a/src/web/routes/application/flow-control/middleware/handle-post.test.js
+++ b/src/web/routes/application/flow-control/middleware/handle-post.test.js
@@ -27,15 +27,15 @@ test('handlePost() should add errors and claim to locals if errors exist', (t) =
   const steps = [{ path: '/first', next: () => '/second' }, { path: '/second' }]
   const journey = { name: 'apply', steps }
   const step = steps[0]
-  const claim = 'claim'
-  const req = { body: claim }
-  const res = { locals: {} }
+  const claim = { firstName: 'Joe', lastName: 'Bloggs' }
+  const req = { body: { lastName: '' } }
+  const res = { locals: { claim } }
   const next = sinon.spy()
 
   handlePost(journey, step)(req, res, next)
 
   t.deepEqual(res.locals.errors, errors, 'it should add errors to locals')
-  t.deepEqual(res.locals.claim, claim, 'it should add claim to locals')
+  t.deepEqual(res.locals.claim, { firstName: 'Joe', lastName: '' }, 'it should override claim properties with body properties')
   t.equal(next.called, true, 'it should call next()')
   t.end()
 })


### PR DESCRIPTION
In the case of a validation error on form data, we have been populating the response body only with the content from the request (so, e.g. if there was a problem with the NINO the response would include the NINO from the request, not the NINO stored in the session - if any). This change adds values form the claim in the session as well - in case the form displays information from the claim as well as data entry fields.