### PR TITLE
AFHS-370 Sanitized postcodes are saved to a new variable.

### DIFF
--- a/src/web/routes/application/steps/address/postcode/validate.js
+++ b/src/web/routes/application/steps/address/postcode/validate.js
@@ -3,13 +3,19 @@ const { check } = require('express-validator')
 const { translateValidationMessage } = require('../../common/translate-validation-message')
 const { UK_POSTCODE_PATTERN, CHANNEL_ISLANDS_AND_IOM_POSTCODE_PATTERN } = require('../constants')
 
+const checkPostcodeIsValid = (_, { req }) => UK_POSTCODE_PATTERN.test(req.body.sanitizedPostcode)
+
+const checkPostcodeIsNotInChannelOrIslandOrIOM = (_, { req }) => !CHANNEL_ISLANDS_AND_IOM_POSTCODE_PATTERN.test(req.body.sanitizedPostcode)
+
 const validate = () => [
+  // calling custom validation method as the field in error is 'postcode', but the field being checked is 'sanitizedPostcode'.
+  // the check method must take in the field name of the input box to correctly display validation errors.
   check('postcode')
-    .matches(UK_POSTCODE_PATTERN)
+    .custom(checkPostcodeIsValid)
     .withMessage(translateValidationMessage('validation:invalidPostcode')),
 
   check('postcode')
-    .not().matches(CHANNEL_ISLANDS_AND_IOM_POSTCODE_PATTERN)
+    .custom(checkPostcodeIsNotInChannelOrIslandOrIOM)
     .withMessage(translateValidationMessage('validation:geographicEligibility'))
 ]
 

--- a/src/web/routes/application/steps/address/sanitize.js
+++ b/src/web/routes/application/steps/address/sanitize.js
@@ -3,11 +3,10 @@ const replaceMultipleSpacesWithOne = (value) => {
 }
 
 const sanitize = () => (req, res, next) => {
-  req.body.postcode = replaceMultipleSpacesWithOne(req.body.postcode)
+  req.body.sanitizedPostcode = replaceMultipleSpacesWithOne(req.body.postcode)
   next()
 }
 
 module.exports = {
-  sanitize,
-  replaceMultipleSpacesWithOne
+  sanitize
 }

--- a/src/web/routes/application/steps/address/sanitize.test.js
+++ b/src/web/routes/application/steps/address/sanitize.test.js
@@ -1,12 +1,21 @@
 const test = require('tape')
-const { replaceMultipleSpacesWithOne } = require('./sanitize')
+const sinon = require('sinon')
+const { sanitize } = require('./sanitize')
 
-test('replaceMultipleSpacesWithOne', (t) => {
-  const postcode = 'aa1     1aa'
-  const expected = 'aa1 1aa'
+test('sanitize replaces multiple whitespace with one and saves to a new variable', (t) => {
+  const req = {
+    body: {
+      postcode: 'aa1     1aa'
+    }
+  }
+  const expectedSanitizedPostcode = 'aa1 1aa'
+  const expectedPostcode = 'aa1     1aa'
+  const next = sinon.spy()
 
-  const result = replaceMultipleSpacesWithOne(postcode)
+  sanitize()(req, {}, next)
 
-  t.deepEqual(result, expected, 'it should replace multiple spaces with a single one')
+  t.equal(req.body.sanitizedPostcode, expectedSanitizedPostcode, 'it should replace multiple spaces with a single one')
+  t.equal(req.body.postcode, expectedPostcode, 'it should not mutate the input')
+  t.equal(next.called, true, 'it should called next()')
   t.end()
 })


### PR DESCRIPTION
The new variable sanitizedPostcode is only used by validate as the address lookup code already performs sanitization (converts to upper and strips all whitespace) before calling os places.