### PR TITLE
Feature/stop mutating nino input

### DIFF
--- a/src/web/routes/application/steps/national-insurance-number/national-insurance-number.js
+++ b/src/web/routes/application/steps/national-insurance-number/national-insurance-number.js
@@ -16,7 +16,7 @@ const contentSummary = (req) => ({
 })
 
 const requestBody = (session) => ({
-  nino: session.claim.nino
+  nino: session.claim.sanitizedNino
 })
 
 const nationalInsuranceNumber = {

--- a/src/web/routes/application/steps/national-insurance-number/national-insurance-number.test.js
+++ b/src/web/routes/application/steps/national-insurance-number/national-insurance-number.test.js
@@ -5,20 +5,21 @@ const req = {
   t: string => string,
   session: {
     claim: {
-      nino: 'QQ123456C'
+      nino: 'QQ 12 34 56 C',
+      sanitizedNino: 'QQ123456C'
     }
   }
 }
 
-test('National insurance number contentSummary() should return content summary in correct format', (t) => {
+test('National insurance number contentSummary() should return content summary in entered format', (t) => {
   const result = nationalInsuranceNumber.contentSummary(req)
 
   const expected = {
     key: 'nationalInsuranceNumber.summaryKey',
-    value: 'QQ123456C'
+    value: 'QQ 12 34 56 C'
   }
 
-  t.deepEqual(result, expected, 'should return content summary in correct format')
+  t.deepEqual(result, expected, 'should return content summary in entered format')
   t.end()
 })
 
@@ -29,6 +30,6 @@ test('requestBody() returns request body in correct format', (t) => {
     nino: 'QQ123456C'
   }
 
-  t.deepEqual(result, expected, 'returns request body in correct format')
+  t.deepEqual(result, expected, 'returns request body in sanitized format')
   t.end()
 })

--- a/src/web/routes/application/steps/national-insurance-number/sanitize.js
+++ b/src/web/routes/application/steps/national-insurance-number/sanitize.js
@@ -1,11 +1,11 @@
-const removeWhiteSpace = (text) => { return text.replace(/\s/g, '') }
+const getSanitizedNino = (nino) => nino.replace(/\s/g, '')
 
 const sanitize = () => (req, res, next) => {
-  req.body.nino = removeWhiteSpace(req.body.nino)
+  req.body.sanitizedNino = getSanitizedNino(req.body.nino)
   next()
 }
 
 module.exports = {
   sanitize,
-  removeWhiteSpace
+  getSanitizedNino
 }

--- a/src/web/routes/application/steps/national-insurance-number/sanitize.js
+++ b/src/web/routes/application/steps/national-insurance-number/sanitize.js
@@ -6,6 +6,5 @@ const sanitize = () => (req, res, next) => {
 }
 
 module.exports = {
-  sanitize,
-  getSanitizedNino
+  sanitize
 }

--- a/src/web/routes/application/steps/national-insurance-number/sanitize.test.js
+++ b/src/web/routes/application/steps/national-insurance-number/sanitize.test.js
@@ -1,12 +1,21 @@
 const test = require('tape')
-const { removeWhiteSpace } = require('./sanitize')
+const sinon = require('sinon')
+const { sanitize } = require('./sanitize')
 
-test('removeWhiteSpace', (t) => {
-  const nino = 'qq 12 34 56 c '
-  const expected = 'qq123456c'
+test('sanitize removes white space and saves to a new variable', (t) => {
+  const req = {
+    body: {
+      nino: 'ab 12 34 56 c '
+    }
+  }
+  const expectedSanitized = 'ab123456c'
+  const expectedNino = 'ab 12 34 56 c '
+  const next = sinon.spy()
 
-  const result = removeWhiteSpace(nino)
+  sanitize()(req, {}, next)
 
-  t.deepEqual(result, expected, 'it should remove all white space')
+  t.equal(req.body.nino, expectedNino, 'it should not mutate the input')
+  t.equal(req.body.sanitizedNino, expectedSanitized, 'it should remove whitespace and save to a new variable')
+  t.equal(next.called, true)
   t.end()
 })

--- a/src/web/routes/application/steps/national-insurance-number/validate.js
+++ b/src/web/routes/application/steps/national-insurance-number/validate.js
@@ -3,9 +3,13 @@ const { translateValidationMessage } = require('../common/translate-validation-m
 
 const NINO_PATTERN = /^[a-zA-Z]{2}[\d]{6}[a-dA-D]$/
 
+const validateNino = (_, { req }) => NINO_PATTERN.test(req.body.sanitizedNino)
+
 const validate = () => [
+  // calling custom validation method as the field in error is'nino', but the field being checked is 'sanitizedNino'.
+  // the check method must take in the field name of the input box to correctly display validation errors.
   check('nino')
-    .matches(NINO_PATTERN)
+    .custom(validateNino)
     .withMessage(translateValidationMessage('validation:invalidNino'))
 ]
 


### PR DESCRIPTION
… is displayed to the user.

E.g If the user enters in 'AB 12 34 56 C', they'll see 'AB 12 34 56 C' on the check your answers page and the nino page if they go back to it, but 'AB123456C' will be sent to the claim service.

Updated the sanitize test to test the whole method rather than just the regex.

Next PR will up the version of the acceptance tests.