### PR TITLE
HTBHF-1943 address mismatch decision view

### DIFF
--- a/src/web/routes/application/steps/decision/decision.js
+++ b/src/web/routes/application/steps/decision/decision.js
@@ -2,11 +2,12 @@ const { configureSessionDetails, handleRequestForPath } = require('../../flow-co
 const { DECISION_URL, prefixPath } = require('../../paths')
 const { isUndefined } = require('../../../../../common/predicates')
 const { getDecisionStatus } = require('./get-decision-status')
-const { FAIL } = require('./decision-statuses')
+const { FAIL, PENDING } = require('./decision-statuses')
 const { getDecisionPageFallback } = require('./decision-fallback')
 
 const STATUS_TEMPLATE_MAP = {
-  [FAIL]: 'failure'
+  [FAIL]: 'failure',
+  [PENDING]: 'pending'
 }
 
 const getRenderArgsForStatus = (req, status) => {

--- a/src/web/routes/application/steps/decision/decision.test.js
+++ b/src/web/routes/application/steps/decision/decision.test.js
@@ -2,7 +2,7 @@ const test = require('tape')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const { identity } = require('ramda')
-const { FAIL } = require('./decision-statuses')
+const { FAIL, PENDING } = require('./decision-statuses')
 
 const getDecisionStatus = sinon.stub()
 
@@ -63,6 +63,32 @@ test(`getDecisionPage() renders failure view if decision status is ${FAIL}`, (t)
 
   t.equal(next.called, false, 'it does not call next()')
   t.equal(render.calledWith('decision/failure'), true, 'it calls render() with correct template')
+  resetStubs()
+  t.end()
+})
+
+test(`getDecisionPage() renders pending view if decision status is ${PENDING}`, (t) => {
+  getDecisionStatus.returns(PENDING)
+
+  const render = sinon.spy()
+  const next = sinon.spy()
+
+  const req = {
+    t: identity,
+    language: 'en',
+    session: {
+      verificationResult: {}
+    }
+  }
+
+  const res = {
+    render
+  }
+
+  getDecisionPage(req, res, next)
+
+  t.equal(next.called, false, 'it does not call next()')
+  t.equal(render.calledWith('decision/pending'), true, 'it calls render() with correct template')
   resetStubs()
   t.end()
 })

--- a/src/web/routes/application/steps/decision/get-decision-status.js
+++ b/src/web/routes/application/steps/decision/get-decision-status.js
@@ -1,23 +1,27 @@
-const { equals, compose, path, prop, cond, always } = require('ramda')
-const { FAIL } = require('./decision-statuses')
+const { equals, compose, path, prop, cond, always, anyPass } = require('ramda')
+const { FAIL, PENDING } = require('./decision-statuses')
 const { DUPLICATE } = require('./eligibility-statuses')
 
 const verificationResultProp = prop => path(['verificationResult', prop])
 
 const outcomeNotMatched = equals('not_matched')
 const outcomeNotConfirmed = equals('not_confirmed')
-const isDuplicate = equals(DUPLICATE)
 
 const identityOutcomeNotMatched = compose(outcomeNotMatched, verificationResultProp('identityOutcome'))
 const eligibilityOutcomeNotConfirmed = compose(outcomeNotConfirmed, verificationResultProp('eligibilityOutcome'))
+const addressLine1MatchNotMatched = compose(outcomeNotMatched, verificationResultProp('addressLine1Match'))
+const postcodeMatchNotMatched = compose(outcomeNotMatched, verificationResultProp('postcodeMatch'))
 
-const isDuplicateClaim = compose(isDuplicate, prop('eligibilityStatus'))
+const isDuplicateClaim = compose(equals(DUPLICATE), prop('eligibilityStatus'))
 
-const isFailure = result => identityOutcomeNotMatched(result) || eligibilityOutcomeNotConfirmed(result)
+const isFailure = anyPass([identityOutcomeNotMatched, eligibilityOutcomeNotConfirmed])
+
+const addressMismatches = anyPass([addressLine1MatchNotMatched, postcodeMatchNotMatched])
 
 const getDecisionStatus = cond([
   [isDuplicateClaim, always(FAIL)],
-  [isFailure, always(FAIL)]
+  [isFailure, always(FAIL)],
+  [addressMismatches, always(PENDING)]
 ])
 
 module.exports = {

--- a/src/web/routes/application/steps/decision/get-decision-status.test.js
+++ b/src/web/routes/application/steps/decision/get-decision-status.test.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 const { getDecisionStatus } = require('./get-decision-status')
-const { FAIL } = require('./decision-statuses')
-const { DUPLICATE } = require('./eligibility-statuses')
+const { FAIL, PENDING } = require('./decision-statuses')
+const { DUPLICATE, ELIGIBLE } = require('./eligibility-statuses')
 
 const SUCCESSFUL_RESULT = {
   deathVerificationFlag: 'n/a',
@@ -51,6 +51,18 @@ const ELIGIBILITY_NOT_CONFIRMED_RESULT = {
   eligibilityOutcome: 'not_confirmed'
 }
 
+const ELIGIBILITY_CONFIRMED_RESULT = {
+  deathVerificationFlag: 'n/a',
+  mobilePhoneMatch: 'not_set',
+  emailAddressMatch: 'not_set',
+  addressLine1Match: 'not_set',
+  postcodeMatch: 'not_set',
+  pregnantChildDOBMatch: 'not_set',
+  qualifyingBenefits: 'not_set',
+  identityOutcome: 'matched',
+  eligibilityOutcome: 'confirmed'
+}
+
 const DUPLICATE_RESULT = undefined // A DUPLICATE response from the claimant service will not return a verification result
 
 test('getDecisionStatus() should return undefined if verification result has no matching decision', (t) => {
@@ -74,5 +86,18 @@ test(`getDecisionStatus() should return ${FAIL} if eligibility not confirmed`, (
 
 test(`getDecisionStatus() should return ${FAIL} if eligibility status is duplicate`, (t) => {
   t.equal(getDecisionStatus({ verificationResult: DUPLICATE_RESULT, eligibilityStatus: DUPLICATE }), FAIL, `returns ${FAIL} if eligibility status is duplicate`)
+  t.end()
+})
+
+test(`getDecisionStatus() should return ${PENDING} if address mismatches`, (t) => {
+  const mismatchingAddressResults = [
+    { ...ELIGIBILITY_CONFIRMED_RESULT, addressLine1Match: 'not_matched', postcodeMatch: 'matched' },
+    { ...ELIGIBILITY_CONFIRMED_RESULT, addressLine1Match: 'matched', postcodeMatch: 'not_matched' },
+    { ...ELIGIBILITY_CONFIRMED_RESULT, addressLine1Match: 'not_matched', postcodeMatch: 'not_matched' }
+  ]
+
+  mismatchingAddressResults.forEach(verificationResult => {
+    t.equal(getDecisionStatus({ verificationResult, eligibilityStatus: ELIGIBLE }), PENDING, `returns ${PENDING} if address mismatches`)
+  })
   t.end()
 })

--- a/src/web/server/locales/cy/common.json
+++ b/src/web/server/locales/cy/common.json
@@ -141,6 +141,9 @@
     "failure": {
       "title": "Risus sed vulputate odio ut enim",
       "body": "Risus sed vulputate odio ut enim"
+    },
+    "pending": {
+      "title": "Lorem ipsum dolor sit amet"
     }
   },
   "cookies": {

--- a/src/web/server/locales/en/common.json
+++ b/src/web/server/locales/en/common.json
@@ -144,6 +144,9 @@
     "failure": {
       "title": "Application not successful",
       "body": "You will not be sent a prepaid money card"
+    },
+    "pending": {
+      "title": "We’re considering your application"
     }
   },
   "cookies": {

--- a/src/web/views/decision/pending.njk
+++ b/src/web/views/decision/pending.njk
@@ -1,0 +1,13 @@
+{% extends "templates/page.njk" %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% block pageContent %}
+
+  {{ govukPanel({
+    titleText: title,
+    classes: "govuk-!-margin-bottom-5"
+  }) }}
+
+  {% include "../locales/" + language + "/decision/pending.njk" %}
+
+{% endblock %}

--- a/src/web/views/locales/en/decision/pending.njk
+++ b/src/web/views/locales/en/decision/pending.njk
@@ -1,0 +1,13 @@
+<h2 class="govuk-heading-m">What happens next</h2>
+<p class="govuk-body">We need to review your application. We’ll send you a letter with our decision within 5 working days.</p>
+<p class="govuk-body">If you’ve not heard from us in that time:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>call 0300 330 7010</li>
+  <li>select option 3</li>
+</ul>
+
+<p class="govuk-body">We’ve also sent you an email.</p>
+
+<h2 class="govuk-heading-m">Give feedback</h2>
+<p class="govuk-body"><a class="govuk-link" href="https://www.smartsurvey.co.uk/s/apply-for-healthy-start-feedback">What did you think of this service?</a> (takes 30 seconds).</p>

--- a/test_versions.properties
+++ b/test_versions.properties
@@ -1,3 +1,3 @@
 # This file is `source`d by the cd pipeline when running tests
-PERF_TESTS_VERSION=1.0.69
-ACCEPTANCE_TESTS_VERSION=0.0.81
+PERF_TESTS_VERSION=1.0.70
+ACCEPTANCE_TESTS_VERSION=0.0.84


### PR DESCRIPTION
Render "we're considering your application" content when applicant's address mismatches:

- Create PENDING `.njk` template
- Update decision engine to handle address mismatch
- Update `or` statements in decision engine to use ramda's `anyPass`. This is a preemptive refactor for adding more conditions to `isFailure` in the next update e.g:

```
const isFailure = anyPass([identityOutcomeNotMatched, eligibilityOutcomeNotConfirmed, isIneligibleClaim])
```