### PR TITLE
AFHS-588 Add success decision logic to decision.js and add success decision template.

### DIFF
--- a/src/web/routes/application/steps/decision/decision.js
+++ b/src/web/routes/application/steps/decision/decision.js
@@ -1,13 +1,17 @@
+const { path } = require('ramda')
 const { configureSessionDetails, handleRequestForPath } = require('../../flow-control')
 const { DECISION_URL, prefixPath } = require('../../paths')
 const { isUndefined } = require('../../../../../common/predicates')
 const { getDecisionStatus } = require('./get-decision-status')
-const { FAIL, PENDING } = require('./decision-statuses')
+const { FAIL, PENDING, SUCCESS } = require('./decision-statuses')
 const { getDecisionPageFallback } = require('./decision-fallback')
+
+const toPounds = pence => (parseInt(pence, 10) / 100).toFixed(2)
 
 const STATUS_TEMPLATE_MAP = {
   [FAIL]: 'failure',
-  [PENDING]: 'pending'
+  [PENDING]: 'pending',
+  [SUCCESS]: 'success'
 }
 
 // TODO: Remove references to "decision fallback" once all stories for epic HTBHF-2014 (receive my decision) are complete.
@@ -16,6 +20,19 @@ const getDecisionPage = (req, res, next) => {
   const { verificationResult, eligibilityStatus } = req.session
   const decisionStatus = getDecisionStatus({ verificationResult, eligibilityStatus })
   const template = STATUS_TEMPLATE_MAP[decisionStatus]
+
+  if (decisionStatus === SUCCESS) {
+    const totalVoucherValueInPence = path(['session', 'voucherEntitlement', 'totalVoucherValueInPence'], req)
+
+    return res.render('decision', {
+      title: req.t('decision.success.title'),
+      body: req.t('decision.success.body', {
+        totalVoucherValue: toPounds(totalVoucherValueInPence),
+        totalVoucherValueForFourWeeks: toPounds(totalVoucherValueInPence * 4)
+      }),
+      template
+    })
+  }
 
   return isUndefined(decisionStatus)
     ? next()
@@ -37,5 +54,6 @@ const registerDecisionRoute = (journey, app) =>
 
 module.exports = {
   registerDecisionRoute,
-  getDecisionPage
+  getDecisionPage,
+  toPounds
 }

--- a/src/web/routes/application/steps/decision/decision.test.js
+++ b/src/web/routes/application/steps/decision/decision.test.js
@@ -3,6 +3,7 @@ const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const { identity } = require('ramda')
 const { FAIL, PENDING } = require('./decision-statuses')
+const { toPounds } = require('./decision')
 
 const getDecisionStatus = sinon.stub()
 
@@ -102,5 +103,12 @@ test(`getDecisionPage() renders pending view if decision status is ${PENDING}`, 
   t.equal(next.called, false, 'it does not call next()')
   t.equal(render.calledWith('decision', expectedTemplateVariables), true, 'it calls render() with the correct arguments')
   resetStubs()
+  t.end()
+})
+
+test('toPounds() converts value in pence to pounds', (t) => {
+  const expected = '3.10'
+  const result = toPounds(310)
+  t.equal(result, expected, 'gets voucher value in pence and converts to pounds')
   t.end()
 })

--- a/src/web/routes/application/steps/decision/get-decision-status.js
+++ b/src/web/routes/application/steps/decision/get-decision-status.js
@@ -1,21 +1,32 @@
-const { equals, compose, path, prop, cond, always, anyPass, not } = require('ramda')
-const { FAIL, PENDING } = require('./decision-statuses')
+const { equals, compose, path, prop, cond, always, allPass, anyPass, not } = require('ramda')
+const { FAIL, PENDING, SUCCESS } = require('./decision-statuses')
 const { DUPLICATE } = require('./eligibility-statuses')
 
 const verificationResultProp = prop => path(['verificationResult', prop])
 
 const outcomeEqualsNotMatched = equals('not_matched')
+const outcomeEqualsMatched = equals('matched')
 const outcomeDoesNotEqualMatched = compose(not, equals('matched'))
 const outcomeNotConfirmed = equals('not_confirmed')
+const outcomeConfirmed = equals('confirmed')
+const isFalse = equals(false)
+const isTrue = equals(true)
 
-const notPregnantAndNoChildMatched = compose(equals(false), verificationResultProp('isPregnantOrAtLeast1ChildMatched'))
+const notPregnantAndNoChildMatched = compose(isFalse, verificationResultProp('isPregnantOrAtLeast1ChildMatched'))
+const isPregnantOrAtLeast1ChildMatched = compose(isTrue, verificationResultProp('isPregnantOrAtLeast1ChildMatched'))
 const identityOutcomeNotMatched = compose(outcomeEqualsNotMatched, verificationResultProp('identityOutcome'))
+const identityOutcomeMatched = compose(outcomeEqualsMatched, verificationResultProp('identityOutcome'))
 const eligibilityOutcomeNotConfirmed = compose(outcomeNotConfirmed, verificationResultProp('eligibilityOutcome'))
+const eligibilityOutcomeConfirmed = compose(outcomeConfirmed, verificationResultProp('eligibilityOutcome'))
 const addressLine1MatchNotMatched = compose(outcomeEqualsNotMatched, verificationResultProp('addressLine1Match'))
+const addressLine1MatchMatched = compose(outcomeEqualsMatched, verificationResultProp('addressLine1Match'))
 const emailAddressMatchNotMatched = compose(outcomeDoesNotEqualMatched, verificationResultProp('emailAddressMatch'))
+const emailAddressMatchMatched = compose(outcomeEqualsMatched, verificationResultProp('emailAddressMatch'))
 const mobilePhoneNotMatched = compose(outcomeDoesNotEqualMatched, verificationResultProp('mobilePhoneMatch'))
+const mobilePhoneMatched = compose(outcomeEqualsMatched, verificationResultProp('mobilePhoneMatch'))
 
 const postcodeMatchNotMatched = compose(outcomeEqualsNotMatched, verificationResultProp('postcodeMatch'))
+const postcodeMatchMatched = compose(outcomeEqualsMatched, verificationResultProp('postcodeMatch'))
 
 const isDuplicateClaim = compose(equals(DUPLICATE), prop('eligibilityStatus'))
 
@@ -23,13 +34,17 @@ const addressMismatches = anyPass([addressLine1MatchNotMatched, postcodeMatchNot
 
 const emailOrPhoneMismatches = anyPass([emailAddressMatchNotMatched, mobilePhoneNotMatched])
 
+const isFullMatch = allPass([emailAddressMatchMatched, mobilePhoneMatched, postcodeMatchMatched, addressLine1MatchMatched,
+  isPregnantOrAtLeast1ChildMatched, eligibilityOutcomeConfirmed, identityOutcomeMatched])
+
 const getDecisionStatus = cond([
   [isDuplicateClaim, always(FAIL)],
   [identityOutcomeNotMatched, always(FAIL)],
   [eligibilityOutcomeNotConfirmed, always(FAIL)],
   [addressMismatches, always(PENDING)],
   [notPregnantAndNoChildMatched, always(FAIL)],
-  [emailOrPhoneMismatches, always(PENDING)]
+  [emailOrPhoneMismatches, always(PENDING)],
+  [isFullMatch, always(SUCCESS)]
 ])
 
 module.exports = {

--- a/src/web/routes/application/steps/decision/get-decision-status.test.js
+++ b/src/web/routes/application/steps/decision/get-decision-status.test.js
@@ -1,6 +1,6 @@
 const test = require('tape')
 const { getDecisionStatus } = require('./get-decision-status')
-const { FAIL, PENDING } = require('./decision-statuses')
+const { FAIL, PENDING, SUCCESS } = require('./decision-statuses')
 const { DUPLICATE, ELIGIBLE } = require('./eligibility-statuses')
 
 const SUCCESSFUL_RESULT = {
@@ -8,7 +8,7 @@ const SUCCESSFUL_RESULT = {
   eligibilityOutcome: 'confirmed',
   addressLine1Match: 'matched',
   postcodeMatch: 'matched',
-  isPregnantOrAtLeast1ChildMatched: 'true',
+  isPregnantOrAtLeast1ChildMatched: true,
   mobilePhoneMatch: 'matched',
   emailAddressMatch: 'matched',
   qualifyingBenefits: 'universal_credit',
@@ -21,7 +21,7 @@ const IDENTITY_NOT_MATCHED_RESULT = {
   eligibilityOutcome: 'not_set',
   addressLine1Match: 'not_set',
   postcodeMatch: 'not_set',
-  isPregnantOrAtLeast1ChildMatched: 'true',
+  isPregnantOrAtLeast1ChildMatched: true,
   mobilePhoneMatch: 'not_set',
   emailAddressMatch: 'not_set',
   qualifyingBenefits: 'not_set',
@@ -34,7 +34,7 @@ const ELIGIBILITY_NOT_CONFIRMED_RESULT = {
   eligibilityOutcome: 'not_confirmed',
   addressLine1Match: 'not_set',
   postcodeMatch: 'not_set',
-  isPregnantOrAtLeast1ChildMatched: 'true',
+  isPregnantOrAtLeast1ChildMatched: true,
   mobilePhoneMatch: 'not_set',
   emailAddressMatch: 'not_set',
   qualifyingBenefits: 'not_set',
@@ -47,7 +47,7 @@ const ELIGIBILITY_CONFIRMED_RESULT = {
   eligibilityOutcome: 'confirmed',
   addressLine1Match: 'not_set',
   postcodeMatch: 'not_set',
-  isPregnantOrAtLeast1ChildMatched: 'true',
+  isPregnantOrAtLeast1ChildMatched: true,
   mobilePhoneMatch: 'not_set',
   emailAddressMatch: 'not_set',
   qualifyingBenefits: 'not_set',
@@ -60,7 +60,7 @@ const ADDRESS_MATCHED_RESULT = {
   eligibilityOutcome: 'confirmed',
   addressLine1Match: 'matched',
   postcodeMatch: 'matched',
-  isPregnantOrAtLeast1ChildMatched: 'true',
+  isPregnantOrAtLeast1ChildMatched: true,
   mobilePhoneMatch: 'not_matched',
   emailAddressMatch: 'not_matched',
   qualifyingBenefits: 'not_set',
@@ -83,9 +83,8 @@ const NOT_PREGNANT_AND_NO_CHILDREN_MATCHED_RESULT = {
 
 const DUPLICATE_RESULT = undefined // A DUPLICATE response from the claimant service will not return a verification result
 
-test('getDecisionStatus() should return undefined if verification result has no matching decision', (t) => {
-  // TODO these non matching results will need to be updated as stories for epic 'receive my decision' are completed
-  t.equal(getDecisionStatus({ verificationResult: SUCCESSFUL_RESULT }), undefined, 'non matching result returns undefined')
+test(`getDecisionStatus() should return ${SUCCESS} if verification result has no matching decision`, (t) => {
+  t.equal(getDecisionStatus({ verificationResult: SUCCESSFUL_RESULT }), SUCCESS, `returns ${SUCCESS} when full pass result is matched`)
   t.end()
 })
 

--- a/src/web/server/locales/cy/common.json
+++ b/src/web/server/locales/cy/common.json
@@ -145,6 +145,10 @@
     "pending": {
       "title": "Lorem ipsum dolor sit amet",
       "body": ""
+    },
+    "success": {
+      "title": "Ullamcorper malesuada",
+      "body": "Dui faucibus in ornare\n£{{totalVoucherValue}} ut labore. Eget felis eget nunc\nlobortis mattis {{totalVoucherValueForFourWeeks}}."
     }
   },
   "cookies": {

--- a/src/web/server/locales/en/common.json
+++ b/src/web/server/locales/en/common.json
@@ -132,7 +132,7 @@
   },
   "decisionFallbackSuccessful": {
     "title": "Application successful",
-    "subTitle": "You’re entitled to\n<strong>£{{totalVoucherValue}}</strong> a week. Your first payment\nwill be <strong>£{{totalVoucherValueForFourWeeks}}</strong>."
+    "subTitle": "You’re entitled to<br/><strong>£{{totalVoucherValue}}</strong> a week. Your first payment<br/>will be <strong>£{{totalVoucherValueForFourWeeks}}</strong>."
   },
   "decisionFallbackUnsuccessful": {
     "title": "Application not successful",
@@ -148,6 +148,10 @@
     "pending": {
       "title": "We’re considering your application",
       "body": ""
+    },
+    "success": {
+      "title": "Application successful",
+      "body": "You’re entitled to<br/><strong>£{{totalVoucherValue}}</strong> a week. Your first payment<br/>will be <strong>£{{totalVoucherValueForFourWeeks}}</strong>."
     }
   },
   "cookies": {

--- a/src/web/views/locales/en/decision/success.njk
+++ b/src/web/views/locales/en/decision/success.njk
@@ -1,0 +1,12 @@
+<h2 class="govuk-heading-m">What happens next</h2>
+<p class="govuk-body">We’ve sent you an email with more information.</p>
+<p class="govuk-body">You should receive your prepaid money card by post within 5 to 10 working days. If you do not receive it: </p>
+<ul class="govuk-list govuk-list--bullet">
+    <li>call 0300 330 7010</li>
+    <li>select option 2 and follow the instructions</li>
+</ul>
+<p class="govuk-body">Money will be added to your card every 4 weeks. You must <a class="govuk-link" href="/what-you-get">spend all the money within 16 weeks</a> to make sure you get this full amount.</p>
+<p class="govuk-body">You must <a class="govuk-link" href="/report-a-change">report any change in your circumstances or personal details.</a></p>
+
+<h2 class="govuk-heading-m">Give feedback</h2>
+<p class="govuk-body"><a class="govuk-link" href="https://www.smartsurvey.co.uk/s/apply-for-healthy-start-feedback">What did you think of this service?</a> (takes 30 seconds).</p>


### PR DESCRIPTION
It turns out that the success route was still using the fallback code to process and show the decision page, so have now added this specifically to decision.js and added in its template.

Once this is in we should now be able to remove the fallback code completely.