### PR TITLE
HTBHF-2683 ignore claim updated flag in claimant service response

### DIFF
--- a/src/web/routes/application/steps/decision/decision.js
+++ b/src/web/routes/application/steps/decision/decision.js
@@ -5,34 +5,24 @@ const { ELIGIBLE } = require('../common/constants')
 
 const toPounds = pence => (parseInt(pence, 10) / 100).toFixed(2)
 
-const getTitle = req => {
-  if (path(['session', 'claimUpdated'], req) === true) {
-    return req.t('decision.updatedClaimTitle')
-  }
-
-  return req.t('decision.newClaimTitle')
-}
-
 const getDecisionPage = (req, res) => {
   if (req.session.eligibilityStatus === ELIGIBLE) {
     const totalVoucherValueInPence = path(['session', 'voucherEntitlement', 'totalVoucherValueInPence'], req)
 
     return res.render('decision', {
-      title: getTitle(req),
-      subTitle: req.t('decision.subTitle',
-        {
-          totalVoucherValue: toPounds(totalVoucherValueInPence),
-          totalVoucherValueForFourWeeks: toPounds(totalVoucherValueInPence * 4)
-        })
+      title: req.t('decision.title'),
+      subTitle: req.t('decision.subTitle', {
+        totalVoucherValue: toPounds(totalVoucherValueInPence),
+        totalVoucherValueForFourWeeks: toPounds(totalVoucherValueInPence * 4)
+      })
     })
   }
 
-  const eligibilityStatus = req.session.eligibilityStatus.toLowerCase()
   return res.render('unsuccessful-application', {
     title: req.t('unsuccessfulApplication.title'),
     subTitle: req.t('unsuccessfulApplication.subTitle'),
     heading: req.t('unsuccessfulApplication.title'),
-    eligibilityStatus
+    eligibilityStatus: req.session.eligibilityStatus.toLowerCase()
   })
 }
 
@@ -42,6 +32,5 @@ const registerDecisionRoute = (journey, app) =>
 module.exports = {
   toPounds,
   registerDecisionRoute,
-  getDecisionPage,
-  getTitle
+  getDecisionPage
 }

--- a/src/web/routes/application/steps/decision/decision.test.js
+++ b/src/web/routes/application/steps/decision/decision.test.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 const sinon = require('sinon')
 const { ELIGIBLE } = require('../common/constants')
-const { toPounds, getTitle, getDecisionPage } = require('./decision')
+const { toPounds, getDecisionPage } = require('./decision')
 
 test('toPounds() converts value in pence to pounds', (t) => {
   const expected = '3.10'
@@ -53,45 +53,5 @@ test(`getDecisionPage() calls render with unsuccessful-application template when
   getDecisionPage(req, res)
 
   t.equal(render.calledWith('unsuccessful-application'), true, 'calls render with unsuccessful-application template')
-  t.end()
-})
-
-test('getTitle() returns ’Application successful’ when the claimUpdated field is false', (t) => {
-  const req = {
-    t: (name) => { return name === 'decision.updatedClaimTitle' ? 'Application Updated' : 'Application successful' },
-    session: {
-      claimUpdated: false
-    }
-  }
-
-  const result = getTitle(req)
-
-  t.equal(result, 'Application successful', 'getTitle returns ’Application successful’')
-  t.end()
-})
-
-test('getTitle() returns ’Application successful’ when the claimUpdated field is undefined', (t) => {
-  const req = {
-    t: (name) => { return name === 'decision.updatedClaimTitle' ? 'Application Updated' : 'Application successful' },
-    session: {}
-  }
-
-  const result = getTitle(req)
-
-  t.equal(result, 'Application successful', 'getTitle returns ’Application successful’')
-  t.end()
-})
-
-test('getTitle() returns ’Application Updated’ when the claimUpdated field is true', (t) => {
-  const req = {
-    t: (name) => { return name === 'decision.updatedClaimTitle' ? 'Application Updated' : 'Application successful' },
-    session: {
-      claimUpdated: true
-    }
-  }
-
-  const result = getTitle(req)
-
-  t.equal(result, 'Application Updated', 'getTitle returns ’Application Updated’')
   t.end()
 })

--- a/src/web/routes/application/steps/terms-and-conditions/post.js
+++ b/src/web/routes/application/steps/terms-and-conditions/post.js
@@ -50,7 +50,7 @@ const postTermsAndConditions = (config, journey) => (req, res, next) => {
     .then(
       (response) => {
         const responseBody = path(['body'], response)
-        const { eligibilityStatus, voucherEntitlement, claimUpdated } = responseBody
+        const { eligibilityStatus, voucherEntitlement } = responseBody
 
         if (!eligibilityStatus) {
           return next(wrapError({
@@ -62,7 +62,6 @@ const postTermsAndConditions = (config, journey) => (req, res, next) => {
 
         req.session.eligibilityStatus = eligibilityStatus
         req.session.voucherEntitlement = voucherEntitlement
-        req.session.claimUpdated = claimUpdated
 
         stateMachine.setState(COMPLETED, req, journey)
         stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, journey)

--- a/src/web/routes/application/steps/terms-and-conditions/post.test.js
+++ b/src/web/routes/application/steps/terms-and-conditions/post.test.js
@@ -32,8 +32,7 @@ const SUCCESSFUL_RESPONSE = {
     eligibilityStatus: ELIGIBLE,
     voucherEntitlement: {
       totalVoucherValueInPence: 310
-    },
-    claimUpdated: true
+    }
   }
 }
 
@@ -148,7 +147,6 @@ test(`successful post sets next allowed step to ${DECISION_URL} and sets returne
       t.equal(getNextAllowedPathForJourney('apply', req), `/apply${DECISION_URL}`, `it sets next allowed step to ${DECISION_URL}`)
       t.equal(req.session.eligibilityStatus, ELIGIBLE, 'it sets the eligibility status to ELIGIBLE')
       t.deepEqual(req.session.voucherEntitlement, { totalVoucherValueInPence: 310 }, 'it sets the voucher entitlement field')
-      t.equal(req.session.claimUpdated, true, 'it sets the claim updated field')
       t.equal(redirect.calledWith(`/apply${DECISION_URL}`), true, 'it calls redirect() with the correct URL')
       t.equal(render.called, false, 'it does not call render()')
       t.end()

--- a/src/web/server/locales/cy/common.json
+++ b/src/web/server/locales/cy/common.json
@@ -128,8 +128,7 @@
     "statement": "Risus sed vulputate odio ut enim blandit volutpat maecenas volutpat."
   },
   "decision": {
-    "newClaimTitle": "Ullamcorper malesuada",
-    "updatedClaimTitle": "Ullamcorper faucibus",
+    "title": "Ullamcorper malesuada",
     "subTitle": "Dui faucibus in ornare\n£{{totalVoucherValue}} ut labore. Eget felis eget nunc\nlobortis mattis {{totalVoucherValueForFourWeeks}}."
   },
   "unsuccessfulApplication": {

--- a/src/web/server/locales/en/common.json
+++ b/src/web/server/locales/en/common.json
@@ -131,8 +131,7 @@
     "statement": "I confirm that I’ve read and will comply with these terms and conditions."
   },
   "decision": {
-    "newClaimTitle": "Application successful",
-    "updatedClaimTitle": "Application updated",
+    "title": "Application successful",
     "subTitle": "You’re entitled to\n<strong>£{{totalVoucherValue}}</strong> a week. Your first payment\nwill be <strong>£{{totalVoucherValueForFourWeeks}}</strong>."
   },
   "unsuccessfulApplication": {

--- a/test_versions.properties
+++ b/test_versions.properties
@@ -1,3 +1,3 @@
 # This file is `source`d by the cd pipeline when running tests
 PERF_TESTS_VERSION=1.0.67
-ACCEPTANCE_TESTS_VERSION=0.0.72
+ACCEPTANCE_TESTS_VERSION=0.0.73


### PR DESCRIPTION
The default "apply" journey no longer has a requirement to handle updated claims. The UI now ignores the `claimUpdated` flag in the claimant service response.