### PR TITLE
HTBHF-2725 handle duplicate claim decision

### DIFF
--- a/src/web/routes/application/steps/decision/decision.js
+++ b/src/web/routes/application/steps/decision/decision.js
@@ -20,7 +20,8 @@ const getRenderArgsForStatus = (req, status) => {
 // TODO: Remove references to "decision fallback" once all stories for epic HTBHF-2014 (receive my decision) are complete.
 // After removal of fallback, update handler to throw error if `decisionStatus` is undefined.
 const getDecisionPage = (req, res, next) => {
-  const decisionStatus = getDecisionStatus(req.session.verificationResult)
+  const { verificationResult, eligibilityStatus } = req.session
+  const decisionStatus = getDecisionStatus({ verificationResult, eligibilityStatus })
 
   return isUndefined(decisionStatus)
     ? next()

--- a/src/web/routes/application/steps/decision/eligibility-statuses.js
+++ b/src/web/routes/application/steps/decision/eligibility-statuses.js
@@ -1,1 +1,2 @@
 module.exports.ELIGIBLE = 'ELIGIBLE'
+module.exports.DUPLICATE = 'DUPLICATE'

--- a/src/web/routes/application/steps/decision/get-decision-status.js
+++ b/src/web/routes/application/steps/decision/get-decision-status.js
@@ -1,15 +1,22 @@
-const { equals, compose, prop, cond, always } = require('ramda')
+const { equals, compose, path, prop, cond, always } = require('ramda')
 const { FAIL } = require('./decision-statuses')
+const { DUPLICATE } = require('./eligibility-statuses')
+
+const verificationResultProp = prop => path(['verificationResult', prop])
 
 const outcomeNotMatched = equals('not_matched')
 const outcomeNotConfirmed = equals('not_confirmed')
+const isDuplicate = equals(DUPLICATE)
 
-const identityOutcomeNotMatched = compose(outcomeNotMatched, prop('identityOutcome'))
-const eligibilityOutcomeNotConfirmed = compose(outcomeNotConfirmed, prop('eligibilityOutcome'))
+const identityOutcomeNotMatched = compose(outcomeNotMatched, verificationResultProp('identityOutcome'))
+const eligibilityOutcomeNotConfirmed = compose(outcomeNotConfirmed, verificationResultProp('eligibilityOutcome'))
+
+const isDuplicateClaim = compose(isDuplicate, prop('eligibilityStatus'))
 
 const isFailure = result => identityOutcomeNotMatched(result) || eligibilityOutcomeNotConfirmed(result)
 
 const getDecisionStatus = cond([
+  [isDuplicateClaim, always(FAIL)],
   [isFailure, always(FAIL)]
 ])
 

--- a/src/web/routes/application/steps/decision/get-decision-status.test.js
+++ b/src/web/routes/application/steps/decision/get-decision-status.test.js
@@ -1,6 +1,7 @@
 const test = require('tape')
 const { getDecisionStatus } = require('./get-decision-status')
 const { FAIL } = require('./decision-statuses')
+const { DUPLICATE } = require('./eligibility-statuses')
 
 const SUCCESSFUL_RESULT = {
   deathVerificationFlag: 'n/a',
@@ -50,21 +51,28 @@ const ELIGIBILITY_NOT_CONFIRMED_RESULT = {
   eligibilityOutcome: 'not_confirmed'
 }
 
+const DUPLICATE_RESULT = undefined // A DUPLICATE response from the claimant service will not return a verification result
+
 test('getDecisionStatus() should return undefined if verification result has no matching decision', (t) => {
   // TODO these non matching results will need to be updated as stories for epic 'receive my decision' are completed
   const nonMatchingResults = [{}, SUCCESSFUL_RESULT, PENDING_RESULT]
-  nonMatchingResults.forEach(result => {
-    t.equal(getDecisionStatus(result), undefined, 'non matching result returns undefined')
+  nonMatchingResults.forEach(verificationResult => {
+    t.equal(getDecisionStatus({ verificationResult }), undefined, 'non matching result returns undefined')
   })
   t.end()
 })
 
 test(`getDecisionStatus() should return ${FAIL} if identity not matched`, (t) => {
-  t.equal(getDecisionStatus(IDENTITY_NOT_MATCHED_RESULT), FAIL, `returns ${FAIL} if identity not matched`)
+  t.equal(getDecisionStatus({ verificationResult: IDENTITY_NOT_MATCHED_RESULT }), FAIL, `returns ${FAIL} if identity not matched`)
   t.end()
 })
 
 test(`getDecisionStatus() should return ${FAIL} if eligibility not confirmed`, (t) => {
-  t.equal(getDecisionStatus(ELIGIBILITY_NOT_CONFIRMED_RESULT), FAIL, `returns ${FAIL} if eligibility not confirmed`)
+  t.equal(getDecisionStatus({ verificationResult: ELIGIBILITY_NOT_CONFIRMED_RESULT }), FAIL, `returns ${FAIL} if eligibility not confirmed`)
+  t.end()
+})
+
+test(`getDecisionStatus() should return ${FAIL} if eligibility status is duplicate`, (t) => {
+  t.equal(getDecisionStatus({ verificationResult: DUPLICATE_RESULT, eligibilityStatus: DUPLICATE }), FAIL, `returns ${FAIL} if eligibility status is duplicate`)
   t.end()
 })

--- a/test_versions.properties
+++ b/test_versions.properties
@@ -1,3 +1,3 @@
 # This file is `source`d by the cd pipeline when running tests
 PERF_TESTS_VERSION=1.0.69
-ACCEPTANCE_TESTS_VERSION=0.0.80
+ACCEPTANCE_TESTS_VERSION=0.0.81


### PR DESCRIPTION
Handle duplicate decision response from claimant service and render failure screen. This involves a refactor of `getDecisionStatus` to accept `eligibilityStatus` as an argument.