### PR TITLE
HTBHF-1942 render instant failure decision

### DIFF
--- a/src/web/routes/application/steps/decision/decision-fallback.js
+++ b/src/web/routes/application/steps/decision/decision-fallback.js
@@ -8,8 +8,8 @@ const getDecisionPageFallback = (req, res) => {
     const totalVoucherValueInPence = path(['session', 'voucherEntitlement', 'totalVoucherValueInPence'], req)
 
     return res.render('decision-fallback-successful', {
-      title: req.t('decision.title'),
-      subTitle: req.t('decision.subTitle', {
+      title: req.t('decisionFallbackSuccessful.title'),
+      subTitle: req.t('decisionFallbackSuccessful.subTitle', {
         totalVoucherValue: toPounds(totalVoucherValueInPence),
         totalVoucherValueForFourWeeks: toPounds(totalVoucherValueInPence * 4)
       })
@@ -17,9 +17,9 @@ const getDecisionPageFallback = (req, res) => {
   }
 
   return res.render('decision-fallback-unsuccessful', {
-    title: req.t('unsuccessfulApplication.title'),
-    subTitle: req.t('unsuccessfulApplication.subTitle'),
-    heading: req.t('unsuccessfulApplication.title'),
+    title: req.t('decisionFallbackUnsuccessful.title'),
+    subTitle: req.t('decisionFallbackUnsuccessful.subTitle'),
+    heading: req.t('decisionFallbackUnsuccessful.title'),
     eligibilityStatus: req.session.eligibilityStatus.toLowerCase()
   })
 }

--- a/src/web/routes/application/steps/decision/decision.js
+++ b/src/web/routes/application/steps/decision/decision.js
@@ -1,15 +1,42 @@
 const { configureSessionDetails, handleRequestForPath } = require('../../flow-control')
 const { DECISION_URL, prefixPath } = require('../../paths')
+const { isUndefined } = require('../../../../../common/predicates')
+const { getDecisionStatus } = require('./get-decision-status')
+const { FAIL } = require('./statuses')
 const { getDecisionPageFallback } = require('./decision-fallback')
+
+const STATUS_TEMPLATE_MAP = {
+  [FAIL]: 'failure'
+}
+
+const getRenderArgsForStatus = (req, status) => {
+  const template = STATUS_TEMPLATE_MAP[status]
+  return [`decision/${template}`, {
+    title: req.t(`decision.${template}.title`),
+    body: req.t(`decision.${template}.body`)
+  }]
+}
+
+// TODO: Remove references to "decision fallback" once all stories for epic HTBHF-2014 (receive my decision) are complete.
+// After removal of fallback, update handler to throw error if `decisionStatus` is undefined.
+const getDecisionPage = (req, res, next) => {
+  const decisionStatus = getDecisionStatus(req.session.verificationResult)
+
+  return isUndefined(decisionStatus)
+    ? next()
+    : res.render(...getRenderArgsForStatus(req, decisionStatus))
+}
 
 const registerDecisionRoute = (journey, app) =>
   app.get(
     prefixPath(journey.pathPrefix, DECISION_URL),
     configureSessionDetails(journey),
     handleRequestForPath(journey),
+    getDecisionPage,
     getDecisionPageFallback
   )
 
 module.exports = {
-  registerDecisionRoute
+  registerDecisionRoute,
+  getDecisionPage
 }

--- a/src/web/routes/application/steps/decision/decision.test.js
+++ b/src/web/routes/application/steps/decision/decision.test.js
@@ -1,0 +1,68 @@
+const test = require('tape')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+const { identity } = require('ramda')
+const { FAIL } = require('./statuses')
+
+const getDecisionStatus = sinon.stub()
+
+const { getDecisionPage } = proxyquire('./decision', {
+  './get-decision-status': {
+    getDecisionStatus
+  }
+})
+
+const resetStubs = () => {
+  getDecisionStatus.reset()
+}
+
+test('getDecisionPage() calls next if decision status is undefined', (t) => {
+  getDecisionStatus.returns(undefined)
+
+  const render = sinon.spy()
+  const next = sinon.spy()
+
+  const req = {
+    t: identity,
+    session: {
+      verificationResult: {}
+    }
+  }
+
+  const res = {
+    render
+  }
+
+  getDecisionPage(req, res, next)
+
+  t.equal(next.called, true, 'it calls next()')
+  t.equal(render.called, false, 'it does not call render()')
+  resetStubs()
+  t.end()
+})
+
+test(`getDecisionPage() renders failure view if decision status is ${FAIL}`, (t) => {
+  getDecisionStatus.returns(FAIL)
+
+  const render = sinon.spy()
+  const next = sinon.spy()
+
+  const req = {
+    t: identity,
+    language: 'en',
+    session: {
+      verificationResult: {}
+    }
+  }
+
+  const res = {
+    render
+  }
+
+  getDecisionPage(req, res, next)
+
+  t.equal(next.called, false, 'it does not call next()')
+  t.equal(render.calledWith('decision/failure'), true, 'it calls render() with correct template')
+  resetStubs()
+  t.end()
+})

--- a/src/web/server/locales/cy/common.json
+++ b/src/web/server/locales/cy/common.json
@@ -140,7 +140,7 @@
   "decision": {
     "failure": {
       "title": "Risus sed vulputate odio ut enim",
-      "subTitle": "Risus sed vulputate odio ut enim"
+      "body": "Risus sed vulputate odio ut enim"
     }
   },
   "cookies": {

--- a/src/web/server/locales/cy/common.json
+++ b/src/web/server/locales/cy/common.json
@@ -127,15 +127,21 @@
     "heading": "Risus sed vulputate odio ut enim blandit volutpat maecenas volutpat",
     "statement": "Risus sed vulputate odio ut enim blandit volutpat maecenas volutpat."
   },
-  "decision": {
+  "decisionFallbackSuccessful": {
     "title": "Ullamcorper malesuada",
     "subTitle": "Dui faucibus in ornare\n£{{totalVoucherValue}} ut labore. Eget felis eget nunc\nlobortis mattis {{totalVoucherValueForFourWeeks}}."
   },
-  "unsuccessfulApplication": {
+  "decisionFallbackUnsuccessful": {
     "title": "Lorem ipsum dolor sit amet",
     "subTitle": "Risus sed vulputate odio ut enim blandit",
     "heading": "Lorem ipsum dolor sit amet",
     "content": "See locales/cy/unsuccessful/*.html"
+  },
+  "decision": {
+    "failure": {
+      "title": "Risus sed vulputate odio ut enim",
+      "subTitle": "Risus sed vulputate odio ut enim"
+    }
   },
   "cookies": {
     "title": "Cwcis",

--- a/src/web/server/locales/en/common.json
+++ b/src/web/server/locales/en/common.json
@@ -130,15 +130,21 @@
     "heading": "Terms and conditions",
     "statement": "I confirm that I’ve read and will comply with these terms and conditions."
   },
-  "decision": {
+  "decisionFallbackSuccessful": {
     "title": "Application successful",
     "subTitle": "You’re entitled to\n<strong>£{{totalVoucherValue}}</strong> a week. Your first payment\nwill be <strong>£{{totalVoucherValueForFourWeeks}}</strong>."
   },
-  "unsuccessfulApplication": {
+  "decisionFallbackUnsuccessful": {
     "title": "Application not successful",
     "subTitle": "You will not be sent a prepaid money card",
     "heading": "Application not successful",
     "content": "See locales/en/unsuccessful/*.html"
+  },
+  "decision": {
+    "failure": {
+      "title": "Application not successful",
+      "subTitle": "You will not be sent a prepaid money card"
+    }
   },
   "cookies": {
     "title": "Cookies",

--- a/src/web/server/locales/en/common.json
+++ b/src/web/server/locales/en/common.json
@@ -143,7 +143,7 @@
   "decision": {
     "failure": {
       "title": "Application not successful",
-      "subTitle": "You will not be sent a prepaid money card"
+      "body": "You will not be sent a prepaid money card"
     }
   },
   "cookies": {

--- a/src/web/views/decision/failure.njk
+++ b/src/web/views/decision/failure.njk
@@ -1,0 +1,14 @@
+{% extends "templates/page.njk" %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% block pageContent %}
+
+  {{ govukPanel({
+    titleText: title,
+    html: body,
+    classes: "govuk-!-margin-bottom-5"
+  }) }}
+
+  {% include "../locales/" + language + "/decision/failure.njk" %}
+
+{% endblock %}

--- a/src/web/views/locales/en/decision/failure.njk
+++ b/src/web/views/locales/en/decision/failure.njk
@@ -1,0 +1,12 @@
+<p class="govuk-body">We cannot find you in our records. You may have entered something wrong.</p>
+<p class="govuk-body"><a class="govuk-link" href="/apply">Go back and try again.</a></p>
+<p class="govuk-body">If you’re on benefits make sure you enter the same details you registered with the benefits agencies (DWP or HMRC).</p>
+<p class="govuk-body">If you’re still having problems:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>call 0300 330 7010</li>
+  <li>select option 3</li>
+</ul>
+
+<h2 class="govuk-heading-m">Give feedback</h2>
+<p class="govuk-body"><a class="govuk-link" href="https://www.smartsurvey.co.uk/s/apply-for-healthy-start-feedback">What did you think of this service?</a> (takes 30 seconds).</p>

--- a/test_versions.properties
+++ b/test_versions.properties
@@ -1,3 +1,3 @@
 # This file is `source`d by the cd pipeline when running tests
 PERF_TESTS_VERSION=1.0.69
-ACCEPTANCE_TESTS_VERSION=0.0.77
+ACCEPTANCE_TESTS_VERSION=0.0.80


### PR DESCRIPTION
Handle failure scenarios for "receive my decision":

- Identity not matched
- Eligibility not confirmed

Based on these scenarios the `/decision` route handler will render a failure screen, otherwise it will fallback to the default claimant service response handling:

- Add missing `decision fallback` renames in translations
- Add `.njk` decision failure template
- Handle verification failure scenarios
- Fallback to default `/decision` route handler if scenarios are not matched