### PR TITLE
HTBHF-1942 determine decision status for failure scenarios

### DIFF
--- a/src/web/routes/application/steps/decision/get-decision-status.js
+++ b/src/web/routes/application/steps/decision/get-decision-status.js
@@ -1,0 +1,26 @@
+const { equals, compose, prop, cond, always } = require('ramda')
+
+const SUCCESS = 'success'
+const FAIL = 'fail'
+const PENDING = 'pending'
+
+const outcomeNotMatched = equals('not_matched')
+const outcomeNotConfirmed = equals('not_confirmed')
+
+const identityOutcomeNotMatched = compose(outcomeNotMatched, prop('identityOutcome'))
+const eligibilityOutcomeNotConfirmed = compose(outcomeNotConfirmed, prop('eligibilityOutcome'))
+
+const isFailure = result => identityOutcomeNotMatched(result) || eligibilityOutcomeNotConfirmed(result)
+
+const getDecisionStatus = cond([
+  [isFailure, always(FAIL)]
+])
+
+module.exports = {
+  statuses: {
+    SUCCESS,
+    FAIL,
+    PENDING
+  },
+  getDecisionStatus
+}

--- a/src/web/routes/application/steps/decision/get-decision-status.test.js
+++ b/src/web/routes/application/steps/decision/get-decision-status.test.js
@@ -1,0 +1,71 @@
+const test = require('tape')
+const { statuses, getDecisionStatus } = require('./get-decision-status')
+
+const { FAIL } = statuses
+
+const SUCCESSFUL_RESULT = {
+  deathVerificationFlag: 'n/a',
+  mobilePhoneMatch: 'matched',
+  emailAddressMatch: 'matched',
+  addressLine1Match: 'matched',
+  postcodeMatch: 'matched',
+  pregnantChildDOBMatch: 'not_supplied',
+  qualifyingBenefits: 'universal_credit',
+  identityOutcome: 'matched',
+  eligibilityOutcome: 'confirmed'
+}
+
+const PENDING_RESULT = {
+  deathVerificationFlag: 'n/a',
+  mobilePhoneMatch: 'not_matched',
+  emailAddressMatch: 'not_matched',
+  addressLine1Match: 'matched',
+  postcodeMatch: 'matched',
+  pregnantChildDOBMatch: 'not_supplied',
+  qualifyingBenefits: 'universal_credit',
+  identityOutcome: 'matched',
+  eligibilityOutcome: 'confirmed'
+}
+
+const IDENTITY_NOT_MATCHED = {
+  deathVerificationFlag: 'n/a',
+  mobilePhoneMatch: 'not_set',
+  emailAddressMatch: 'not_set',
+  addressLine1Match: 'not_set',
+  postcodeMatch: 'not_set',
+  pregnantChildDOBMatch: 'not_set',
+  qualifyingBenefits: 'not_set',
+  identityOutcome: 'not_matched',
+  eligibilityOutcome: 'not_set'
+}
+
+const ELIGIBILITY_NOT_CONFIRMED = {
+  deathVerificationFlag: 'n/a',
+  mobilePhoneMatch: 'not_set',
+  emailAddressMatch: 'not_set',
+  addressLine1Match: 'not_set',
+  postcodeMatch: 'not_set',
+  pregnantChildDOBMatch: 'not_set',
+  qualifyingBenefits: 'not_set',
+  identityOutcome: 'matched',
+  eligibilityOutcome: 'not_confirmed'
+}
+
+test('getDecisionStatus() should return undefined if verification result has no matching decision', (t) => {
+  // TODO these non matching results will need to be updated as stories for epic 'receive my decision' are completed
+  const nonMatchingResults = [{}, SUCCESSFUL_RESULT, PENDING_RESULT]
+  nonMatchingResults.forEach(result => {
+    t.equal(getDecisionStatus(result), undefined, 'non matching result returns undefined')
+  })
+  t.end()
+})
+
+test(`getDecisionStatus() should return ${FAIL} if identity not matched`, (t) => {
+  t.equal(getDecisionStatus(IDENTITY_NOT_MATCHED), FAIL, `returns ${FAIL} if identity not matched`)
+  t.end()
+})
+
+test(`getDecisionStatus() should return ${FAIL} if eligibility not confirmed`, (t) => {
+  t.equal(getDecisionStatus(ELIGIBILITY_NOT_CONFIRMED), FAIL, `returns ${FAIL} if eligibility not confirmed`)
+  t.end()
+})


### PR DESCRIPTION
`getDecisionStatus` consumes `verificationResult` returned from the claimant service. Ultimately this function will return one of four values:

- SUCCESS
- FAIL
- PENDING
- undefined

In a future PR `getDecisionStatus` will be implemented in the `/decision` route handler to determine which decision template to render.