### PR TITLE
HTBHF-2675 Moved adding count of matching addresses from nunjucks int…

### DIFF
--- a/src/web/routes/application/steps/address/select-address/select-address.js
+++ b/src/web/routes/application/steps/address/select-address/select-address.js
@@ -35,11 +35,16 @@ const resetAddressState = (req) => {
 }
 
 const getAddressDataFromSession = (req, addressId) => {
-  const addresses = req.session.postcodeLookupResults.map(buildAddressOption(addressId))
+  const results = req.session.postcodeLookupResults.map(buildAddressOption(addressId))
+  const addressCount = {
+    value: '',
+    text: req.t('address.numberOfAddressesFound', { count: results.length }),
+    disabled: true,
+    selected: !results.some(addr => addr.selected)
+  }
+  const addresses = results.length === 0 ? [] : [addressCount, ...results]
   return {
-    addresses,
-    addressSelected: addresses.some(addr => addr.selected),
-    numberOfAddressesFound: req.t('address.numberOfAddressesFound', { count: addresses.length })
+    addresses
   }
 }
 

--- a/src/web/views/select-address-form.njk
+++ b/src/web/views/select-address-form.njk
@@ -28,12 +28,6 @@
             <h2 class="govuk-heading-m">{{ addressNotFound }}</h2>
         {% else %}
 
-            {% set isSelected = false if addressSelected else true %}
-
-            {% set firstOption = { text: numberOfAddressesFound, value: "", disabled: true, selected: isSelected } %}
-
-            {% set newLength = addresses.unshift(firstOption) %}
-
             {{ govukSelect({
                 id: "address-results",
                 name: "selectedAddress",


### PR DESCRIPTION
I hadn't realised that Nunjucks would cache the select-address form between posts, so have moved the insertion of the number of matching addresses into javascript from the nunjucks template.