### PR TITLE
HTBHF-2014 remove extraneous error check

### DIFF
--- a/src/web/routes/application/steps/decision/decision.js
+++ b/src/web/routes/application/steps/decision/decision.js
@@ -1,13 +1,9 @@
-const httpStatus = require('http-status-codes')
-const { path, isNil } = require('ramda')
+const { path } = require('ramda')
 const { configureSessionDetails, handleRequestForPath } = require('../../flow-control')
 const { DECISION_URL, prefixPath } = require('../../paths')
 const { ELIGIBLE } = require('../common/constants')
-const { wrapError } = require('../../errors')
 
 const toPounds = pence => (parseInt(pence, 10) / 100).toFixed(2)
-
-const isNilOrLteZero = value => isNil(value) || value <= 0
 
 const getTitle = req => {
   if (path(['session', 'claimUpdated'], req) === true) {
@@ -17,18 +13,9 @@ const getTitle = req => {
   return req.t('decision.newClaimTitle')
 }
 
-const getDecisionPage = (req, res, next) => {
+const getDecisionPage = (req, res) => {
   if (req.session.eligibilityStatus === ELIGIBLE) {
     const totalVoucherValueInPence = path(['session', 'voucherEntitlement', 'totalVoucherValueInPence'], req)
-
-    if (isNilOrLteZero(totalVoucherValueInPence)) {
-      const errorMessage = `Invalid voucher value in pence returned from claimant service for ${ELIGIBLE} status: ${totalVoucherValueInPence}`
-      return next(wrapError({
-        cause: new Error(errorMessage),
-        message: errorMessage,
-        statusCode: httpStatus.INTERNAL_SERVER_ERROR
-      }))
-    }
 
     return res.render('decision', {
       title: getTitle(req),
@@ -54,7 +41,6 @@ const registerDecisionRoute = (journey, app) =>
 
 module.exports = {
   toPounds,
-  isNilOrLteZero,
   registerDecisionRoute,
   getDecisionPage,
   getTitle

--- a/src/web/routes/application/steps/decision/decision.test.js
+++ b/src/web/routes/application/steps/decision/decision.test.js
@@ -1,28 +1,12 @@
 const test = require('tape')
 const sinon = require('sinon')
-const proxyquire = require('proxyquire')
 const { ELIGIBLE } = require('../common/constants')
-
-const wrapError = sinon.spy()
-
-const { toPounds, isNilOrLteZero, getDecisionPage } = proxyquire('./decision', {
-  '../../errors': { wrapError }
-})
-
-const { getTitle } = require('./decision')
+const { toPounds, getTitle, getDecisionPage } = require('./decision')
 
 test('toPounds() converts value in pence to pounds', (t) => {
   const expected = '3.10'
   const result = toPounds(310)
   t.equal(result, expected, 'gets voucher value in pence and converts to pounds')
-  t.end()
-})
-
-test('isNilOrLteZero()', (t) => {
-  t.equal(isNilOrLteZero(0), true, 'returns true for zero')
-  t.equal(isNilOrLteZero(-3), true, 'returns true for an integer less than zero')
-  t.equal(isNilOrLteZero(null), true, 'returns true for null')
-  t.equal(isNilOrLteZero(3), false, 'returns false for a positive integer')
   t.end()
 })
 
@@ -69,30 +53,6 @@ test(`getDecisionPage() calls render with unsuccessful-application template when
   getDecisionPage(req, res)
 
   t.equal(render.calledWith('unsuccessful-application'), true, 'calls render with unsuccessful-application template')
-  t.end()
-})
-
-test('getDecisionPage() calls next with error when invalid voucher value in pence stored in session', (t) => {
-  const req = {
-    t: () => {},
-    session: {
-      eligibilityStatus: ELIGIBLE,
-      voucherEntitlement: {
-        totalVoucherValueInPence: -3
-      }
-    }
-  }
-
-  const res = {}
-  const next = sinon.spy()
-
-  getDecisionPage(req, res, next)
-
-  const expectedErrorMessage = 'Invalid voucher value in pence returned from claimant service for ELIGIBLE status: -3'
-  const actualErrorMessage = wrapError.getCall(0).args[0].message
-
-  t.equal(next.called, true, 'it calls next()')
-  t.equal(actualErrorMessage, expectedErrorMessage, 'it throws an error')
   t.end()
 })
 


### PR DESCRIPTION
Tidying up the `/decision` route handler in preparation for "receive my decision" epic.

Removed error check that is the domain of the claimant service. UI should not need to validate data it receives from an API.