### PR TITLE
HTBHF-2032 Fix issue with sub-title key being shown on pending decision page.

### DIFF
--- a/src/web/server/locales/cy/common.json
+++ b/src/web/server/locales/cy/common.json
@@ -143,7 +143,8 @@
       "body": "Risus sed vulputate odio ut enim"
     },
     "pending": {
-      "title": "Lorem ipsum dolor sit amet"
+      "title": "Lorem ipsum dolor sit amet",
+      "body": ""
     }
   },
   "cookies": {

--- a/src/web/server/locales/en/common.json
+++ b/src/web/server/locales/en/common.json
@@ -146,7 +146,8 @@
       "body": "You will not be sent a prepaid money card"
     },
     "pending": {
-      "title": "We’re considering your application"
+      "title": "We’re considering your application",
+      "body": ""
     }
   },
   "cookies": {

--- a/test_versions.properties
+++ b/test_versions.properties
@@ -1,3 +1,3 @@
 # This file is `source`d by the cd pipeline when running tests
 PERF_TESTS_VERSION=1.0.70
-ACCEPTANCE_TESTS_VERSION=0.0.90
+ACCEPTANCE_TESTS_VERSION=0.0.92


### PR DESCRIPTION
The text `decision.pending.body` was being added to the pending decision page, setting the value to a blank String removes this. I'll add an acceptance test for this in a different PR in the acceptance-test module.