### PR TITLE
HTBHF-1942 persist verification result

### DIFF
--- a/src/web/routes/application/steps/decision/get-decision-status.js
+++ b/src/web/routes/application/steps/decision/get-decision-status.js
@@ -1,8 +1,5 @@
 const { equals, compose, prop, cond, always } = require('ramda')
-
-const SUCCESS = 'success'
-const FAIL = 'fail'
-const PENDING = 'pending'
+const { FAIL } = require('./statuses')
 
 const outcomeNotMatched = equals('not_matched')
 const outcomeNotConfirmed = equals('not_confirmed')
@@ -17,10 +14,5 @@ const getDecisionStatus = cond([
 ])
 
 module.exports = {
-  statuses: {
-    SUCCESS,
-    FAIL,
-    PENDING
-  },
   getDecisionStatus
 }

--- a/src/web/routes/application/steps/decision/get-decision-status.test.js
+++ b/src/web/routes/application/steps/decision/get-decision-status.test.js
@@ -1,7 +1,6 @@
 const test = require('tape')
-const { statuses, getDecisionStatus } = require('./get-decision-status')
-
-const { FAIL } = statuses
+const { getDecisionStatus } = require('./get-decision-status')
+const { FAIL } = require('./statuses')
 
 const SUCCESSFUL_RESULT = {
   deathVerificationFlag: 'n/a',

--- a/src/web/routes/application/steps/decision/statuses.js
+++ b/src/web/routes/application/steps/decision/statuses.js
@@ -1,0 +1,3 @@
+module.exports.SUCCESS = 'success'
+module.exports.FAIL = 'fail'
+module.exports.PENDING = 'pending'

--- a/src/web/routes/application/steps/terms-and-conditions/post.js
+++ b/src/web/routes/application/steps/terms-and-conditions/post.js
@@ -50,7 +50,7 @@ const postTermsAndConditions = (config, journey) => (req, res, next) => {
     .then(
       (response) => {
         const responseBody = path(['body'], response)
-        const { eligibilityStatus, voucherEntitlement } = responseBody
+        const { eligibilityStatus, voucherEntitlement, verificationResult } = responseBody
 
         if (!eligibilityStatus) {
           return next(wrapError({
@@ -62,6 +62,7 @@ const postTermsAndConditions = (config, journey) => (req, res, next) => {
 
         req.session.eligibilityStatus = eligibilityStatus
         req.session.voucherEntitlement = voucherEntitlement
+        req.session.verificationResult = verificationResult
 
         stateMachine.setState(COMPLETED, req, journey)
         stateMachine.dispatch(INCREMENT_NEXT_ALLOWED_PATH, req, journey)

--- a/src/web/routes/application/steps/terms-and-conditions/post.test.js
+++ b/src/web/routes/application/steps/terms-and-conditions/post.test.js
@@ -32,6 +32,9 @@ const SUCCESSFUL_RESPONSE = {
     eligibilityStatus: ELIGIBLE,
     voucherEntitlement: {
       totalVoucherValueInPence: 310
+    },
+    verificationResult: {
+      eligibilityOutcome: 'confirmed'
     }
   }
 }
@@ -147,6 +150,7 @@ test(`successful post sets next allowed step to ${DECISION_URL} and sets returne
       t.equal(getNextAllowedPathForJourney('apply', req), `/apply${DECISION_URL}`, `it sets next allowed step to ${DECISION_URL}`)
       t.equal(req.session.eligibilityStatus, ELIGIBLE, 'it sets the eligibility status to ELIGIBLE')
       t.deepEqual(req.session.voucherEntitlement, { totalVoucherValueInPence: 310 }, 'it sets the voucher entitlement field')
+      t.deepEqual(req.session.verificationResult, { eligibilityOutcome: 'confirmed' }, 'it sets the verification result field')
       t.equal(redirect.calledWith(`/apply${DECISION_URL}`), true, 'it calls redirect() with the correct URL')
       t.equal(render.called, false, 'it does not call render()')
       t.end()

--- a/test_versions.properties
+++ b/test_versions.properties
@@ -1,3 +1,3 @@
 # This file is `source`d by the cd pipeline when running tests
 PERF_TESTS_VERSION=1.0.69
-ACCEPTANCE_TESTS_VERSION=0.0.76
+ACCEPTANCE_TESTS_VERSION=0.0.77


### PR DESCRIPTION
Make `verificationResult` available between route handlers. Preparation for "receive decision" view handling:

- Set `verificationResult` on session to make it accessible between routes
- Extract decision `statuses` for easier reuse between files