### PR TITLE
NO-JIRA replaced all test addresses with Fake Street, Springfield

### DIFF
--- a/src/test/a11y/tests/apply.js
+++ b/src/test/a11y/tests/apply.js
@@ -83,10 +83,10 @@ const apply = [
     url: URLS['MANUAL_ADDRESS'],
     formData: () => ({
       'addressLine1': 'Flat B',
-      'addressLine2': 'Baker Street',
-      'townOrCity': 'London',
-      'county': 'Greater London',
-      'postcode': 'AA1 1AA'
+      'addressLine2': 'Fake Street',
+      'townOrCity': 'Springfield',
+      'county': 'Greater Springfield',
+      'postcode': 'BS1 4TB'
     })
   },
   {

--- a/src/web/routes/application/steps/address/content-summary.test.js
+++ b/src/web/routes/application/steps/address/content-summary.test.js
@@ -8,10 +8,10 @@ test('contentSummary() should return content summary in correct format', (t) => 
     session: {
       claim: {
         addressLine1: 'Flat b',
-        addressLine2: '221 Baker street',
-        townOrCity: 'London',
+        addressLine2: '123 Fake Street',
+        townOrCity: 'Springfield',
         county: 'Devon',
-        postcode: 'aa1 1ab'
+        postcode: 'bs1 4tb'
       }
     }
   }
@@ -20,7 +20,7 @@ test('contentSummary() should return content summary in correct format', (t) => 
 
   const expected = {
     key: 'address.summaryKey',
-    value: 'Flat b\n221 Baker street\nLondon\nDevon\naa1 1ab'
+    value: 'Flat b\n123 Fake Street\nSpringfield\nDevon\nbs1 4tb'
   }
 
   t.deepEqual(result, expected, 'should return content summary in correct format')
@@ -33,9 +33,9 @@ test('contentSummary() should return content summary in correct format with no c
     session: {
       claim: {
         addressLine1: 'Flat b',
-        addressLine2: '221 Baker street',
-        townOrCity: 'London',
-        postcode: 'aa1 1ab'
+        addressLine2: '123 Fake Street',
+        townOrCity: 'Springfield',
+        postcode: 'bs1 4tb'
       }
     }
   }
@@ -44,7 +44,7 @@ test('contentSummary() should return content summary in correct format with no c
 
   const expected = {
     key: 'address.summaryKey',
-    value: 'Flat b\n221 Baker street\nLondon\naa1 1ab'
+    value: 'Flat b\n123 Fake Street\nSpringfield\nbs1 4tb'
   }
 
   t.deepEqual(result, expected, 'should return content summary in correct format with no county')
@@ -57,9 +57,9 @@ test('contentSummary() should return content summary in correct format with no a
     session: {
       claim: {
         addressLine1: 'Flat b',
-        townOrCity: 'London',
+        townOrCity: 'Springfield',
         county: 'Devon',
-        postcode: 'aa1 1ab'
+        postcode: 'bs1 4tb'
       }
     }
   }
@@ -68,7 +68,7 @@ test('contentSummary() should return content summary in correct format with no a
 
   const expected = {
     key: 'address.summaryKey',
-    value: 'Flat b\nLondon\nDevon\naa1 1ab'
+    value: 'Flat b\nSpringfield\nDevon\nbs1 4tb'
   }
 
   t.deepEqual(result, expected, 'should return content summary in correct format with no addressLine2')

--- a/src/web/routes/application/steps/address/manual-address/maunal-address.test.js
+++ b/src/web/routes/application/steps/address/manual-address/maunal-address.test.js
@@ -7,10 +7,10 @@ const req = {
   session: {
     claim: {
       addressLine1: 'Flat b',
-      addressLine2: '221 Baker street',
-      townOrCity: 'London',
+      addressLine2: '123 Fake Street',
+      townOrCity: 'Springfield',
       county: 'Devon',
-      postcode: 'aa1 1ab'
+      postcode: 'bs1 4tb'
     }
   }
 }
@@ -19,7 +19,7 @@ test('Address contentSummary() should return content summary in correct format',
   const result = contentSummary(req)
   const expected = {
     key: 'address.summaryKey',
-    value: 'Flat b\n221 Baker street\nLondon\nDevon\naa1 1ab'
+    value: 'Flat b\n123 Fake Street\nSpringfield\nDevon\nbs1 4tb'
   }
 
   t.deepEqual(result, expected, 'should return content summary in correct format')
@@ -31,7 +31,7 @@ test('Address contentSummary() should return content summary in correct format w
   const result = contentSummary(testReq)
   const expected = {
     key: 'address.summaryKey',
-    value: 'Flat b\nLondon\nDevon\naa1 1ab'
+    value: 'Flat b\nSpringfield\nDevon\nbs1 4tb'
   }
 
   t.deepEqual(result, expected, 'should return content summary in correct format without address line 2')
@@ -43,7 +43,7 @@ test('Address contentSummary() should return content summary in correct format w
   const result = contentSummary(testReq)
   const expected = {
     key: 'address.summaryKey',
-    value: 'Flat b\n221 Baker street\nLondon\naa1 1ab'
+    value: 'Flat b\n123 Fake Street\nSpringfield\nbs1 4tb'
   }
 
   t.deepEqual(result, expected, 'should return content summary in correct format without address line 2')
@@ -55,7 +55,7 @@ test('Address contentSummary() should return content summary in correct format w
   const result = contentSummary(testReq)
   const expected = {
     key: 'address.summaryKey',
-    value: 'Flat b\nLondon\nDevon\naa1 1ab'
+    value: 'Flat b\nSpringfield\nDevon\nbs1 4tb'
   }
 
   t.deepEqual(result, expected, 'should return content summary in correct format with address line 2 undefined')
@@ -76,7 +76,7 @@ test('Address contentSummary() should return content summary in correct format w
   const result = contentSummary(testReq)
   const expected = {
     key: 'address.summaryKey',
-    value: 'Flat b\n221 Baker street\nLondon\naa1 1ab'
+    value: 'Flat b\n123 Fake Street\nSpringfield\nbs1 4tb'
   }
 
   t.deepEqual(result, expected, 'should return content summary in correct format with address line 2 undefined')

--- a/src/web/routes/application/steps/address/manual-address/test/validation-composition.test.js
+++ b/src/web/routes/application/steps/address/manual-address/test/validation-composition.test.js
@@ -13,11 +13,11 @@ const req = {
   t: translate,
   body: {
     addressLine1: 'Flat B',
-    addressLine2: '221 Baker Street',
-    townOrCity: 'London',
-    county: 'Greater London',
-    postcode: 'aa1 1aa',
-    sanitizedPostcode: 'AA1 1AA'
+    addressLine2: '123 Fake Street',
+    townOrCity: 'Springfield',
+    county: 'Greater Springfield',
+    postcode: 'bs1 4tb',
+    sanitizedPostcode: 'BS1 4TB'
   }
 }
 

--- a/src/web/routes/application/steps/address/request-body.test.js
+++ b/src/web/routes/application/steps/address/request-body.test.js
@@ -5,11 +5,11 @@ const req = {
   session: {
     claim: {
       addressLine1: 'Flat b',
-      addressLine2: '221 Baker street',
-      townOrCity: 'London',
+      addressLine2: '123 Fake Street',
+      townOrCity: 'Springfield',
       county: 'Devon',
-      postcode: 'aa1  1ab',
-      sanitizedPostcode: 'AA1 1AB'
+      postcode: 'bs1  4tb',
+      sanitizedPostcode: 'BS1 4TB'
     }
   }
 }
@@ -20,10 +20,10 @@ test('requestBody() returns request body in correct format', (t) => {
   const expected = {
     address: {
       addressLine1: 'Flat b',
-      addressLine2: '221 Baker street',
-      townOrCity: 'London',
+      addressLine2: '123 Fake Street',
+      townOrCity: 'Springfield',
       county: 'Devon',
-      postcode: 'AA1 1AB'
+      postcode: 'BS1 4TB'
     }
   }
 

--- a/src/web/routes/application/steps/address/sanitize.test.js
+++ b/src/web/routes/application/steps/address/sanitize.test.js
@@ -5,11 +5,11 @@ const { sanitize } = require('./sanitize')
 test('sanitize replaces multiple whitespace with one, converts to uppercase and saves to a new variable', (t) => {
   const req = {
     body: {
-      postcode: 'aa1     1aa'
+      postcode: 'bs1     4tb'
     }
   }
-  const expectedSanitizedPostcode = 'AA1 1AA'
-  const expectedPostcode = 'aa1     1aa'
+  const expectedSanitizedPostcode = 'BS1 4TB'
+  const expectedPostcode = 'bs1     4tb'
   const next = sinon.spy()
 
   sanitize()(req, {}, next)

--- a/src/web/routes/application/steps/address/select-address/select-address.test.js
+++ b/src/web/routes/application/steps/address/select-address/select-address.test.js
@@ -300,11 +300,11 @@ test('Address contentSummary() should return content summary in correct format w
     session: {
       claim: {
         addressLine1: 'Flat b',
-        addressLine2: '221 Baker street',
-        townOrCity: 'London',
+        addressLine2: '123 Fake Street',
+        townOrCity: 'Springfield',
         county: 'Devon',
-        postcode: 'aa1 1ab',
-        selectedAddress: 'Flat b, 221 Baker Street, London, Devon, aa1 1ab'
+        postcode: 'bs1 4tb',
+        selectedAddress: 'Flat b, 123 Fake Street, Springfield, Devon, bs1 4tb'
       }
     }
   }
@@ -313,7 +313,7 @@ test('Address contentSummary() should return content summary in correct format w
 
   const expected = {
     key: 'address.summaryKey',
-    value: 'Flat b\n221 Baker street\nLondon\nDevon\naa1 1ab'
+    value: 'Flat b\n123 Fake Street\nSpringfield\nDevon\nbs1 4tb'
   }
 
   t.deepEqual(result, expected, 'should return content summary in correct format when there is a selected address on the session')

--- a/src/web/routes/application/steps/check-answers/get-row-data.test.js
+++ b/src/web/routes/application/steps/check-answers/get-row-data.test.js
@@ -53,7 +53,7 @@ test('normaliseRows() flattens nested iterables and removes empty values', (t) =
       },
       {
         key: 'addressline2',
-        value: 'London'
+        value: 'Springfield'
       }
     ],
     null
@@ -70,7 +70,7 @@ test('normaliseRows() flattens nested iterables and removes empty values', (t) =
     },
     {
       key: 'addressline2',
-      value: 'London'
+      value: 'Springfield'
     }
   ]
 


### PR DESCRIPTION
Replaced all usages of Baker Street, London with Fake Street, Springfield. Also replaced the AA1 1AA postcode (which doesn't exist, and causes all postcode data to be NOT_FOUND in Google Analytics) with BS1 4TB.